### PR TITLE
kdiff3: kparts dependency

### DIFF
--- a/kde/unreleased/kdiff3/kdiff3.py
+++ b/kde/unreleased/kdiff3/kdiff3.py
@@ -16,6 +16,7 @@ class subinfo(info.infoclass):
         self.runtimeDependencies["kde/frameworks/tier1/ki18n"] = None
         self.runtimeDependencies["kde/frameworks/tier2/kcrash"] = None
         self.runtimeDependencies["kde/frameworks/tier3/kiconthemes"] = None
+        self.runtimeDependencies["kde/frameworks/tier3/kparts"] = None
 
 
 from Package.CMakePackageBase import *


### PR DESCRIPTION
`craft kdiff3` failed to build on `ABI = windows-msvc2017_64-cl` prior to this change.
For completeness, this is the error without it:
> Could NOT find KF5 (missing: Parts) (found suitable version "5.54.0", minimum required is "5.23.0")