### PR TITLE
Add ccache dynamicOption to qtbase

### DIFF
--- a/libs/qt5/qtbase/qtbase.py
+++ b/libs/qt5/qtbase/qtbase.py
@@ -10,6 +10,7 @@ class subinfo(info.infoclass):
         self.options.dynamic.registerOption("buildReleaseAndDebug", False)
         self.options.dynamic.registerOption("buildDoc", True)
         self.options.dynamic.registerOption("libInfix", "")
+        self.options.dynamic.registerOption("enableCcache", "")
 
     def setTargets(self):
         self.versionInfo.setDefaultValues()
@@ -226,6 +227,8 @@ class QtPackage(Qt5CorePackageBase):
             command += "-nomake examples "
             command += "-nomake tests "
 
+            if self.subinfo.options.dynamic.enableCcache and self.supportsCCACHE:
+                command += "-ccache "
             if (CraftCore.compiler.isMSVC() and CraftCore.compiler.isClang()) or OsUtils.isUnix() or self.supportsCCACHE:
                 command += "-no-pch "
             if CraftCore.compiler.isLinux:


### PR DESCRIPTION
I found that this reduces the compile time (`craft --options libs/qt5/qtbase.enableCcache=True --compile libs/qt5/qtbase`) from around 15 minutes to 12 seconds. Not sure how to enable it in craft without adding an option or hacking the code.

I'm not very well-versed in Qt, C++, or all this kind of stuff so there's lots I don't know - open to feedback.