### PR TITLE
Add VLC Binary for macOS

### DIFF
--- a/binary/_mac/vlc/vlc-plugin-headers.diff
+++ b/binary/_mac/vlc/vlc-plugin-headers.diff
@@ -1,0 +1,23950 @@
+
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_about.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_about.h
+new file mode 100644
+index 0000000..a878a41
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_about.h
+@@ -0,0 +1,1525 @@
++/* Automatically generated file - DO NOT EDIT */
++static const char psz_license[] =
++"                    GNU GENERAL PUBLIC LICENSE\n"
++"                       Version 2, June 1991\n"
++"\n"
++" Copyright (C) 1989, 1991 Free Software Foundation, Inc.,\n"
++" 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA\n"
++" Everyone is permitted to copy and distribute verbatim copies\n"
++" of this license document, but changing it is not allowed.\n"
++"\n"
++"                            Preamble\n"
++"\n"
++"  The licenses for most software are designed to take away your\n"
++"freedom to share and change it.  By contrast, the GNU General Public\n"
++"License is intended to guarantee your freedom to share and change free\n"
++"software--to make sure the software is free for all its users.  This\n"
++"General Public License applies to most of the Free Software\n"
++"Foundation's software and to any other program whose authors commit to\n"
++"using it.  (Some other Free Software Foundation software is covered by\n"
++"the GNU Lesser General Public License instead.)  You can apply it to\n"
++"your programs, too.\n"
++"\n"
++"  When we speak of free software, we are referring to freedom, not\n"
++"price.  Our General Public Licenses are designed to make sure that you\n"
++"have the freedom to distribute copies of free software (and charge for\n"
++"this service if you wish), that you receive source code or can get it\n"
++"if you want it, that you can change the software or use pieces of it\n"
++"in new free programs; and that you know you can do these things.\n"
++"\n"
++"  To protect your rights, we need to make restrictions that forbid\n"
++"anyone to deny you these rights or to ask you to surrender the rights.\n"
++"These restrictions translate to certain responsibilities for you if you\n"
++"distribute copies of the software, or if you modify it.\n"
++"\n"
++"  For example, if you distribute copies of such a program, whether\n"
++"gratis or for a fee, you must give the recipients all the rights that\n"
++"you have.  You must make sure that they, too, receive or can get the\n"
++"source code.  And you must show them these terms so they know their\n"
++"rights.\n"
++"\n"
++"  We protect your rights with two steps: (1) copyright the software, and\n"
++"(2) offer you this license which gives you legal permission to copy,\n"
++"distribute and/or modify the software.\n"
++"\n"
++"  Also, for each author's protection and ours, we want to make certain\n"
++"that everyone understands that there is no warranty for this free\n"
++"software.  If the software is modified by someone else and passed on, we\n"
++"want its recipients to know that what they have is not the original, so\n"
++"that any problems introduced by others will not reflect on the original\n"
++"authors' reputations.\n"
++"\n"
++"  Finally, any free program is threatened constantly by software\n"
++"patents.  We wish to avoid the danger that redistributors of a free\n"
++"program will individually obtain patent licenses, in effect making the\n"
++"program proprietary.  To prevent this, we have made it clear that any\n"
++"patent must be licensed for everyone's free use or not licensed at all.\n"
++"\n"
++"  The precise terms and conditions for copying, distribution and\n"
++"modification follow.\n"
++"\n"
++"                    GNU GENERAL PUBLIC LICENSE\n"
++"   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION\n"
++"\n"
++"  0. This License applies to any program or other work which contains\n"
++"a notice placed by the copyright holder saying it may be distributed\n"
++"under the terms of this General Public License.  The \"Program\", below,\n"
++"refers to any such program or work, and a \"work based on the Program\"\n"
++"means either the Program or any derivative work under copyright law:\n"
++"that is to say, a work containing the Program or a portion of it,\n"
++"either verbatim or with modifications and/or translated into another\n"
++"language.  (Hereinafter, translation is included without limitation in\n"
++"the term \"modification\".)  Each licensee is addressed as \"you\".\n"
++"\n"
++"Activities other than copying, distribution and modification are not\n"
++"covered by this License; they are outside its scope.  The act of\n"
++"running the Program is not restricted, and the output from the Program\n"
++"is covered only if its contents constitute a work based on the\n"
++"Program (independent of having been made by running the Program).\n"
++"Whether that is true depends on what the Program does.\n"
++"\n"
++"  1. You may copy and distribute verbatim copies of the Program's\n"
++"source code as you receive it, in any medium, provided that you\n"
++"conspicuously and appropriately publish on each copy an appropriate\n"
++"copyright notice and disclaimer of warranty; keep intact all the\n"
++"notices that refer to this License and to the absence of any warranty;\n"
++"and give any other recipients of the Program a copy of this License\n"
++"along with the Program.\n"
++"\n"
++"You may charge a fee for the physical act of transferring a copy, and\n"
++"you may at your option offer warranty protection in exchange for a fee.\n"
++"\n"
++"  2. You may modify your copy or copies of the Program or any portion\n"
++"of it, thus forming a work based on the Program, and copy and\n"
++"distribute such modifications or work under the terms of Section 1\n"
++"above, provided that you also meet all of these conditions:\n"
++"\n"
++"    a) You must cause the modified files to carry prominent notices\n"
++"    stating that you changed the files and the date of any change.\n"
++"\n"
++"    b) You must cause any work that you distribute or publish, that in\n"
++"    whole or in part contains or is derived from the Program or any\n"
++"    part thereof, to be licensed as a whole at no charge to all third\n"
++"    parties under the terms of this License.\n"
++"\n"
++"    c) If the modified program normally reads commands interactively\n"
++"    when run, you must cause it, when started running for such\n"
++"    interactive use in the most ordinary way, to print or display an\n"
++"    announcement including an appropriate copyright notice and a\n"
++"    notice that there is no warranty (or else, saying that you provide\n"
++"    a warranty) and that users may redistribute the program under\n"
++"    these conditions, and telling the user how to view a copy of this\n"
++"    License.  (Exception: if the Program itself is interactive but\n"
++"    does not normally print such an announcement, your work based on\n"
++"    the Program is not required to print an announcement.)\n"
++"\n"
++"These requirements apply to the modified work as a whole.  If\n"
++"identifiable sections of that work are not derived from the Program,\n"
++"and can be reasonably considered independent and separate works in\n"
++"themselves, then this License, and its terms, do not apply to those\n"
++"sections when you distribute them as separate works.  But when you\n"
++"distribute the same sections as part of a whole which is a work based\n"
++"on the Program, the distribution of the whole must be on the terms of\n"
++"this License, whose permissions for other licensees extend to the\n"
++"entire whole, and thus to each and every part regardless of who wrote it.\n"
++"\n"
++"Thus, it is not the intent of this section to claim rights or contest\n"
++"your rights to work written entirely by you; rather, the intent is to\n"
++"exercise the right to control the distribution of derivative or\n"
++"collective works based on the Program.\n"
++"\n"
++"In addition, mere aggregation of another work not based on the Program\n"
++"with the Program (or with a work based on the Program) on a volume of\n"
++"a storage or distribution medium does not bring the other work under\n"
++"the scope of this License.\n"
++"\n"
++"  3. You may copy and distribute the Program (or a work based on it,\n"
++"under Section 2) in object code or executable form under the terms of\n"
++"Sections 1 and 2 above provided that you also do one of the following:\n"
++"\n"
++"    a) Accompany it with the complete corresponding machine-readable\n"
++"    source code, which must be distributed under the terms of Sections\n"
++"    1 and 2 above on a medium customarily used for software interchange; or,\n"
++"\n"
++"    b) Accompany it with a written offer, valid for at least three\n"
++"    years, to give any third party, for a charge no more than your\n"
++"    cost of physically performing source distribution, a complete\n"
++"    machine-readable copy of the corresponding source code, to be\n"
++"    distributed under the terms of Sections 1 and 2 above on a medium\n"
++"    customarily used for software interchange; or,\n"
++"\n"
++"    c) Accompany it with the information you received as to the offer\n"
++"    to distribute corresponding source code.  (This alternative is\n"
++"    allowed only for noncommercial distribution and only if you\n"
++"    received the program in object code or executable form with such\n"
++"    an offer, in accord with Subsection b above.)\n"
++"\n"
++"The source code for a work means the preferred form of the work for\n"
++"making modifications to it.  For an executable work, complete source\n"
++"code means all the source code for all modules it contains, plus any\n"
++"associated interface definition files, plus the scripts used to\n"
++"control compilation and installation of the executable.  However, as a\n"
++"special exception, the source code distributed need not include\n"
++"anything that is normally distributed (in either source or binary\n"
++"form) with the major components (compiler, kernel, and so on) of the\n"
++"operating system on which the executable runs, unless that component\n"
++"itself accompanies the executable.\n"
++"\n"
++"If distribution of executable or object code is made by offering\n"
++"access to copy from a designated place, then offering equivalent\n"
++"access to copy the source code from the same place counts as\n"
++"distribution of the source code, even though third parties are not\n"
++"compelled to copy the source along with the object code.\n"
++"\n"
++"  4. You may not copy, modify, sublicense, or distribute the Program\n"
++"except as expressly provided under this License.  Any attempt\n"
++"otherwise to copy, modify, sublicense or distribute the Program is\n"
++"void, and will automatically terminate your rights under this License.\n"
++"However, parties who have received copies, or rights, from you under\n"
++"this License will not have their licenses terminated so long as such\n"
++"parties remain in full compliance.\n"
++"\n"
++"  5. You are not required to accept this License, since you have not\n"
++"signed it.  However, nothing else grants you permission to modify or\n"
++"distribute the Program or its derivative works.  These actions are\n"
++"prohibited by law if you do not accept this License.  Therefore, by\n"
++"modifying or distributing the Program (or any work based on the\n"
++"Program), you indicate your acceptance of this License to do so, and\n"
++"all its terms and conditions for copying, distributing or modifying\n"
++"the Program or works based on it.\n"
++"\n"
++"  6. Each time you redistribute the Program (or any work based on the\n"
++"Program), the recipient automatically receives a license from the\n"
++"original licensor to copy, distribute or modify the Program subject to\n"
++"these terms and conditions.  You may not impose any further\n"
++"restrictions on the recipients' exercise of the rights granted herein.\n"
++"You are not responsible for enforcing compliance by third parties to\n"
++"this License.\n"
++"\n"
++"  7. If, as a consequence of a court judgment or allegation of patent\n"
++"infringement or for any other reason (not limited to patent issues),\n"
++"conditions are imposed on you (whether by court order, agreement or\n"
++"otherwise) that contradict the conditions of this License, they do not\n"
++"excuse you from the conditions of this License.  If you cannot\n"
++"distribute so as to satisfy simultaneously your obligations under this\n"
++"License and any other pertinent obligations, then as a consequence you\n"
++"may not distribute the Program at all.  For example, if a patent\n"
++"license would not permit royalty-free redistribution of the Program by\n"
++"all those who receive copies directly or indirectly through you, then\n"
++"the only way you could satisfy both it and this License would be to\n"
++"refrain entirely from distribution of the Program.\n"
++"\n"
++"If any portion of this section is held invalid or unenforceable under\n"
++"any particular circumstance, the balance of the section is intended to\n"
++"apply and the section as a whole is intended to apply in other\n"
++"circumstances.\n"
++"\n"
++"It is not the purpose of this section to induce you to infringe any\n"
++"patents or other property right claims or to contest validity of any\n"
++"such claims; this section has the sole purpose of protecting the\n"
++"integrity of the free software distribution system, which is\n"
++"implemented by public license practices.  Many people have made\n"
++"generous contributions to the wide range of software distributed\n"
++"through that system in reliance on consistent application of that\n"
++"system; it is up to the author/donor to decide if he or she is willing\n"
++"to distribute software through any other system and a licensee cannot\n"
++"impose that choice.\n"
++"\n"
++"This section is intended to make thoroughly clear what is believed to\n"
++"be a consequence of the rest of this License.\n"
++"\n"
++"  8. If the distribution and/or use of the Program is restricted in\n"
++"certain countries either by patents or by copyrighted interfaces, the\n"
++"original copyright holder who places the Program under this License\n"
++"may add an explicit geographical distribution limitation excluding\n"
++"those countries, so that distribution is permitted only in or among\n"
++"countries not thus excluded.  In such case, this License incorporates\n"
++"the limitation as if written in the body of this License.\n"
++"\n"
++"  9. The Free Software Foundation may publish revised and/or new versions\n"
++"of the General Public License from time to time.  Such new versions will\n"
++"be similar in spirit to the present version, but may differ in detail to\n"
++"address new problems or concerns.\n"
++"\n"
++"Each version is given a distinguishing version number.  If the Program\n"
++"specifies a version number of this License which applies to it and \"any\n"
++"later version\", you have the option of following the terms and conditions\n"
++"either of that version or of any later version published by the Free\n"
++"Software Foundation.  If the Program does not specify a version number of\n"
++"this License, you may choose any version ever published by the Free Software\n"
++"Foundation.\n"
++"\n"
++"  10. If you wish to incorporate parts of the Program into other free\n"
++"programs whose distribution conditions are different, write to the author\n"
++"to ask for permission.  For software which is copyrighted by the Free\n"
++"Software Foundation, write to the Free Software Foundation; we sometimes\n"
++"make exceptions for this.  Our decision will be guided by the two goals\n"
++"of preserving the free status of all derivatives of our free software and\n"
++"of promoting the sharing and reuse of software generally.\n"
++"\n"
++"                            NO WARRANTY\n"
++"\n"
++"  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY\n"
++"FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN\n"
++"OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES\n"
++"PROVIDE THE PROGRAM \"AS IS\" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED\n"
++"OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF\n"
++"MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS\n"
++"TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE\n"
++"PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,\n"
++"REPAIR OR CORRECTION.\n"
++"\n"
++"  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING\n"
++"WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR\n"
++"REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,\n"
++"INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING\n"
++"OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED\n"
++"TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY\n"
++"YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER\n"
++"PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE\n"
++"POSSIBILITY OF SUCH DAMAGES.\n"
++"\n"
++"                     END OF TERMS AND CONDITIONS\n"
++"\n"
++"            How to Apply These Terms to Your New Programs\n"
++"\n"
++"  If you develop a new program, and you want it to be of the greatest\n"
++"possible use to the public, the best way to achieve this is to make it\n"
++"free software which everyone can redistribute and change under these terms.\n"
++"\n"
++"  To do so, attach the following notices to the program.  It is safest\n"
++"to attach them to the start of each source file to most effectively\n"
++"convey the exclusion of warranty; and each file should have at least\n"
++"the \"copyright\" line and a pointer to where the full notice is found.\n"
++"\n"
++"    <one line to give the program's name and a brief idea of what it does.>\n"
++"    Copyright (C) <year>  <name of author>\n"
++"\n"
++"    This program is free software; you can redistribute it and/or modify\n"
++"    it under the terms of the GNU General Public License as published by\n"
++"    the Free Software Foundation; either version 2 of the License, or\n"
++"    (at your option) any later version.\n"
++"\n"
++"    This program is distributed in the hope that it will be useful,\n"
++"    but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
++"    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"
++"    GNU General Public License for more details.\n"
++"\n"
++"    You should have received a copy of the GNU General Public License along\n"
++"    with this program; if not, write to the Free Software Foundation, Inc.,\n"
++"    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.\n"
++"\n"
++"Also add information on how to contact you by electronic and paper mail.\n"
++"\n"
++"If the program is interactive, make it output a short notice like this\n"
++"when it starts in an interactive mode:\n"
++"\n"
++"    Gnomovision version 69, Copyright (C) year name of author\n"
++"    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.\n"
++"    This is free software, and you are welcome to redistribute it\n"
++"    under certain conditions; type `show c' for details.\n"
++"\n"
++"The hypothetical commands `show w' and `show c' should show the appropriate\n"
++"parts of the General Public License.  Of course, the commands you use may\n"
++"be called something other than `show w' and `show c'; they could even be\n"
++"mouse-clicks or menu items--whatever suits your program.\n"
++"\n"
++"You should also get your employer (if you work as a programmer) or your\n"
++"school, if any, to sign a \"copyright disclaimer\" for the program, if\n"
++"necessary.  Here is a sample; alter the names:\n"
++"\n"
++"  Yoyodyne, Inc., hereby disclaims all copyright interest in the program\n"
++"  `Gnomovision' (which makes passes at compilers) written by James Hacker.\n"
++"\n"
++"  <signature of Ty Coon>, 1 April 1989\n"
++"  Ty Coon, President of Vice\n"
++"\n"
++"This General Public License does not permit incorporating your program into\n"
++"proprietary programs.  If your program is a subroutine library, you may\n"
++"consider it more useful to permit linking proprietary applications with the\n"
++"library.  If this is what you want to do, use the GNU Lesser General\n"
++"Public License instead of this License.\n"
++;
++static const char psz_thanks[] =
++"Some VLC plugins use external libraries and make extensive use of the\n"
++"following persons' or companies' code:\n"
++"\n"
++"FAAD2 - Copyright (c) Nero AG, www.nero.com\" - GPLv2 or later\n"
++"FFmpeg - Copyright (c) 2000-2017 the FFmpeg developers - LGPLv2.1 or later\n"
++"FluidLite - Copyright (c) 2016 Robin Lobel - LGPLv2.1 or later\n"
++"FluidSynth - Copyright (c) 2003-2010 Peter Hanappe, Conrad Berhörster, Antoine\n"
++"   Schmitt, Pedro López-Cabanillas, Josh Green, David Henningsson - LGPLv2.1 or\n"
++"   later\n"
++"Fontconfig - Copyright (c) 2000,2001,2002,2003,2004,2006,2007 Keith Packard,\n"
++"   (c) 2005 Patrick Lam, (c) 2009 Roozbeh Pournader, (c) 2008,2009 Red Hat,\n"
++"   Inc., (c) 2008 Danilo Šegan, (c) 2012 Google, Inc. - MIT License\n"
++"freetype - David Turner, Robert Wilhelm, and Werner Lemberg - FreeType License\n"
++"GSM - Copyright (c) 1992 - 1994, 2009 Jutta Degener & Carsten Bormann - GSM\n"
++"   permissive license\n"
++"GNU FriBidi - Copyright (c) 2004-2012 Behdad Esfahbod, Dov Grobgeld, Roozbeh\n"
++"   Pournader - LGPLv2.1 or later\n"
++"GnuTLS - Copyright (C) 2000-2012 Free Software Foundation, Inc. - LGPLv2.1 or\n"
++"   later\n"
++"harfbuzz - Copyright (c) 2010, 2011, 2012  Google, Inc., (c) 2012  Mozilla\n"
++"   Foundation, (c) 2011 Codethink Limited, (c) 2008, 2010  Nokia Corporation\n"
++"   and/or its subsidiary(-ies), (c) 2009 Keith Stribley, (c) 2009 Martin Hosken\n"
++"   and SIL International, (c) 2007 Chris Wilson, (c) 2006 Behdad Esfahbod,\n"
++"   (c) 2005 David Turner, (c) 2004, 2007, 2008, 2009, 2010 Red Hat, Inc.,\n"
++"   (c) 1998-2004 David Turner and Werner Lemberg - Old MIT License\n"
++"liba52 - Aaron Holtzman & Michel Lespinasse, et al. - GPLv2 or later\n"
++"libav - Copyright (c) 2000 - 2015 the libav developers - LGPLv2.1 or later\n"
++"libass - Copyright (c) 2006-2015 Grigori Goronzy et al. - ISC License\n"
++"libbluray - Copyright (c) 2009-2015 VideoLAN and authors - LGPLv2.1 or later\n"
++"libcaca - Copyright (c) 2004 Sam Hocevar - WTFPL / LGPLv2.1 or later /\n"
++"   GPLv2 or later / ISC\n"
++"libdca - Copyright (c) 2004-2007 VideoLAN and authors - GPLv2 or later\n"
++"libdvbpsi - Copyright (c) 2001-2017 VideoLAN and authors - LGPLv2.1 or later\n"
++"libdvdcss - Copyright (c) 2001-2017 VideoLAN and authors - GPLv2 or later\n"
++"libdvdread - GPLv2 or later\n"
++"libdvdnav - GPLv2 or later\n"
++"libebml - Copyright (c) 2002-2015 Steve Lhomme - LGPLv2.1 or later\n"
++"libFLAC - Copyright (c) 2001 - 2014 Josh Coalson et al. - Xiph.org BSD license\n"
++"libgme - LGPLv2.1 or later\n"
++"libgpg-error - Copyright 2003, 2004, 2005, 2006, 2007, 2013 g10 Code GmbH\n"
++"   - LGPLv2.1 or later\n"
++"libkate - Copyright (c) 2008-2011 Vincent Penquerc'h - 3-clause BSD License\n"
++"liblive555 - Copyright (c) 1996-2015 Live Networks, Inc. - LGPLv2.1 or later\n"
++"libmad - Copyright (c) 2000-2004 Robert Leslie, et al. - GPLv2 or later\n"
++"libmatroska - Copyright (c) 2002-2015 Steve Lhomme - LGPLv2.1 or later\n"
++"libmpeg2 - Aaron Holtzman & Michel Lespinasse, et al. - GPLv2 or later\n"
++"libmodplug - Oliver Lapicque, Konstanty - Public domain\n"
++"libogg, libvorbis - Copyright (c) 2002-2015 Xiph.org Foundation - Xiph.org BSD\n"
++"   license\n"
++"libpostproc - Copyright (C) 2001-2015 Michael Niedermayer, et al. - GPLv2 or\n"
++"   later\n"
++"libpng - Copyright (c) 2004, 2006-2014 Glenn Randers-Perhson, et al. - libpng\n"
++"   license\n"
++"libsamplerate - Copyright (c) 2002-2011 Erik de Castro Lopo - GPLv2 or later\n"
++"libschroedinger - Copyright (c) 2006 BBC and Fluendo - MIT License\n"
++"libsdl - Copyright (c) 1997-2014 Sam Lantinga et al. - LGPLv2.1 or later\n"
++"libshout - Copyright (c) 2012 - LGPLv2.1 or later\n"
++"libtheora - Copyright (c) Xiph.org Foundation - Xiph.org BSD license\n"
++"libtiff - Copyright (c) 1988-1997 Sam Leffler, (c) 1991-1997 Silicon Graphics,\n"
++"   Inc. - BSD-like\n"
++"libtwolame - Copyright (c) 2001-2004 Michael Cheng, (c) 2004-2006 The TwoLAME\n"
++"   Project - LGPLv2.1 or later\n"
++"libupnp - Copyright (c) 2000-2003 Intel Corporation - 3-clause BSD License\n"
++"libvpx - Copyright (c) 2010-2015, Google Inc. - 3-clause BSD License\n"
++"libxml2 - Copyright (c) 1998-2014 Daniel Veillard - MIT License\n"
++"lua - Copyright (c) 1994-2008 Lua.org, PUC-Rio. - MIT License\n"
++"Musepack decoder library - Copyright (c) 2005-2011, The Musepack Development\n"
++"   Team - 3-clause BSD License\n"
++"OpenJPEG - Copyright (c) 2002-2014, Communcations and Remote Sensing\n"
++"   Laboratory, UCL, Belgium - ISC License\n"
++"Opus - Copyright 2001-2013 Xiph.Org, Skype Limited, Octasic, Jean-Marc Valin,\n"
++"   Timothy B. Terriberry, CSIRO, Gregory Maxwell, Mark Borgerding,\n"
++"   Erik de Castro Lopo - Xiph.org BSD License\n"
++"Sparkle — Andy Matuschak et al. - MIT License\n"
++"Speex, Speexdsp - Copyright (c) 1992-2015 Xiph.org Foundation, Jean-Marc Valin,\n"
++"   Analog Devices Inc. Commonwealth Scientific and Industrial Research\n"
++"   Organisation, David Row, Jutta Degener, Carsten Bormann - 3-clause BSD\n"
++"   License\n"
++"taglib - Copyright (c) 2004-2016 Scott Wheeler, et al. - LGPLv2.1 or later\n"
++"x264 - Copyright (c) 2004-2017 VideoLAN and authors - GPLv2 or later\n"
++"x265 - Copyright (c) 2004-2015 x265 project - GPLv2 or later\n"
++"Zapping VBI library - Copyright (c) 2000-2003 Michael H. Schimek, Iñaki García\n"
++"   Etxebarria - LGPLv2.1 or later\n"
++"zlib - Copyright (c) 1995-2017 Jean-loup Gailly and Mark Adler - zlib license\n"
++"\n"
++"The VideoLAN team would like to thank the following donators:\n"
++"\n"
++"Julian Cain, who made a $1000 donation\n"
++"The French website MacBidouille gave €500 to help us buy a PowerMac G5\n"
++"The French magazine à vos MAC gave €500 to help us buy a PowerMac G5\n"
++"Laurent Dupuy, who made a €540 donation\n"
++"The French company Cybervia (Actech) gave €2000 to pay for webserver hosting\n"
++"Dennis Perov - Hardware donation\n"
++"\n"
++"...the following active members of our user community:\n"
++"\n"
++"Alan Wright\n"
++"David J LaBarre \"DJ\"\n"
++"Eric Adler\n"
++"Julien Bouquillon\n"
++"\n"
++"...and code auditors and testers:\n"
++"\n"
++"David Thiel\n"
++"Philippe A. aka \"Lotesdelère\"\n"
++"Sebastien Chaumat\n"
++;
++static const char psz_authors[] =
++"VideoLAN and the VLC team would like to acknowledge the following contributors:\n"
++"\n"
++"Programming\n"
++"-----------\n"
++"Rémi Denis-Courmont\n"
++"Jean-Baptiste Kempf\n"
++"Laurent Aimar\n"
++"François Cartegnie\n"
++"Gildas Bazin\n"
++"Felix Paul Kühne\n"
++"Rafaël Carré\n"
++"Pierre d'Herbemont\n"
++"Thomas Guillem\n"
++"Rémi Duraffort\n"
++"Derk-Jan Hartman\n"
++"Antoine Cellerier\n"
++"Samuel Hocevar\n"
++"Jean-Paul Saman\n"
++"Steve Lhomme\n"
++"Christophe Mutricy\n"
++"Clément Stenac\n"
++"Christophe Massiot\n"
++"Ilkka Ollakka\n"
++"Pierre Ynard\n"
++"Filip Roséen\n"
++"Damien Fouilleul\n"
++"Sigmund Augdal Helberg\n"
++"Erwan Tulou\n"
++"David Fuhrmann\n"
++"Marvin Scholz\n"
++"Olivier Teulière\n"
++"Cyril Deguet\n"
++"Eric Petit\n"
++"Filippo Carone\n"
++"Rocky Bernstein\n"
++"Hugo Beauzée-Luyssen\n"
++"Olivier Aubert\n"
++"Pavlov Konstantin\n"
++"Jakob Leben\n"
++"Benjamin Pracht\n"
++"Jean-Philippe André\n"
++"Stéphane Borel\n"
++"JP Dinger\n"
++"Geoffroy Couprie\n"
++"Martin Storsjö\n"
++"Marian Ďurkovič\n"
++"Ludovic Fauvet\n"
++"Petri Hintukainen\n"
++"Yoann Peronneau\n"
++"Denis Charmet\n"
++"Sébastien Escudier\n"
++"Jon Lech Johansen\n"
++"KO Myung-Hun\n"
++"Edward Wang\n"
++"Dennis van Amerongen\n"
++"Faustino Osuna\n"
++"Mirsal Ennaime\n"
++"Sean McGovern\n"
++"Jérôme Decoodt\n"
++"Loïc Minier\n"
++"David Flynn\n"
++"Frédéric Yhuel\n"
++"Kaarlo Raiha\n"
++"Mark Moriarty\n"
++"Christopher Mueller\n"
++"Fabio Ritrovato\n"
++"Tony Castley\n"
++"Srikanth Raju\n"
++"Michel Kaempf\n"
++"Jean-Marc Dressler\n"
++"Johan Bilien\n"
++"Vincent Seguin\n"
++"Simon Latapie\n"
++"Bernie Purcell\n"
++"Henri Fallon\n"
++"Sebastien Zwickert\n"
++"Christoph Miebach\n"
++"Adrien Maglo\n"
++"Emmanuel Puig\n"
++"Renaud Dartus\n"
++"Alexis de Lattre\n"
++"Vincent Penquerc'h\n"
++"Arnaud de Bossoreille de Ribou\n"
++"Mohammed Adnène Trojette\n"
++"Salah-Eddin Shaban\n"
++"Vittorio Giovara\n"
++"Boris Dorès\n"
++"Jai Menon\n"
++"Anil Daoud\n"
++"Daniel Mierswa\n"
++"Naohiro Koriyama\n"
++"Rob Jonson\n"
++"Pierre Baillet\n"
++"Dominique Leuenberger\n"
++"Andre Pang\n"
++"Zoran Turalija\n"
++"Akash Mehrotra\n"
++"André Weber\n"
++"Anthony Loiseau\n"
++"Lukas Durfina\n"
++"Xavier Marchesini\n"
++"Cyril Mathé\n"
++"Devin Heitmueller\n"
++"Juho Vähä-Herttua\n"
++"Ken Self\n"
++"Alexis Ballier\n"
++"Juha Jeronen\n"
++"Nicolas Chauvet\n"
++"Richard Hosking\n"
++"Éric Lassauge\n"
++"Marc Ariberti\n"
++"Sébastien Toque\n"
++"Tobias Güntner\n"
++"Benoit Steiner\n"
++"Michel Lespinasse\n"
++"Carlo Calabrò\n"
++"Cheng Sun\n"
++"Michał Trzebiatowski\n"
++"Brad Smith\n"
++"Brendon Justin\n"
++"Alexey Sokolov\n"
++"Basos G\n"
++"Philippe Morin\n"
++"Steinar H. Gunderson\n"
++"Vicente Jimenez Aguilar\n"
++"Yuval Tze\n"
++"Yves Duret\n"
++"Benjamin Drung\n"
++"Michael Hanselmann\n"
++"Alex Merry\n"
++"Damien Lucas\n"
++"Grigori Goronzy\n"
++"Richard Shepherd\n"
++"Gaël Hendryckx\n"
++"Michael Feurstein\n"
++"Stephan Assmus\n"
++"Adrien Grand\n"
++"Colin Guthrie\n"
++"David Menestrina\n"
++"Dominique Martinet\n"
++"Gleb Pinigin\n"
++"Jason Luka\n"
++"Luc Saillard\n"
++"Luca Barbato\n"
++"Mario Speiß\n"
++"Pankaj Yadav\n"
++"Ramiro Polla\n"
++"Ronald Wright\n"
++"Rui Zhang\n"
++"Can Wu\n"
++"Christophe Courtaut\n"
++"FUJISAWA Tooru\n"
++"Hannes Domani\n"
++"Manol Manolov\n"
++"Timothy B. Terriberry\n"
++"Antoine Lejeune\n"
++"Arnaud Schauly\n"
++"Branko Kokanovic\n"
++"Dylan Yudaken\n"
++"Florian G. Pflug\n"
++"François Revol\n"
++"G Finch\n"
++"Keary Griffin\n"
++"Konstanty Bialkowski\n"
++"Ming Hu\n"
++"Philippe Coent\n"
++"Przemyslaw Fiala\n"
++"Tanguy Krotoff\n"
++"Vianney BOYER\n"
++"Casian Andrei\n"
++"Chris Smowton\n"
++"David Kaplan\n"
++"Eugenio Jarosiewicz\n"
++"Fabian Keil\n"
++"Guillaume Poussel\n"
++"John Peterson\n"
++"Justus Piater\n"
++"Mark Lee\n"
++"Martin T. H. Sandsmark\n"
++"Rune Botten\n"
++"Søren Bøg\n"
++"Toralf Niebuhr\n"
++"Tristan Matthews\n"
++"Angelo Haller\n"
++"Aurélien Nephtali\n"
++"Austin Burrow\n"
++"Bill C. Riemers\n"
++"Colin Delacroix\n"
++"Cristian Maglie\n"
++"Elminster2031\n"
++"Jakub Wieczorek\n"
++"John Freed\n"
++"Mark Hassman\n"
++"Martin Briza\n"
++"Mike Houben\n"
++"Romain Goyet\n"
++"Adrian Yanes\n"
++"Alexander Lakhin\n"
++"Anatoliy Anischovich\n"
++"Barry Wardell\n"
++"Ben Hutchings\n"
++"Besnard Jean-Baptiste\n"
++"Brian Weaver\n"
++"Clement Chesnin\n"
++"David Geldreich\n"
++"Diego Elio Pettenò\n"
++"Diego Fernando Nieto\n"
++"Georgi Chorbadzhiyski\n"
++"Jon Stacey\n"
++"Jonathan Rosser\n"
++"Joris van Rooij\n"
++"Kaloyan Kovachev\n"
++"Katsushi Kobayashi\n"
++"Kelly Anderson\n"
++"Loren Merritt\n"
++"Maciej Blizinski\n"
++"Mark Bidewell\n"
++"Miguel Angel Cabrera Moya\n"
++"Niles Bindel\n"
++"Samuel Pitoiset\n"
++"Scott Caudle\n"
++"Sean Robinson\n"
++"Sergey Radionov\n"
++"Simon Hailes\n"
++"Stephen Parry\n"
++"Sukrit Sangwan\n"
++"Thierry Reding\n"
++"Xavier Martin\n"
++"Alex Converse\n"
++"Alexander Bethke\n"
++"Alexandre Ratchov\n"
++"Andres Krapf\n"
++"Andrey Utkin\n"
++"Andri Pálsson\n"
++"Andy Chenee\n"
++"Anuradha Suraparaju\n"
++"Benjamin Poulain\n"
++"Brieuc Jeunhomme\n"
++"Chris Clayton\n"
++"Clément Lecigne\n"
++"Cédric Cocquebert\n"
++"Daniel Peng\n"
++"Danny Wood\n"
++"David K\n"
++"Edouard Gomez\n"
++"Emmanuel de Roux\n"
++"Frode Tennebø\n"
++"GBX\n"
++"Gaurav Narula\n"
++"Geraud CONTINSOUZAS\n"
++"Hugues Fruchet\n"
++"Jan Winter\n"
++"Jean-François Massol\n"
++"Jean-Philippe Grimaldi\n"
++"Josh Watzman\n"
++"Kai Lauterbach\n"
++"Konstantin Bogdanov\n"
++"Kuan-Chung Chiu\n"
++"Kuang Rufan\n"
++"Matthias Dahl\n"
++"Michael McEll\n"
++"Michael Ploujnikov\n"
++"Mike Schrag\n"
++"Nickolai Zeldovich\n"
++"Nicolas Bertrand\n"
++"Niklas Hayer\n"
++"Olafs Vandāns\n"
++"Olivier Gambier\n"
++"Paul Corke\n"
++"Ron Frederick\n"
++"Rov Juvano\n"
++"Sabourin Gilles\n"
++"Sam Lade\n"
++"Sandeep Kumar\n"
++"Sasha Koruga\n"
++"Sreng Jean\n"
++"Sven Petai\n"
++"Tomas Krotil\n"
++"Tomer Barletz\n"
++"Tristan Leteurtre\n"
++"Wang Bo\n"
++"maxime Ripard\n"
++"xxcv\n"
++"Adam Hoka\n"
++"Adrian Knoth\n"
++"Adrien Cunin\n"
++"Alan Fischer\n"
++"Alan McCosh\n"
++"Alex Helfet\n"
++"Alexander Terentyev\n"
++"Alexandre Ferreira\n"
++"Alina Friedrichsen\n"
++"An L. Ber\n"
++"Andreas Schlick\n"
++"Andrew Schubert\n"
++"Andrey Makhnutin\n"
++"Arnaud Vallat\n"
++"Asad Mehmood\n"
++"Ashok Bhat\n"
++"Austin English\n"
++"Baptiste Coudurier\n"
++"Benoit Calvez\n"
++"Björn Stenberg\n"
++"Blake Livingston\n"
++"Brandon Brooks\n"
++"Brian Johnson\n"
++"Brian Kurle\n"
++"Cezar Elnazli\n"
++"Chris White\n"
++"Christian Masus\n"
++"Christoph Pfister\n"
++"Christoph Seibert\n"
++"Christopher Key\n"
++"Christopher Rath\n"
++"Claudio Ortelli\n"
++"Cody Russell\n"
++"Cristian Morales Vega\n"
++"Dan Rosenberg\n"
++"Daniel Marth\n"
++"Daniel Tisza\n"
++"Detlef Schroeder\n"
++"Diego Biurrun\n"
++"Dominik 'Rathann' Mierzejewski\n"
++"Duncan Salerno\n"
++"Edward Sheldrake\n"
++"Elliot Murphy\n"
++"Eren Inan Canpolat\n"
++"Ernest E. Teem III\n"
++"Etienne Membrives\n"
++"Fargier Sylvain\n"
++"Fathi Boudra\n"
++"Felix Geyer\n"
++"Filipe Azevedo\n"
++"Finn Hughes\n"
++"Florian Hubold\n"
++"Florian Roeske\n"
++"Frank Enderle\n"
++"Frédéric Crozat\n"
++"Georg Seifert\n"
++"Gertjan Van Droogenbroeck\n"
++"Gilles Chanteperdrix\n"
++"Greg Farrell\n"
++"Gregory Maxwell\n"
++"Gwenole Beauchesne\n"
++"Götz Waschk\n"
++"Hans-Kristian Arntzen\n"
++"Harry Sintonen\n"
++"Iain Wade\n"
++"Ibraheem Paredath\n"
++"Isamu Arimoto\n"
++"Ismael Luceno\n"
++"James Bates\n"
++"James Bond\n"
++"James Turner\n"
++"Janne Grunau\n"
++"Janne Kujanpää\n"
++"Jarmo Torvinen\n"
++"Jason Scheunemann\n"
++"Jeff Lu\n"
++"Jeroen Ost\n"
++"Joe Taber\n"
++"Johann Ransay\n"
++"Johannes Weißl\n"
++"John Hendrikx\n"
++"John Stebbins\n"
++"Jonas Gehring\n"
++"Joseph S. Atkinson\n"
++"Juergen Lock\n"
++"Julien 'Lta' BALLET\n"
++"Julien / Gellule\n"
++"Julien Humbert\n"
++"Kamil Baldyga\n"
++"Kamil Klimek\n"
++"Karlheinz Wohlmuth\n"
++"Kevin Anthony\n"
++"Kevin DuBois\n"
++"Lari Natri\n"
++"Lorenzo Pistone\n"
++"Lucas C. Villa Real\n"
++"Lukáš Lalinský\n"
++"Mal Graty\n"
++"Malte Tancred\n"
++"Martin Pöhlmann\n"
++"Martin Zeman\n"
++"Marton Balint\n"
++"Mathew King\n"
++"Mathieu Sonet\n"
++"Matthew A. Townsend\n"
++"Matthias Bauer\n"
++"Mika Tiainen\n"
++"Mike Cardillo\n"
++"Mounir Lamouri (volkmar)\n"
++"Natanael Copa\n"
++"Nathan Phillip Brink\n"
++"Nick Briggs\n"
++"Nick Pope\n"
++"Nil Geiswiller\n"
++"Pascal Thomet\n"
++"Pere Orga\n"
++"Peter Bak Nielsen\n"
++"Phil Roffe and David Grellscheid\n"
++"Philip Sequeira\n"
++"Pierre Souchay\n"
++"Piotr Fusik\n"
++"Pádraig Brady\n"
++"R.M\n"
++"Ralph Giles\n"
++"Ramon Gabarró\n"
++"Robert Forsman\n"
++"Robert Jedrzejczyk\n"
++"Robert Paciorek\n"
++"Rolf Ahrenberg\n"
++"Roman Pen\n"
++"Ruud Althuizen\n"
++"Samuli Suominen\n"
++"Scott Lyons\n"
++"Sebastian Birk\n"
++"Sergey Puzanov\n"
++"Sergio Ammirata\n"
++"Sharad Dixit\n"
++"Song Ye Wen\n"
++"Stephan Krempel\n"
++"Steven Kramer\n"
++"Steven Sheehy\n"
++"Sveinung Kvilhaugsvik\n"
++"Sylvain Cadhillac\n"
++"Sylver Bruneau\n"
++"Takahito HIRANO\n"
++"Theron Lewis\n"
++"Thijs Alkemade\n"
++"Tillmann Karras\n"
++"Timo Paulssen\n"
++"Timo Rothenpieler\n"
++"Tobias Rapp\n"
++"Tomasen\n"
++"Tony Vankrunkelsven\n"
++"Tristan Heaven\n"
++"Varphone Wong\n"
++"Vasily Fomin\n"
++"Vikram Narayanan\n"
++"Yannick Bréhon\n"
++"Yavor Doganov\n"
++"Yohann Martineau\n"
++"dharani.prabhu.s\n"
++"suheaven\n"
++"wucan\n"
++"김정은\n"
++"Adam Sampson\n"
++"Alexander Gall\n"
++"Alex Antropoff\n"
++"Alexis Guillard\n"
++"Alex Izvorski\n"
++"Amir Gouini\n"
++"Andrea Guzzo\n"
++"Andrew Flintham\n"
++"Andrew Zaikin\n"
++"Andy Lindsay\n"
++"Arai/Fujisawa Tooru\n"
++"Arkadiusz Miskiewicz\n"
++"Arnaud Gomes-do-Vale\n"
++"Arwed v. Merkatz\n"
++"Barak Ori\n"
++"Basil Achermann\n"
++"Benjamin Mironer\n"
++"Bill\n"
++"Bob Maguire\n"
++"Brian C. Wiles\n"
++"Brian Raymond\n"
++"Brian Robb\n"
++"Carsten Gottbehüt\n"
++"Carsten Haitzler\n"
++"Charles Hordis\n"
++"Chris Clepper\n"
++"Christian Henz\n"
++"Christof Baumgaertner\n"
++"Christophe Burgalat\n"
++"Christopher Johnson\n"
++"Cian Duffy\n"
++"Colin Simmonds\n"
++"Damian Ivereigh\n"
++"Daniel Fischer\n"
++"Daniel Stränger\n"
++"Danko Dolch\n"
++"Dennis Lou\n"
++"Dermot McGahon\n"
++"Douglas West\n"
++"Dugal Harris\n"
++"Emmanuel Blindauer\n"
++"Enrico Gueli\n"
++"Enrique Osuna\n"
++"Eren Türkay\n"
++"Eric Dudiak\n"
++"Espen Skoglund\n"
++"Ethan C. Baldridge\n"
++"François Seingier\n"
++"Frans van Veen\n"
++"Frédéric Ruget\n"
++"Gerald Hansink\n"
++"Gisle Vanem\n"
++"Glen Gray\n"
++"Goetz Waschk\n"
++"Gregory Hazel\n"
++"Gustaf Neumann\n"
++"Hang Su\n"
++"Hans Lambermont\n"
++"Hans-Peter Jansen\n"
++"Harris Dugal\n"
++"Heiko Panther\n"
++"Igor Helman\n"
++"Isaac Osunkunle\n"
++"Jan David Mol\n"
++"Jan Gerber\n"
++"Jan Van Boghout\n"
++"Jasper Alias\n"
++"Jean-Alexis Montignies\n"
++"Jean-Baptiste Le Stang\n"
++"Jeffrey Baker\n"
++"Jeroen Massar\n"
++"Jérôme Guilbaud\n"
++"Johannes Buchner\n"
++"Johen Michael Zorko\n"
++"Johnathan Rosser\n"
++"John Dalgliesh\n"
++"John Paul Lorenti\n"
++"Jörg\n"
++"Joseph Tulou\n"
++"Julien Blache\n"
++"Julien Plissonneau Duquène\n"
++"Julien Robert\n"
++"Kenneth Ostby\n"
++"Kenneth Self\n"
++"Kevin H. Patterson\n"
++"Koehler, Vitally\n"
++"K. Staring\n"
++"Lahiru Lakmal Priyadarshana\n"
++"Laurent Mutricy\n"
++"Leo Spalteholz\n"
++"Loox Thefuture\n"
++"Marc Nolette\n"
++"Marco Munderloh\n"
++"Mark Gritter\n"
++"Markus Kern\n"
++"Markus Kuespert\n"
++"Martin Hamrle\n"
++"Martin Kahr\n"
++"Mateus Krepsky Ludwich\n"
++"Mathias Kretschmer\n"
++"Mats Rojestal\n"
++"Matthias P. Nowak\n"
++"Matthieu Lochegnies\n"
++"Michael Mondragon\n"
++"Michael S. Feurstein\n"
++"Michel Lanners\n"
++"Mickael Hoerdt\n"
++"Miguel Angel Cabrera\n"
++"Mikko Hirvonen\n"
++"Moritz Bunkus\n"
++"Nilmoni Deb\n"
++"Olivier Houchard\n"
++"Olivier Pomel\n"
++"Ondrej Kuda aka Albert\n"
++"Øyvind Kolbu\n"
++"Pascal Levesque\n"
++"Patrick Horn\n"
++"Patrick McLean\n"
++"Pauline Castets\n"
++"Paul Mackerras\n"
++"Peter Surda\n"
++"Petr Vacek\n"
++"Philippe Van Hecke\n"
++"Pierre-Luc Beaudoin\n"
++"Pierre Marc Dumuid\n"
++"Régis Duchesne\n"
++"Remco Poortinga\n"
++"Rene Gollent\n"
++"Rob Casey\n"
++"Robson Braga Araujo\n"
++"Roine Gustafsson\n"
++"Roman Bednarek\n"
++"Rudolf Cornelissen\n"
++"Sašo Kiselkov\n"
++"Sebastian Jenny\n"
++"Shane Harper\n"
++"Stefán Freyr Stefánsson\n"
++"Steve Brown\n"
++"Steven M. Schultz\n"
++"Tapio Hiltunen\n"
++"Thomas L. Wood\n"
++"Thomas Mühlgrabner\n"
++"Thomas Parmelan\n"
++"Tim 'O Callagha\n"
++"Tim Schuerewegen\n"
++"Tong Ka Man\n"
++"Torsten Spindler\n"
++"Udo Richter\n"
++"Vincent Dimar\n"
++"Vincent Penne\n"
++"Vitalijus Slavinskas\n"
++"Vitaly V. Bursov\n"
++"Vladimir Chernyshov\n"
++"Wade Majors\n"
++"Wallace Wadge\n"
++"Watanabe Go\n"
++"William Hawkins\n"
++"Xavier Maillard\n"
++"Ye zhang\n"
++"Yuehua Zhao\n"
++"Abylay Ospan\n"
++"Adam Leggett\n"
++"Adrian Haensler\n"
++"Ago Allikmaa\n"
++"Ajith Manjula Senarathne\n"
++"Alain Degreffe\n"
++"Alan Pope\n"
++"Aleksandr Pasechnik\n"
++"Alexandre Fernandez\n"
++"Alexandre Pereira Nunes\n"
++"Alexandre Perraud\n"
++"Alex Peak\n"
++"Alex Warhawk\n"
++"Alex Woods\n"
++"Allan Odgaard\n"
++"Ancelot Mark Pinto\n"
++"Andrea Giudiceandrea\n"
++"Andreas Hartmetz\n"
++"Andreas Mieke\n"
++"André Silva\n"
++"Andrew Clayton\n"
++"Andrey Gursky\n"
++"Andrii Zui\n"
++"Andy Tather\n"
++"Antti Ajanki\n"
++"Ara Qadir\n"
++"Arjun Sreedharan\n"
++"Arne de Bruijn\n"
++"Arun Pandian G\n"
++"A S Alam\n"
++"Avani Sharma\n"
++"Avishay Spitzer\n"
++"Bastien Penavayre\n"
++"Benjamin Adolphi\n"
++"Ben Littler\n"
++"Benoit du Payrat\n"
++"Benoît Noël du Payrat\n"
++"Bernd Kuhls\n"
++"Boris Egorov\n"
++"Boy van Amstel\n"
++"Brian Schmidt\n"
++"Brion Vibber\n"
++"Cameron Mozie\n"
++"Carlos Fenollosa\n"
++"Carola Nitz\n"
++"Christian Suloway\n"
++"Clemens Werther\n"
++"C.W. Betts\n"
++"Daniel Amm\n"
++"Daniel Verkamp\n"
++"Darko Jankovic\n"
++"Darrell Walisser\n"
++"David Robison\n"
++"David R Robison\n"
++"Dennis Hamester\n"
++"Derek Buitenhuis\n"
++"Diogo Silva\n"
++"Dominko Azdajic\n"
++"Donald Campbell\n"
++"Doney den Ouden\n"
++"Duncan McNamara\n"
++"Duncan McNAMARA\n"
++"Elodie Thomann\n"
++"Emeric Grange\n"
++"Eric Engestrom\n"
++"Etienne BRATEAU\n"
++"Eugen Geist\n"
++"Fabian Yamaguchi\n"
++"Fabrizio Ge\n"
++"Fabrizio Gennari\n"
++"Fahad Al-Saidi\n"
++"Felix Abecassis\n"
++"Florent Pillet\n"
++"Forteve Zepushisti\n"
++"Frank Praznik\n"
++"Gabriel de Perthuis\n"
++"Gal Vinograd\n"
++"Gaurav Pruthi\n"
++"Geoffrey Métais\n"
++"Gian Marco Sibilla\n"
++"Gilles Sabourin\n"
++"Gina Dobrescu\n"
++"Gonzalo Higuera Díaz\n"
++"Goran Dokic\n"
++"Guillaume Gomez\n"
++"Harald Sitter\n"
++"Heorhi Valakhanovich\n"
++"Ian Chamberlain\n"
++"Ibrahima SARR\n"
++"Igor Prokopenkov\n"
++"Ion Agorria\n"
++"Jarrad Whitaker\n"
++"Jean-Yves Avenard\n"
++"Jed Smith\n"
++"Jérémy Carrier\n"
++"Jeremy Huddleston Sequoia\n"
++"Jerome Forissier\n"
++"Jim Bankoski\n"
++"Jonas Lundqvist\n"
++"Jonatan \"jaw\" Wallmander\n"
++"Jonathan Calmels\n"
++"Jonathan Heard\n"
++"Jonathan McGowan\n"
++"Jonathan Thambidurai\n"
++"Joni Räsänen\n"
++"Josef Andersson\n"
++"Joseph DeVore\n"
++"Julian Scheel\n"
++"Justin Kim\n"
++"Kaarlo Räihä\n"
++"Kamil Rytarowski\n"
++"Kazuki Yamaguchi\n"
++"Konstantin K. Beliak\n"
++"Konstantinos Tsanaktsidis\n"
++"Konstantin Pavlov\n"
++"Kornel Lesiński\n"
++"Olivier Langlois\n"
++"Lochlin Duperron\n"
++"Lukas Juhrich\n"
++"Lyndon Brown\n"
++"Marc Aldorasi\n"
++"Marcel Schnirring\n"
++"Marc Etcheverry\n"
++"Mariusz Wasak\n"
++"Mark Becwar\n"
++"Martell Malone\n"
++"Mathieu Malaterre\n"
++"Mathieu Parent\n"
++"Mathieu Velten\n"
++"Matthias Keiser\n"
++"Matthias Treydte\n"
++"Max Dilipovich\n"
++"Maxim Bublis\n"
++"Maxime CHAPELET\n"
++"Maxime Mouchet\n"
++"Michael Tänzer\n"
++"Miha Sokolov\n"
++"Mohammed (Shaan) Huzaifa Danish\n"
++"Moti Zilberman\n"
++"Nathan Egge\n"
++"Niklas Haas\n"
++"Odd-Arild Kristensen\n"
++"O. Hartmann\n"
++"Olaf Hering\n"
++"Oliver Collyer\n"
++"Paul B Mahol\n"
++"Paul Clark\n"
++"Paulo Vitor Magacho da Silva\n"
++"Pavol Babincak\n"
++"Paweł Stankowski\n"
++"Petter Reinholdtsen\n"
++"Philip Höhlein\n"
++"Pierre-Hugues Husson\n"
++"Pierre Lamot\n"
++"Pyry Kontio\n"
++"Radek Vybiral\n"
++"Rafael Waldo Delgado Doblas\n"
++"Rajeesh K V\n"
++"Ray Tiley\n"
++"Reka Inovan\n"
++"Remita Amine\n"
++"Ricardo Ribalda Delgado\n"
++"Richard Diamond\n"
++"Rinat Ibragimov\n"
++"Robert Mourning\n"
++"Romain Bentz\n"
++"Romain Fliedel\n"
++"Romain Vimont\n"
++"Ronald S. Bultje\n"
++"Ross Finlayson\n"
++"Sam Malone\n"
++"Samuel Martin\n"
++"Samuel Thibault\n"
++"Sanchit Arora\n"
++"Santiago Gimeno\n"
++"Sebastian Ramacher\n"
++"Sebastian Roth\n"
++"Sergey Bolshakov\n"
++"Shaleen Jain\n"
++"Shlomi Fish\n"
++"Simona-Marinela Prodea\n"
++"Stanislas Plessia\n"
++"Stefan Pöschel\n"
++"Steven Toth\n"
++"Sushma Reddy\n"
++"Takahito Hirano\n"
++"T. Chomphuming\n"
++"Thierry Foucu\n"
++"Thomas Nigro\n"
++"Tim Allen\n"
++"Tim Walker\n"
++"Tobias Conradi\n"
++"Tony Gaillard\n"
++"Benoît Tuduri\n"
++"Tzu-Jung Lee\n"
++"Uwe L. Korn\n"
++"Valentin Deniaud\n"
++"Valentin Vetter\n"
++"Valter Correia\n"
++"Vianney Boyer\n"
++"Victorien Le Couviour--Tuffet\n"
++"Vikram Fugro\n"
++"Vinson Lee\n"
++"Wayne McDougall\n"
++"Wieland Hoffmann\n"
++"Wills Wang\n"
++"Xabier Aramendi\n"
++"Yaşar Tay\n"
++"Yidong Ren\n"
++"Yuudai Yamashigi\n"
++"Zhao Zhili\n"
++"أحمد المحم ودي (Ahmed El-Mahmoudy)\n"
++"Баярсайхан Энхтайван\n"
++"Сергей Дарьичев\n"
++"\n"
++"Artwork\n"
++"-------\n"
++"Damien Erambert\n"
++"Daniel Dreibrodt, aka aLtgLasS\n"
++"David Weber\n"
++"Davor Orel\n"
++"Dominic Spitaler\n"
++"Doney den Ouden\n"
++"Eurodata Computer Club\n"
++"Geoffrey Roussel\n"
++"Joeri van Dooren\n"
++"kty0ne\n"
++"Max Rudberg\n"
++"Richard Øiestad\n"
++"Simon Damkjær Andersen\n"
++"Tom Bigelajzen\n"
++"Vincent van den Heuvel\n"
++"\n"
++"Documentation\n"
++"-------------\n"
++"Bill Eldridge\n"
++"\n"
++"Localization\n"
++"------------\n"
++"Abdul Fousan - Tamil\n"
++"A. Decorte - Friulian\n"
++"A. Regnander - Swedish\n"
++"Adem Gunes - Turkish\n"
++"Adi Nugroho - Tagalog\n"
++"Adnan Memija - Bosnian\n"
++"airplanez - Korean\n"
++"Ajith Manjula - Sinhala\n"
++"Aled Powell - Welsh\n"
++"Alexander Didebulidze - Georgian\n"
++"Alexander Henket - Dutch\n"
++"Alexander Jansen - Norwegian Bokmål\n"
++"Alexander Lakhin - Russian\n"
++"Alexey Lugin - Ukrainian\n"
++"Alexey Salmin - Russian\n"
++"Alfred John - Acoli\n"
++"Amanpreet Singh Alam - Punjabi\n"
++"André de Barros Martins Ribeiro - Brazilian portuguese\n"
++"Andrey Brilevskiy - Russian\n"
++"Andrey Wolk - Russian\n"
++"Andri Pálsson - Icelandic\n"
++"Andriy Bandura - Ukrainian\n"
++"Anh Phan - Vietnamese\n"
++"Aniket Eknath Kudale - Marathi\n"
++"Animesh Swar - Nepalese\n"
++"Aputsiaĸ Niels Janussen - Danish\n"
++"Ara Bextiyar - Sorani (Kurdish)\n"
++"Ari Constâncio - Portuguese\n"
++"Arkadiusz Lipiec - Polish\n"
++"Ask Hjorth Larsen - Danish\n"
++"Audrey Prevost - French\n"
++"Auk Piseth - Khmer\n"
++"Bayarsaikhan Enkhtaivan Баярсайхан Энхтайван - Mongolian\n"
++"Biraj Karmakar - Bengali (India)\n"
++"Bruno Queirós - Portuguese\n"
++"Bruno Vella - Italian\n"
++"Caner Başaran - Turkish\n"
++"Carlo Calabrò - Italian\n"
++"Chandan Kumar - Hindi\n"
++"Chesús Daniel Trigo - Aragonese\n"
++"Christoph Miebach - German\n"
++"Chynggyz Jumaliev - Kirgyz\n"
++"Circo Radu - Romanian\n"
++"Cristian Secară - Romanian\n"
++"Daniel Nylander - Swedish\n"
++"Daniel Winzen - German\n"
++"David González - Spanish\n"
++"David Planella - Catalan\n"
++"Dean Lee - Simplified Chinese\n"
++"Denis Arnaud - Breton\n"
++"Derk-Jan Hartman - Dutch\n"
++"DirektX - Hungarian\n"
++"Dominko Aždajić - Croatian\n"
++"Dylan Aïssi - French\n"
++"Đorđe Vasiljević - Serbian\n"
++"Eduard Babayan - Armenian\n"
++"Eero - Estonian\n"
++"Eirik U. Birkeland - Norwegian Nynorsk\n"
++"Elizabeth Da Conceicao Baptista - Tetum\n"
++"Emilio Sepúlveda - Interlingua\n"
++"Emin Mastizada - Azerbaijani\n"
++"Éric Lassauge - French\n"
++"Farzaneh Sarafraz - Persian\n"
++"Florence Tushabe - Chiga\n"
++"Fouzia Bourai - Arabic\n"
++"Frank Chao - Traditional Chinese\n"
++"Freyr Gunnar Ólafsson - Icelandic\n"
++"Friedel Wolff - Afrikaans\n"
++"Fumio Nakayama - Japanese\n"
++"Gabor Kelemen - Hungarian\n"
++"Gaurav Kumar - Hindi\n"
++"Gaëtan Rousseaux - Walloon\n"
++"Ghjuvan Pasquinu - Corsican\n"
++"Goce Manevski - Macedonian\n"
++"Golam Maruf Oovee - Bengali\n"
++"Gonçalo Cordeiro - Galician\n"
++"Gorana Milicevic - Serbian\n"
++"Goswami Hardikpuri Kishorpuri - Gujarati\n"
++"Haakon Meland Eriksen - Norwegian\n"
++"Han HoJoong - Korean\n"
++"Hardik Kishorpuri Goswami - Gujarati\n"
++"Hemanta Nandi - Bengali (India)\n"
++"Huw Waters - Welsh\n"
++"H.Shalitha Vikum - Sinhala\n"
++"Ibrahima Sarr - Fulah\n"
++"Ingmārs Dīriņš - Latvian\n"
++"Israt Jahan - Bengali\n"
++"Ivar Smolin - Estonian\n"
++"Iván Seoane Pardo - Galician\n"
++"Ivo Ivanov - Bulgarian\n"
++"Iñaki Larrañaga Murgoitio - Basque\n"
++"Iñigo Varela - Asturian; Bable\n"
++"Jakub Žáček - Czech\n"
++"James Olweny - Ganda\n"
++"Jamil Ahmed - Bengali\n"
++"Javier Varela - Spanish\n"
++"Jean-Pierre Kuypers - French\n"
++"Jens Seidel - German\n"
++"Joao Almeida - Portuguese\n"
++"Joel Arvidsson - Swedish\n"
++"jogijs - Latvian\n"
++"Jonas Larsen - Danish\n"
++"Jon Stødle - Norwegian Nynorsk\n"
++"Jouni Kähkönen - Finnish\n"
++"Juha Jeronen - Finnish\n"
++"Julen Ruiz Aizpuru - Basque\n"
++"Kai Hermann - German\n"
++"Kamil Páral - Czech\n"
++"Kang Jeong-Hee - Korean\n"
++"Kasper Tvede - Danish\n"
++"Kaya Zeren - Turkish\n"
++"Kenneth Nielsen - Danish\n"
++"Khin Mi Mi Aung - Burmese\n"
++"Khoem Sokhem - Khmer\n"
++"Kola - Albanian\n"
++"Kypchak Kypchak - Kazakh\n"
++"Laurent Jonqueres - Occitan\n"
++"Loba Yeasmeen - Bengali\n"
++"Lorena Gomes - Catalan\n"
++"Lorenzo Porta - Italian\n"
++"Luqman Hakim - Indonesian\n"
++"L. Balasubramaniam - Hindi\n"
++"Mahrazi Mohd Kamal - Malay\n"
++"Manolis Stefanis - Modern Greek\n"
++"Manuela Silva/Alfredo Silva - Portuguese\n"
++"Marián Hikaník - Slovak\n"
++"Mario Siegmann - German\n"
++"Marko Uskokovic - Serbian\n"
++"Martin Srebotnjak - Slovenian\n"
++"Martin Zicha - Czech\n"
++"Matej Urbančič - Slovenian\n"
++"Mathias C. Berens, welcome-soft - German\n"
++"Mattias Põldaru - Estonian\n"
++"Md. Rezwan Shahid - Bengali\n"
++"Meelad Zakaria - Persian\n"
++"Michael Bauer - Scottish Gaelic\n"
++"Michal Halenka - Czech\n"
++"Michał Trzebiatowski - Polish\n"
++"Miguel Sousa - Portuguese\n"
++"Mihkel Kirjutas - Estonian\n"
++"Mindaugas Baranauskas - Lithuanian\n"
++"Miroslav Oujeský - Czech\n"
++"Morten Brix Pedersen - Danish\n"
++"Mustafa Sandal - Czech\n"
++"Myckel Habets - Dutch\n"
++"Namhyung Kim - Korean\n"
++"Niels Fanøe - Danish\n"
++"Niklas 'Nille' Åkerström - Swedish\n"
++"Olav Dahlum - Norwegian Bokmål\n"
++"Oleksandr Natalenko - Ukrainian\n"
++"Omer Ensari - Kurmanji (Kurdish)\n"
++"Osama Khalid - Arabic\n"
++"Otto Kekäläinen - Finnish\n"
++"Paras Nath Chaudhary - Nepali\n"
++"Pasindu Kavinda - Sinhala\n"
++"Pau Iranzo - Catalan\n"
++"Paula Iglesias - Galician\n"
++"Pedro Valadares - Portuguese\n"
++"Peter Jespersen - Danish\n"
++"Petr Šimáček - Czech\n"
++"Phan Anh - Vietnamese\n"
++"Philipp Weissenbacher - German\n"
++"Pittayakom Saingtong - Thai\n"
++"Prasannajit Acharya - Oriya\n"
++"Praveen Illa - Telugu\n"
++"Predrag Ljubenović - Serbian\n"
++"Pyae Sone - Burmese\n"
++"Rajnikant Kumbhar - Marathi\n"
++"Ricardo Perdigão - Portuguese\n"
++"Ricardo Pérez López - Spanish\n"
++"Roustam Ghizdatov - Russian\n"
++"Ruei-Yuan Lu - Traditional Chinese\n"
++"Saad Liaquat Kiani - Urdu\n"
++"Sadia Afroz - Bengali\n"
++"Said Marjan Zazai - Pashto\n"
++"Salar Khalilzadeh - Persian\n"
++"Sam Askari - Spanish\n"
++"Sam Hocevar - British\n"
++"Samuel Hocevar - French\n"
++"Saúl Ortega - Spanish\n"
++"Savvas Nesseris - Modern Greek\n"
++"Sayan Chowdhury - Hindi\n"
++"Seanán Ó Coistín - Irish\n"
++"Semsudin Abdic - Bosnian\n"
++"Shambhu Kumar - Hindi\n"
++"Shantanu Sarkar - Hindi\n"
++"Shashi Ranjan - Hindi\n"
++"Siarhei Daryichau Дар'ічаў Сяргей - Belarusian\n"
++"Sidney Doria - Brazilian Portuguese\n"
++"Sigmund Augdal - Norwegian Bokmål\n"
++"Simos Xenitellis - Modern Greek\n"
++"Sipho Sibiya - Zulu\n"
++"Sok Sophea - Khmer\n"
++"Solomon Gizaw - Amharic\n"
++"Sreejith P - Malayalam\n"
++"Suraj Kawade - Marathi\n"
++"Stian Jørgensrud - Norwegian Bokmål\n"
++"Sveinn í Felli - Icelandic\n"
++"Tadashi Jokagi - Japanese\n"
++"Tarsem Singh - Hindi\n"
++"Thanakrit Chomphuming - Thai\n"
++"Tero Pelander - Finnish\n"
++"Thomas De Rocker - Dutch\n"
++"Thomas Graf - gettext support, German\n"
++"Tomáš Chvátal - Czech\n"
++"Tòni Galhard - Occitan\n"
++"Umesh Agarwal - Bengali (India)\n"
++"Umidjon Almasov - Uzbek\n"
++"Václav Pavlíček - Czech\n"
++"Valek Filippov - Russian\n"
++"Vicente Jimenez Aguilar - Spanish\n"
++"Vincenzo Reale - Italian\n"
++"Vít Pelčák - Czech\n"
++"viyyer - Hindi\n"
++"Vladimir Yermolayev - Russian\n"
++"Vojtěch Smejkal - Czech\n"
++"Wei Mingzhi - Simplified Chinese\n"
++"Xènia Albà Cantero - Catalan\n"
++"Xuacu Saturio - Asturian\n"
++"Yaron Shahrabani - Hebrew\n"
++"Yaşar Tay - Turkish\n"
++"Yhal Htet Aung - Burmese\n"
++"Yogesh K S - Kannada\n"
++"Yoyo - Simplified Chinese\n"
++"Yuksel Yildirim - Turkish\n"
++"Zabeeh Khan - Pashto\n"
++"Zhang Tong - Chinese\n"
++;
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_access.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_access.h
+new file mode 100644
+index 0000000..4356be6
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_access.h
+@@ -0,0 +1,81 @@
++/*****************************************************************************
++ * vlc_access.h: Access descriptor, queries and methods
++ *****************************************************************************
++ * Copyright (C) 1999-2006 VLC authors and VideoLAN
++ * $Id: da06554814885d03823aefbf58e858f6941b3400 $
++ *
++ * Authors: Laurent Aimar <fenrir@via.ecp.fr>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_ACCESS_H
++#define VLC_ACCESS_H 1
++
++#include <vlc_stream.h>
++
++/**
++ * \defgroup access Access
++ * \ingroup stream
++ * Raw input byte streams
++ * @{
++ * \file
++ * Input byte stream modules interface
++ */
++
++/**
++ * Special redirection error code.
++ *
++ * In case of redirection, the access open function should clean up (as in
++ * normal failure case), store the heap-allocated redirection URL in
++ * stream_t.psz_url, and return this value.
++ */
++#define VLC_ACCESS_REDIRECT VLC_ETIMEOUT
++
++/**
++ * Opens a new read-only byte stream.
++ *
++ * This function might block.
++ * The initial offset is of course always zero.
++ *
++ * \param obj parent VLC object
++ * \param mrl media resource location to read
++ * \return a new access object on success, NULL on failure
++ */
++VLC_API stream_t *vlc_access_NewMRL(vlc_object_t *obj, const char *mrl);
++
++/**
++ * \defgroup access_helper Access Helpers
++ * @{
++ */
++
++/**
++ * Default pf_control callback for directory accesses.
++ */
++VLC_API int access_vaDirectoryControlHelper( stream_t *p_access, int i_query, va_list args );
++
++#define ACCESS_SET_CALLBACKS( read, block, control, seek ) \
++    do { \
++        p_access->pf_read = (read); \
++        p_access->pf_block = (block); \
++        p_access->pf_control = (control); \
++        p_access->pf_seek = (seek); \
++    } while(0)
++
++/**
++ * @} @}
++ */
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_actions.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_actions.h
+new file mode 100644
+index 0000000..5d78f5e
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_actions.h
+@@ -0,0 +1,275 @@
++/*****************************************************************************
++ * vlc_actions.h: handle vlc actions
++ *****************************************************************************
++ * Copyright (C) 2003-2016 VLC authors and VideoLAN
++ * $Id: 404c1662a82ef3f3ffc983a81fa73b90f5773eef $
++ *
++ * Authors: Sigmund Augdal Helberg <dnumgis@videolan.org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_ACTIONS_H
++#define VLC_ACTIONS_H 1
++
++/* Called from src/libvlc.c */
++int
++libvlc_InternalActionsInit(libvlc_int_t *p_libvlc);
++
++/* Called from src/libvlc.c */
++void
++libvlc_InternalActionsClean(libvlc_int_t *p_libvlc);
++
++/**
++ * \file
++ * This file defines keys and functions
++ */
++
++#define KEY_MODIFIER         0xFF000000
++#define KEY_MODIFIER_ALT     0x01000000
++#define KEY_MODIFIER_SHIFT   0x02000000
++#define KEY_MODIFIER_CTRL    0x04000000
++#define KEY_MODIFIER_META    0x08000000
++#define KEY_MODIFIER_COMMAND 0x10000000
++
++#define KEY_UNSET            0x00000000
++#define KEY_BACKSPACE              0x08
++#define KEY_TAB                    0x09
++#define KEY_ENTER                  0x0D
++#define KEY_ESC                    0x1B
++/* End of Unicode range:     0x0010FFFF */
++#define KEY_LEFT             0x00210000
++#define KEY_RIGHT            0x00220000
++#define KEY_UP               0x00230000
++#define KEY_DOWN             0x00240000
++#define KEY_F1               0x00270000
++#define KEY_F2               0x00280000
++#define KEY_F3               0x00290000
++#define KEY_F4               0x002A0000
++#define KEY_F5               0x002B0000
++#define KEY_F6               0x002C0000
++#define KEY_F7               0x002D0000
++#define KEY_F8               0x002E0000
++#define KEY_F9               0x002F0000
++#define KEY_F10              0x00300000
++#define KEY_F11              0x00310000
++#define KEY_F12              0x00320000
++#define KEY_HOME             0x00330000
++#define KEY_END              0x00340000
++#define KEY_INSERT           0x00350000
++#define KEY_DELETE           0x00360000
++#define KEY_MENU             0x00370000
++#define KEY_PAGEUP           0x00390000
++#define KEY_PAGEDOWN         0x003A0000
++#define KEY_PRINT            0x003B0000
++#define KEY_PAUSE            0x003D0000
++
++#define KEY_BROWSER_BACK     0x003F0000
++#define KEY_BROWSER_FORWARD  0x00400000
++#define KEY_BROWSER_REFRESH  0x00410000
++#define KEY_BROWSER_STOP     0x00420000
++#define KEY_BROWSER_SEARCH   0x00430000
++#define KEY_BROWSER_FAVORITES 0x00440000
++#define KEY_BROWSER_HOME     0x00450000
++#define KEY_VOLUME_MUTE      0x00460000
++#define KEY_VOLUME_DOWN      0x00470000
++#define KEY_VOLUME_UP        0x00480000
++#define KEY_MEDIA_NEXT_TRACK 0x00490000
++#define KEY_MEDIA_PREV_TRACK 0x004A0000
++#define KEY_MEDIA_STOP       0x004B0000
++#define KEY_MEDIA_PLAY_PAUSE 0x004C0000
++#define KEY_MEDIA_RECORD     0x004D0000
++#define KEY_MEDIA_REWIND     0x004E0000
++#define KEY_MEDIA_FORWARD    0x004F0000
++#define KEY_MEDIA_REPEAT     0x00500000
++#define KEY_MEDIA_SHUFFLE    0x00510000
++#define KEY_MEDIA_SUBTITLE   0x00520000
++#define KEY_MEDIA_AUDIO      0x00530000
++#define KEY_MEDIA_ANGLE      0x00540000
++#define KEY_MEDIA_TIME       0x00550000
++#define KEY_MEDIA_FRAME_PREV 0x00560000
++#define KEY_MEDIA_FRAME_NEXT 0x00570000
++#define KEY_MEDIA_SELECT     0x00580000
++#define KEY_MEDIA_VIEW       0x00590000
++#define KEY_MEDIA_MENU       0x005A0000
++#define KEY_ZOOM_IN          0x00600000
++#define KEY_ZOOM_OUT         0x00610000
++#define KEY_BRIGHTNESS_UP    0x00620000
++#define KEY_BRIGHTNESS_DOWN  0x00630000
++
++#define KEY_MOUSEWHEELUP     0x00F00000
++#define KEY_MOUSEWHEELDOWN   0x00F10000
++#define KEY_MOUSEWHEELLEFT   0x00F20000
++#define KEY_MOUSEWHEELRIGHT  0x00F30000
++
++VLC_API char *vlc_keycode2str(uint_fast32_t i_key, bool locale) VLC_USED;
++VLC_API uint_fast32_t vlc_str2keycode(const char *str) VLC_USED;
++
++typedef enum vlc_action_id {
++    ACTIONID_NONE = 0,
++    ACTIONID_QUIT,
++    ACTIONID_PLAY_PAUSE,
++    ACTIONID_PLAY,
++    ACTIONID_PAUSE,
++    ACTIONID_STOP,
++    ACTIONID_PREV,
++    ACTIONID_NEXT,
++    ACTIONID_SLOWER,
++    ACTIONID_FASTER,
++    ACTIONID_TOGGLE_FULLSCREEN,
++    ACTIONID_VOL_UP,
++    ACTIONID_VOL_DOWN,
++    ACTIONID_NAV_ACTIVATE,
++    ACTIONID_NAV_UP,
++    ACTIONID_NAV_DOWN,
++    ACTIONID_NAV_LEFT,
++    ACTIONID_NAV_RIGHT,
++    ACTIONID_JUMP_BACKWARD_EXTRASHORT,
++    ACTIONID_JUMP_FORWARD_EXTRASHORT,
++    ACTIONID_JUMP_BACKWARD_SHORT,
++    ACTIONID_JUMP_FORWARD_SHORT,
++    ACTIONID_JUMP_BACKWARD_MEDIUM,
++    ACTIONID_JUMP_FORWARD_MEDIUM,
++    ACTIONID_JUMP_BACKWARD_LONG,
++    ACTIONID_JUMP_FORWARD_LONG,
++    ACTIONID_FRAME_NEXT,
++    ACTIONID_POSITION,
++    ACTIONID_VOL_MUTE,
++/* let ACTIONID_SET_BOOMARK* and ACTIONID_PLAY_BOOKMARK* be contiguous */
++    ACTIONID_SET_BOOKMARK1,
++    ACTIONID_SET_BOOKMARK2,
++    ACTIONID_SET_BOOKMARK3,
++    ACTIONID_SET_BOOKMARK4,
++    ACTIONID_SET_BOOKMARK5,
++    ACTIONID_SET_BOOKMARK6,
++    ACTIONID_SET_BOOKMARK7,
++    ACTIONID_SET_BOOKMARK8,
++    ACTIONID_SET_BOOKMARK9,
++    ACTIONID_SET_BOOKMARK10,
++    ACTIONID_PLAY_BOOKMARK1,
++    ACTIONID_PLAY_BOOKMARK2,
++    ACTIONID_PLAY_BOOKMARK3,
++    ACTIONID_PLAY_BOOKMARK4,
++    ACTIONID_PLAY_BOOKMARK5,
++    ACTIONID_PLAY_BOOKMARK6,
++    ACTIONID_PLAY_BOOKMARK7,
++    ACTIONID_PLAY_BOOKMARK8,
++    ACTIONID_PLAY_BOOKMARK9,
++    ACTIONID_PLAY_BOOKMARK10,
++    /* end of contiguous zone */
++    ACTIONID_PLAY_CLEAR,
++    ACTIONID_SUBDELAY_UP,
++    ACTIONID_SUBDELAY_DOWN,
++    ACTIONID_SUBSYNC_MARKAUDIO,
++    ACTIONID_SUBSYNC_MARKSUB,
++    ACTIONID_SUBSYNC_APPLY,
++    ACTIONID_SUBSYNC_RESET,
++    ACTIONID_SUBPOS_UP,
++    ACTIONID_SUBPOS_DOWN,
++    ACTIONID_AUDIO_TRACK,
++    ACTIONID_SUBTITLE_REVERSE_TRACK,
++    ACTIONID_SUBTITLE_TRACK,
++    ACTIONID_SUBTITLE_TOGGLE,
++    ACTIONID_SUBTITLE_TEXT_SCALE_NORMAL,
++    ACTIONID_SUBTITLE_TEXT_SCALE_UP,
++    ACTIONID_SUBTITLE_TEXT_SCALE_DOWN,
++    ACTIONID_INTF_TOGGLE_FSC,
++    ACTIONID_INTF_HIDE,
++    ACTIONID_INTF_BOSS,
++    /* chapter and title navigation */
++    ACTIONID_TITLE_PREV,
++    ACTIONID_TITLE_NEXT,
++    ACTIONID_CHAPTER_PREV,
++    ACTIONID_CHAPTER_NEXT,
++    /* end of chapter and title navigation */
++    ACTIONID_AUDIODELAY_UP,
++    ACTIONID_AUDIODELAY_DOWN,
++    ACTIONID_SNAPSHOT,
++    ACTIONID_RECORD,
++    ACTIONID_DISC_MENU,
++    ACTIONID_ASPECT_RATIO,
++    ACTIONID_CROP,
++    ACTIONID_DEINTERLACE,
++    ACTIONID_DEINTERLACE_MODE,
++    ACTIONID_ZOOM,
++    ACTIONID_UNZOOM,
++    ACTIONID_CROP_TOP,
++    ACTIONID_UNCROP_TOP,
++    ACTIONID_CROP_LEFT,
++    ACTIONID_UNCROP_LEFT,
++    ACTIONID_CROP_BOTTOM,
++    ACTIONID_UNCROP_BOTTOM,
++    ACTIONID_CROP_RIGHT,
++    ACTIONID_UNCROP_RIGHT,
++    ACTIONID_RANDOM,
++    ACTIONID_LOOP,
++    ACTIONID_WALLPAPER,
++    ACTIONID_LEAVE_FULLSCREEN,
++    /* Zoom */
++    ACTIONID_ZOOM_QUARTER,
++    ACTIONID_ZOOM_HALF,
++    ACTIONID_ZOOM_ORIGINAL,
++    ACTIONID_ZOOM_DOUBLE,
++    /* Cycle Through Audio Devices */
++    ACTIONID_AUDIODEVICE_CYCLE,
++    /* scaling */
++    ACTIONID_TOGGLE_AUTOSCALE,
++    ACTIONID_SCALE_UP,
++    ACTIONID_SCALE_DOWN,
++    /* */
++    ACTIONID_RATE_NORMAL,
++    ACTIONID_RATE_SLOWER_FINE,
++    ACTIONID_RATE_FASTER_FINE,
++    /* Cycle Through Program Service IDs */
++    ACTIONID_PROGRAM_SID_NEXT,
++    ACTIONID_PROGRAM_SID_PREV,
++    ACTIONID_INTF_POPUP_MENU,
++    /* Viewpoint */
++    ACTIONID_VIEWPOINT_FOV_IN,
++    ACTIONID_VIEWPOINT_FOV_OUT,
++    ACTIONID_VIEWPOINT_ROLL_CLOCK,
++    ACTIONID_VIEWPOINT_ROLL_ANTICLOCK,
++    /* Combo Actions */
++    ACTIONID_COMBO_VOL_FOV_UP,
++    ACTIONID_COMBO_VOL_FOV_DOWN,
++
++} vlc_action_id_t;
++
++/**
++ * Get the action ID from an action key name
++ * \return the action ID or ACTIONID_NONE on error.
++ */
++VLC_API vlc_action_id_t
++vlc_actions_get_id(const char *psz_key_name);
++
++/**
++ * Get keycodes from a action key name and vlc configuration
++ * \return The number of keycodes for this action, or 0 in case of an error.
++ * The list needs to be released with free()
++ */
++VLC_API size_t
++vlc_actions_get_keycodes(vlc_object_t *p_obj, const char *psz_key_name,
++                        bool b_global, uint_fast32_t **pp_keycodes );
++#define vlc_actions_get_keycodes(a, b, c, d) vlc_actions_get_keycodes(VLC_OBJECT(a), b, c, d)
++
++/**
++ * Get a list a key names
++ * \return A NULL terminated list of const char *
++ */
++VLC_API const char* const*
++vlc_actions_get_key_names(vlc_object_t *p_obj);
++#define vlc_actions_get_key_names(x) vlc_actions_get_key_names(VLC_OBJECT(x))
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_addons.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_addons.h
+new file mode 100644
+index 0000000..23cb134
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_addons.h
+@@ -0,0 +1,227 @@
++/*****************************************************************************
++ * vlc_addons.h : addons handling and describing
++ *****************************************************************************
++ * Copyright (C) 2013 VideoLAN and authors
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_ADDONS_H
++#define VLC_ADDONS_H 1
++
++#include <vlc_arrays.h>
++#include <vlc_events.h>
++
++# ifdef __cplusplus
++extern "C" {
++# endif
++
++typedef enum addon_type_t
++{
++    ADDON_UNKNOWN = 0,
++    ADDON_EXTENSION,
++    ADDON_PLAYLIST_PARSER,
++    ADDON_SERVICE_DISCOVERY,
++    ADDON_SKIN2,
++    ADDON_PLUGIN,
++    ADDON_INTERFACE,
++    ADDON_META,
++    ADDON_OTHER
++} addon_type_t;
++
++typedef enum addon_state_t
++{
++    ADDON_NOTINSTALLED = 0,
++    ADDON_INSTALLING,
++    ADDON_INSTALLED,
++    ADDON_UNINSTALLING
++} addon_state_t;
++
++typedef enum addon_flags_t
++{
++    ADDON_BROKEN     = 1, /* Have install inconsistency */
++    ADDON_MANAGEABLE = 1 << 1, /* Have manifest, can install or uninstall files */
++    ADDON_UPDATABLE  = 1 << 2,
++} addon_flags_t;
++
++#define ADDON_MAX_SCORE (5 * 100)
++#define ADDON_UUID_SIZE 16
++#define ADDON_UUID_PSZ_SIZE (ADDON_UUID_SIZE * 2 + 4)
++typedef uint8_t addon_uuid_t[ADDON_UUID_SIZE];
++
++typedef struct addon_file_t
++{
++    addon_type_t e_filetype;
++    char *psz_download_uri;
++    char *psz_filename;
++} addon_file_t;
++
++struct addon_entry_t
++{
++    vlc_mutex_t lock;
++
++    addon_type_t e_type;
++    addon_state_t e_state;
++    addon_flags_t e_flags;
++
++    /* data describing addon */
++    addon_uuid_t uuid;
++    char *psz_name;
++    char *psz_summary;
++    char *psz_description;
++    char *psz_author;
++    char *psz_source_uri; /* webpage, ... */
++    char *psz_image_uri;
++    char *psz_image_data; /* base64, png */
++    char *psz_version;
++
++    /* stats */
++    long int i_downloads;
++    int i_score; /* score 0..5 in hundredth */
++
++    /* Lister */
++    char *psz_source_module;
++
++    /* files list */
++    char *psz_archive_uri; /* Archive */
++    DECL_ARRAY(addon_file_t *) files;
++
++    /* custom data storage (if needed by module/source) */
++    void * p_custom;
++};
++
++typedef struct addons_finder_t addons_finder_t;
++typedef struct addons_finder_sys_t addons_finder_sys_t;
++struct addons_finder_t
++{
++    VLC_COMMON_MEMBERS
++
++    int ( * pf_find )( addons_finder_t * );
++    int ( * pf_retrieve )( addons_finder_t *, addon_entry_t * );
++    DECL_ARRAY( addon_entry_t * ) entries;
++    char *psz_uri;
++
++    addons_finder_sys_t *p_sys;
++};
++
++typedef struct addons_storage_t addons_storage_t;
++typedef struct addons_storage_sys_t addons_storage_sys_t;
++struct addons_storage_t
++{
++    VLC_COMMON_MEMBERS
++
++    int ( * pf_install )( addons_storage_t *, addon_entry_t * );
++    int ( * pf_remove )( addons_storage_t *, addon_entry_t * );
++    int ( * pf_catalog ) ( addons_storage_t *, addon_entry_t **, int );
++
++    addons_storage_sys_t *p_sys;
++};
++
++typedef struct addons_manager_t addons_manager_t;
++
++struct addons_manager_owner
++{
++    void *sys;
++    void (*addon_found)(struct addons_manager_t *, struct addon_entry_t *);
++    void (*discovery_ended)(struct addons_manager_t *);
++    void (*addon_changed)(struct addons_manager_t *, struct addon_entry_t *);
++};
++
++typedef struct addons_manager_private_t addons_manager_private_t;
++struct addons_manager_t
++{
++    struct addons_manager_owner owner;
++    addons_manager_private_t *p_priv;
++};
++
++/**
++ *  addon entry lifecycle
++ */
++VLC_API addon_entry_t *addon_entry_New( void );
++VLC_API addon_entry_t *addon_entry_Hold(addon_entry_t *);
++VLC_API void addon_entry_Release(addon_entry_t *);
++
++/**
++ * addons manager lifecycle
++ */
++VLC_API addons_manager_t *addons_manager_New( vlc_object_t *,
++    const struct addons_manager_owner * );
++VLC_API void addons_manager_Delete( addons_manager_t * );
++
++/**
++ * Charge currently installed, usable and manageable addons
++ * (default "addons storage" module)
++ */
++VLC_API int addons_manager_LoadCatalog( addons_manager_t * );
++
++/**
++ * Gather addons info from repository (default "addons finder" module)
++ * If psz_uri is not NULL, only gather info from the pointed package.
++ */
++VLC_API void addons_manager_Gather( addons_manager_t *, const char *psz_uri );
++
++/**
++ * Install or Remove the addon identified by its uuid
++ */
++VLC_API int addons_manager_Install( addons_manager_t *p_manager, const addon_uuid_t uuid );
++VLC_API int addons_manager_Remove( addons_manager_t *p_manager, const addon_uuid_t uuid );
++
++/**
++ * String uuid to binary uuid helpers
++ */
++static inline bool addons_uuid_read( const char *psz_uuid, addon_uuid_t *p_uuid )
++{
++    if ( !psz_uuid ) return false;
++    if ( strlen( psz_uuid ) < ADDON_UUID_PSZ_SIZE ) return false;
++
++    int i = 0, j = 0;
++    while ( i<ADDON_UUID_PSZ_SIZE )
++    {
++        if ( *( psz_uuid + i ) == '-' )
++            i++;
++        int v;
++        sscanf( psz_uuid + i, "%02x", &v );
++        (*p_uuid)[j++] = v & 0xFF;
++        i+=2;
++    }
++
++    return true;
++}
++
++static inline char * addons_uuid_to_psz( const addon_uuid_t * p_uuid )
++{
++    char *psz = (char*) calloc( ADDON_UUID_PSZ_SIZE + 1 , sizeof(char) );
++    if ( psz )
++    {
++        int i=0;
++        char *p = psz;
++        while ( i < ADDON_UUID_SIZE )
++        {
++            if ( i == 4 || i== 7 || i== 9 || i== 11 )
++                *p++ = '-';
++            int v = 0xFF & (*p_uuid)[i];
++            sprintf( p, "%02x", v );
++            p += 2;
++            i++;
++        }
++    }
++    return psz;
++}
++
++# ifdef __cplusplus
++}
++# endif
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_aout.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_aout.h
+new file mode 100644
+index 0000000..62338ba
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_aout.h
+@@ -0,0 +1,409 @@
++/*****************************************************************************
++ * vlc_aout.h : audio output interface
++ *****************************************************************************
++ * Copyright (C) 2002-2011 VLC authors and VideoLAN
++ *
++ * Authors: Christophe Massiot <massiot@via.ecp.fr>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_AOUT_H
++#define VLC_AOUT_H 1
++
++#include <assert.h>
++
++/**
++ * \defgroup audio_output Audio output
++ * \ingroup output
++ * @{
++ * \file
++ * Audio output modules interface
++ */
++
++/* Buffers which arrive in advance of more than AOUT_MAX_ADVANCE_TIME
++ * will be considered as bogus and be trashed */
++#define AOUT_MAX_ADVANCE_TIME           (AOUT_MAX_PREPARE_TIME + CLOCK_FREQ)
++
++/* Buffers which arrive in advance of more than AOUT_MAX_PREPARE_TIME
++ * will cause the calling thread to sleep */
++#define AOUT_MAX_PREPARE_TIME           (2 * CLOCK_FREQ)
++
++/* Buffers which arrive after pts - AOUT_MIN_PREPARE_TIME will be trashed
++ * to avoid too heavy resampling */
++#define AOUT_MIN_PREPARE_TIME           AOUT_MAX_PTS_ADVANCE
++
++/* Tolerance values from EBU Recommendation 37 */
++/** Maximum advance of actual audio playback time to coded PTS,
++ * above which downsampling will be performed */
++#define AOUT_MAX_PTS_ADVANCE            (CLOCK_FREQ / 25)
++
++/** Maximum delay of actual audio playback time from coded PTS,
++ * above which upsampling will be performed */
++#define AOUT_MAX_PTS_DELAY              (3 * CLOCK_FREQ / 50)
++
++/* Max acceptable resampling (in %) */
++#define AOUT_MAX_RESAMPLING             10
++
++#include "vlc_es.h"
++
++#define AOUT_FMTS_IDENTICAL( p_first, p_second ) (                          \
++    ((p_first)->i_format == (p_second)->i_format)                           \
++      && AOUT_FMTS_SIMILAR(p_first, p_second) )
++
++/* Check if i_rate == i_rate and i_channels == i_channels */
++#define AOUT_FMTS_SIMILAR( p_first, p_second ) (                            \
++    ((p_first)->i_rate == (p_second)->i_rate)                               \
++      && ((p_first)->channel_type == (p_second)->channel_type)            \
++      && ((p_first)->i_physical_channels == (p_second)->i_physical_channels)\
++      && ((p_first)->i_chan_mode == (p_second)->i_chan_mode) )
++
++#define AOUT_FMT_LINEAR( p_format ) \
++    (aout_BitsPerSample((p_format)->i_format) != 0)
++
++#define VLC_CODEC_SPDIFL VLC_FOURCC('s','p','d','i')
++#define VLC_CODEC_SPDIFB VLC_FOURCC('s','p','d','b')
++
++#define AOUT_FMT_SPDIF( p_format ) \
++    ( ((p_format)->i_format == VLC_CODEC_SPDIFL)       \
++       || ((p_format)->i_format == VLC_CODEC_SPDIFB)   \
++       || ((p_format)->i_format == VLC_CODEC_A52)      \
++       || ((p_format)->i_format == VLC_CODEC_DTS) )
++
++#define AOUT_FMT_HDMI( p_format )                   \
++    ( (p_format)->i_format == VLC_CODEC_EAC3        \
++    ||(p_format)->i_format == VLC_CODEC_TRUEHD      \
++    ||(p_format)->i_format == VLC_CODEC_MLP         \
++    )
++
++/* Values used for the audio-channels object variable */
++#define AOUT_VAR_CHAN_UNSET         0 /* must be zero */
++#define AOUT_VAR_CHAN_STEREO        1
++#define AOUT_VAR_CHAN_RSTEREO       2
++#define AOUT_VAR_CHAN_LEFT          3
++#define AOUT_VAR_CHAN_RIGHT         4
++#define AOUT_VAR_CHAN_DOLBYS        5
++#define AOUT_VAR_CHAN_HEADPHONES    6
++#define AOUT_VAR_CHAN_MONO          7
++
++/*****************************************************************************
++ * Main audio output structures
++ *****************************************************************************/
++
++/* Size of a frame for S/PDIF output. */
++#define AOUT_SPDIF_SIZE 6144
++
++/* Number of samples in an A/52 frame. */
++#define A52_FRAME_NB 1536
++
++/* FIXME to remove once aout.h is cleaned a bit more */
++#include <vlc_block.h>
++
++/** Audio output object */
++struct audio_output
++{
++    VLC_COMMON_MEMBERS
++
++    struct aout_sys_t *sys; /**< Private data for callbacks */
++
++    int (*start)(audio_output_t *, audio_sample_format_t *fmt);
++    /**< Starts a new stream (mandatory, cannot be NULL).
++      * \param fmt input stream sample format upon entry,
++      *            output stream sample format upon return [IN/OUT]
++      * \return VLC_SUCCESS on success, non-zero on failure
++      * \note No other stream may be already started when called.
++      */
++    void (*stop)(audio_output_t *);
++    /**< Stops the existing stream (optional, may be NULL).
++      * \note A stream must have been started when called.
++      */
++    int (*time_get)(audio_output_t *, mtime_t *delay);
++    /**< Estimates playback buffer latency (optional, may be NULL).
++      * \param delay pointer to the delay until the next sample to be written
++      *              to the playback buffer is rendered [OUT]
++      * \return 0 on success, non-zero on failure or lack of data
++      * \note A stream must have been started when called.
++      */
++    void (*play)(audio_output_t *, block_t *);
++    /**< Queues a block of samples for playback (mandatory, cannot be NULL).
++      * \note A stream must have been started when called.
++      */
++    void (*pause)( audio_output_t *, bool pause, mtime_t date);
++    /**< Pauses or resumes playback (optional, may be NULL).
++      * \param pause pause if true, resume from pause if false
++      * \param date timestamp when the pause or resume was requested
++      * \note A stream must have been started when called.
++      */
++    void (*flush)( audio_output_t *, bool wait);
++    /**< Flushes or drains the playback buffers (mandatory, cannot be NULL).
++      * \param wait true to wait for playback of pending buffers (drain),
++      *             false to discard pending buffers (flush)
++      * \note A stream must have been started when called.
++      */
++    int (*volume_set)(audio_output_t *, float volume);
++    /**< Changes playback volume (optional, may be NULL).
++      * \param volume requested volume (0. = mute, 1. = nominal)
++      * \note The volume is always a positive number.
++      * \warning A stream may or may not have been started when called.
++      */
++    int (*mute_set)(audio_output_t *, bool mute);
++    /**< Changes muting (optinal, may be NULL).
++      * \param mute true to mute, false to unmute
++      * \warning A stream may or may not have been started when called.
++      */
++    int (*device_select)(audio_output_t *, const char *id);
++    /**< Selects an audio output device (optional, may be NULL).
++      * \param id nul-terminated device unique identifier.
++      * \return 0 on success, non-zero on failure.
++      * \warning A stream may or may not have been started when called.
++      */
++
++    struct {
++        bool headphones; /**< Default to false, set it to true if the current
++                              sink is using headphones */
++    } current_sink_info;
++    /**< Current sink informations set by the module from the start() function */
++
++    struct {
++        void (*volume_report)(audio_output_t *, float);
++        void (*mute_report)(audio_output_t *, bool);
++        void (*policy_report)(audio_output_t *, bool);
++        void (*device_report)(audio_output_t *, const char *);
++        void (*hotplug_report)(audio_output_t *, const char *, const char *);
++        int (*gain_request)(audio_output_t *, float);
++        void (*restart_request)(audio_output_t *, unsigned);
++    } event;
++};
++
++typedef enum
++{
++    AOUT_CHANIDX_DISABLE = -1,
++    AOUT_CHANIDX_LEFT,
++    AOUT_CHANIDX_RIGHT,
++    AOUT_CHANIDX_MIDDLELEFT,
++    AOUT_CHANIDX_MIDDLERIGHT,
++    AOUT_CHANIDX_REARLEFT,
++    AOUT_CHANIDX_REARRIGHT,
++    AOUT_CHANIDX_REARCENTER,
++    AOUT_CHANIDX_CENTER,
++    AOUT_CHANIDX_LFE,
++    AOUT_CHANIDX_MAX
++} vlc_chan_order_idx_t;
++
++static_assert(AOUT_CHANIDX_MAX == AOUT_CHAN_MAX, "channel count mismatch");
++
++#define AOUT_CHAN_REMAP_INIT { \
++    AOUT_CHANIDX_LEFT,  \
++    AOUT_CHANIDX_RIGHT, \
++    AOUT_CHANIDX_MIDDLELEFT, \
++    AOUT_CHANIDX_MIDDLERIGHT, \
++    AOUT_CHANIDX_REARLEFT, \
++    AOUT_CHANIDX_REARRIGHT, \
++    AOUT_CHANIDX_REARCENTER, \
++    AOUT_CHANIDX_CENTER, \
++    AOUT_CHANIDX_LFE, \
++}
++
++/**
++ * It describes the audio channel order VLC expect.
++ */
++static const uint32_t pi_vlc_chan_order_wg4[] =
++{
++    AOUT_CHAN_LEFT, AOUT_CHAN_RIGHT,
++    AOUT_CHAN_MIDDLELEFT, AOUT_CHAN_MIDDLERIGHT,
++    AOUT_CHAN_REARLEFT, AOUT_CHAN_REARRIGHT, AOUT_CHAN_REARCENTER,
++    AOUT_CHAN_CENTER, AOUT_CHAN_LFE, 0
++};
++
++#define AOUT_RESTART_FILTERS        0x1
++#define AOUT_RESTART_OUTPUT         (AOUT_RESTART_FILTERS|0x2)
++#define AOUT_RESTART_STEREOMODE     (AOUT_RESTART_OUTPUT|0x4)
++
++/*****************************************************************************
++ * Prototypes
++ *****************************************************************************/
++
++/**
++ * This function computes the reordering needed to go from pi_chan_order_in to
++ * pi_chan_order_out.
++ * If pi_chan_order_in or pi_chan_order_out is NULL, it will assume that vlc
++ * internal (WG4) order is requested.
++ */
++VLC_API unsigned aout_CheckChannelReorder( const uint32_t *, const uint32_t *,
++                                           uint32_t mask, uint8_t *table );
++VLC_API void aout_ChannelReorder(void *, size_t, uint8_t, const uint8_t *, vlc_fourcc_t);
++
++VLC_API void aout_Interleave(void *dst, const void *const *planes,
++                             unsigned samples, unsigned channels,
++                             vlc_fourcc_t fourcc);
++VLC_API void aout_Deinterleave(void *dst, const void *src, unsigned samples,
++                             unsigned channels, vlc_fourcc_t fourcc);
++
++/**
++ * This function will compute the extraction parameter into pi_selection to go
++ * from i_channels with their type given by pi_order_src[] into the order
++ * describe by pi_order_dst.
++ * It will also set :
++ * - *pi_channels as the number of channels that will be extracted which is
++ * lower (in case of non understood channels type) or equal to i_channels.
++ * - the layout of the channels (*pi_layout).
++ *
++ * It will return true if channel extraction is really needed, in which case
++ * aout_ChannelExtract must be used
++ *
++ * XXX It must be used when the source may have channel type not understood
++ * by VLC. In this case the channel type pi_order_src[] must be set to 0.
++ * XXX It must also be used if multiple channels have the same type.
++ */
++VLC_API bool aout_CheckChannelExtraction( int *pi_selection, uint32_t *pi_layout, int *pi_channels, const uint32_t pi_order_dst[AOUT_CHAN_MAX], const uint32_t *pi_order_src, int i_channels );
++
++/**
++ * Do the actual channels extraction using the parameters created by
++ * aout_CheckChannelExtraction.
++ *
++ * XXX this function does not work in place (p_dst and p_src must not overlap).
++ * XXX Only 8, 16, 32, 64 bits per sample are supported.
++ */
++VLC_API void aout_ChannelExtract( void *p_dst, int i_dst_channels, const void *p_src, int i_src_channels, int i_sample_count, const int *pi_selection, int i_bits_per_sample );
++
++/* */
++static inline unsigned aout_FormatNbChannels(const audio_sample_format_t *fmt)
++{
++    return popcount(fmt->i_physical_channels);
++}
++
++VLC_API unsigned int aout_BitsPerSample( vlc_fourcc_t i_format ) VLC_USED;
++VLC_API void aout_FormatPrepare( audio_sample_format_t * p_format );
++VLC_API void aout_FormatPrint(vlc_object_t *, const char *,
++                              const audio_sample_format_t *);
++#define aout_FormatPrint(o, t, f) aout_FormatPrint(VLC_OBJECT(o), t, f)
++VLC_API const char * aout_FormatPrintChannels( const audio_sample_format_t * ) VLC_USED;
++
++#define AOUT_VOLUME_DEFAULT             256
++#define AOUT_VOLUME_MAX                 512
++
++VLC_API float aout_VolumeGet (audio_output_t *);
++VLC_API int aout_VolumeSet (audio_output_t *, float);
++VLC_API int aout_VolumeUpdate (audio_output_t *, int, float *);
++VLC_API int aout_MuteGet (audio_output_t *);
++VLC_API int aout_MuteSet (audio_output_t *, bool);
++VLC_API char *aout_DeviceGet (audio_output_t *);
++VLC_API int aout_DeviceSet (audio_output_t *, const char *);
++VLC_API int aout_DevicesList (audio_output_t *, char ***, char ***);
++
++/**
++ * Report change of configured audio volume to the core and UI.
++ */
++static inline void aout_VolumeReport(audio_output_t *aout, float volume)
++{
++    aout->event.volume_report(aout, volume);
++}
++
++/**
++ * Report change of muted flag to the core and UI.
++ */
++static inline void aout_MuteReport(audio_output_t *aout, bool mute)
++{
++    aout->event.mute_report(aout, mute);
++}
++
++/**
++ * Report audio policy status.
++ * \param cork true to request a cork, false to undo any pending cork.
++ */
++static inline void aout_PolicyReport(audio_output_t *aout, bool cork)
++{
++    aout->event.policy_report(aout, cork);
++}
++
++/**
++ * Report change of output device.
++ */
++static inline void aout_DeviceReport(audio_output_t *aout, const char *id)
++{
++    aout->event.device_report(aout, id);
++}
++
++/**
++ * Report a device hot-plug event.
++ * @param id device ID
++ * @param name human-readable device name (NULL for hot unplug)
++ */
++static inline void aout_HotplugReport(audio_output_t *aout,
++                                      const char *id, const char *name)
++{
++    aout->event.hotplug_report(aout, id, name);
++}
++
++/**
++ * Request a change of software audio amplification.
++ * \param gain linear amplitude gain (must be positive)
++ * \warning Values in excess 1.0 may cause overflow and distorsion.
++ */
++static inline int aout_GainRequest(audio_output_t *aout, float gain)
++{
++    return aout->event.gain_request(aout, gain);
++}
++
++static inline void aout_RestartRequest(audio_output_t *aout, unsigned mode)
++{
++    aout->event.restart_request(aout, mode);
++}
++
++/* Audio output filters */
++
++typedef struct
++{
++    /**
++     * If the remap order differs from the WG4 order, a remap audio filter will
++     * be inserted to remap channels according to this array.
++     */
++    int remap[AOUT_CHANIDX_MAX];
++    /**
++     * If true, a filter will be inserted to add a headphones effect (like a
++     * binauralizer audio filter).
++     */
++    bool headphones;
++} aout_filters_cfg_t;
++
++#define AOUT_FILTERS_CFG_INIT (aout_filters_cfg_t) \
++    { .remap = AOUT_CHAN_REMAP_INIT, \
++      .headphones = false, \
++    };
++
++typedef struct aout_filters aout_filters_t;
++typedef struct aout_request_vout aout_request_vout_t;
++
++VLC_API aout_filters_t *aout_FiltersNew(vlc_object_t *,
++                                        const audio_sample_format_t *,
++                                        const audio_sample_format_t *,
++                                        const aout_request_vout_t *,
++                                        const aout_filters_cfg_t *cfg) VLC_USED;
++#define aout_FiltersNew(o,inf,outf,rv,remap) \
++        aout_FiltersNew(VLC_OBJECT(o),inf,outf,rv,remap)
++VLC_API void aout_FiltersDelete(vlc_object_t *, aout_filters_t *);
++#define aout_FiltersDelete(o,f) \
++        aout_FiltersDelete(VLC_OBJECT(o),f)
++VLC_API bool aout_FiltersAdjustResampling(aout_filters_t *, int);
++VLC_API block_t *aout_FiltersPlay(aout_filters_t *, block_t *, int rate);
++VLC_API block_t *aout_FiltersDrain(aout_filters_t *);
++VLC_API void     aout_FiltersFlush(aout_filters_t *);
++VLC_API void     aout_FiltersChangeViewpoint(aout_filters_t *, const vlc_viewpoint_t *vp);
++
++VLC_API vout_thread_t * aout_filter_RequestVout( filter_t *, vout_thread_t *p_vout, const video_format_t *p_fmt );
++
++/** @} */
++
++#endif /* VLC_AOUT_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_aout_volume.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_aout_volume.h
+new file mode 100644
+index 0000000..7a61af5
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_aout_volume.h
+@@ -0,0 +1,59 @@
++/*****************************************************************************
++ * vlc_aout_volume.h: audio volume module
++ *****************************************************************************
++ * Copyright (C) 2002-2009 VLC authors and VideoLAN
++ * $Id: df85b8fd14e00454e88c08061e3059fa67927dab $
++ *
++ * Authors: Christophe Massiot <massiot@via.ecp.fr>
++ *          Laurent Aimar <fenrir _AT_ videolan _DOT_ org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_AOUT_MIXER_H
++#define VLC_AOUT_MIXER_H 1
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++/**
++ * \defgroup audio_volume Audio output volume
++ * \ingroup audio_output
++ * @{
++ * \file
++ * This file defines functions, structures and macros for audio output mixer object
++ */
++
++typedef struct audio_volume audio_volume_t;
++
++/**
++ * Audio volume
++ */
++struct audio_volume
++{
++    VLC_COMMON_MEMBERS
++
++    vlc_fourcc_t format; /**< Audio samples format */
++    void (*amplify)(audio_volume_t *, block_t *, float); /**< Amplifier */
++};
++
++/** @} */
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_arrays.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_arrays.h
+new file mode 100644
+index 0000000..832b95a
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_arrays.h
+@@ -0,0 +1,627 @@
++/*****************************************************************************
++ * vlc_arrays.h : Arrays and data structures handling
++ *****************************************************************************
++ * Copyright (C) 1999-2004 VLC authors and VideoLAN
++ * $Id: 39b69952ffce040330da239f52778c3e82024bc4 $
++ *
++ * Authors: Samuel Hocevar <sam@zoy.org>
++ *          Clément Stenac <zorglub@videolan.org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_ARRAYS_H_
++#define VLC_ARRAYS_H_
++
++/**
++ * \file
++ * This file defines functions, structures and macros for handling arrays in vlc
++ */
++
++/* realloc() that never fails *if* downsizing */
++static inline void *realloc_down( void *ptr, size_t size )
++{
++    void *ret = realloc( ptr, size );
++    return ret ? ret : ptr;
++}
++
++#define TAB_INIT( count, tab )                  \
++  do {                                          \
++    (count) = 0;                                \
++    (tab) = NULL;                               \
++  } while(0)
++
++#define TAB_CLEAN( count, tab )                 \
++  do {                                          \
++    free( tab );                                \
++    (count)= 0;                                 \
++    (tab)= NULL;                                \
++  } while(0)
++
++#define TAB_APPEND_CAST( cast, count, tab, p )             \
++  do {                                          \
++    if( (count) > 0 )                           \
++        (tab) = cast realloc( tab, sizeof( *(tab) ) * ( (count) + 1 ) ); \
++    else                                        \
++        (tab) = cast malloc( sizeof( *(tab) ) );    \
++    if( !(tab) ) abort();                       \
++    (tab)[count] = (p);                         \
++    (count)++;                                  \
++  } while(0)
++
++#define TAB_APPEND( count, tab, p )             \
++    TAB_APPEND_CAST( , count, tab, p )
++
++#define TAB_FIND( count, tab, p, idx )          \
++  do {                                          \
++    for( (idx) = 0; (idx) < (count); (idx)++ )  \
++        if( (tab)[(idx)] == (p) )               \
++            break;                              \
++    if( (idx) >= (count) )                      \
++        (idx) = -1;                             \
++  } while(0)
++
++
++#define TAB_ERASE( count, tab, index )      \
++  do {                                      \
++        if( (count) > 1 )                   \
++            memmove( (tab) + (index),       \
++                     (tab) + (index) + 1,   \
++                     ((count) - (index) - 1 ) * sizeof( *(tab) ) );\
++        (count)--;                          \
++        if( (count) == 0 )                  \
++        {                                   \
++            free( tab );                    \
++            (tab) = NULL;                   \
++        }                                   \
++  } while(0)
++
++#define TAB_REMOVE( count, tab, p )             \
++  do {                                          \
++        int i_index;                            \
++        TAB_FIND( count, tab, p, i_index );     \
++        if( i_index >= 0 )                      \
++            TAB_ERASE( count, tab, i_index );   \
++  } while(0)
++
++#define TAB_INSERT_CAST( cast, count, tab, p, index ) do { \
++    if( (count) > 0 )                           \
++        (tab) = cast realloc( tab, sizeof( *(tab) ) * ( (count) + 1 ) ); \
++    else                                        \
++        (tab) = cast malloc( sizeof( *(tab) ) );       \
++    if( !(tab) ) abort();                       \
++    if( (count) - (index) > 0 )                 \
++        memmove( (tab) + (index) + 1,           \
++                 (tab) + (index),               \
++                 ((count) - (index)) * sizeof( *(tab) ) );\
++    (tab)[(index)] = (p);                       \
++    (count)++;                                  \
++} while(0)
++
++#define TAB_INSERT( count, tab, p, index )      \
++    TAB_INSERT_CAST( , count, tab, p, index )
++
++/**
++ * Binary search in a sorted array. The key must be comparable by < and >
++ * \param entries array of entries
++ * \param count number of entries
++ * \param elem key to check within an entry (like .id, or ->i_id)
++ * \param zetype type of the key
++ * \param key value of the key
++ * \param answer index of answer within the array. -1 if not found
++ */
++#define BSEARCH( entries, count, elem, zetype, key, answer ) \
++   do {  \
++    int low = 0, high = count - 1;   \
++    answer = -1; \
++    while( low <= high ) {\
++        int mid = ((unsigned int)low + (unsigned int)high) >> 1;\
++        zetype mid_val = entries[mid] elem;\
++        if( mid_val < key ) \
++            low = mid + 1; \
++        else if ( mid_val > key ) \
++            high = mid -1;  \
++        else    \
++        {   \
++            answer = mid;  break;   \
++        }\
++    } \
++ } while(0)
++
++
++/************************************************************************
++ * Dynamic arrays with progressive allocation
++ ************************************************************************/
++
++/* Internal functions */
++#define _ARRAY_ALLOC(array, newsize) {                                      \
++    (array).i_alloc = newsize;                                              \
++    (array).p_elems = realloc( (array).p_elems, (array).i_alloc *           \
++                               sizeof(*(array).p_elems) );                  \
++    if( !(array).p_elems ) abort();                                         \
++}
++
++#define _ARRAY_GROW1(array) {                                               \
++    if( (array).i_alloc < 10 )                                              \
++        _ARRAY_ALLOC(array, 10 )                                            \
++    else if( (array).i_alloc == (array).i_size )                            \
++        _ARRAY_ALLOC(array, (int)((array).i_alloc * 1.5) )                    \
++}
++
++#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
++
++/* API */
++#define DECL_ARRAY(type) struct {                                           \
++    int i_alloc;                                                            \
++    int i_size;                                                             \
++    type *p_elems;                                                          \
++}
++
++#define TYPEDEF_ARRAY(type, name) typedef DECL_ARRAY(type) name;
++
++#define ARRAY_INIT(array)                                                   \
++  do {                                                                      \
++    (array).i_alloc = 0;                                                    \
++    (array).i_size = 0;                                                     \
++    (array).p_elems = NULL;                                                 \
++  } while(0)
++
++#define ARRAY_RESET(array)                                                  \
++  do {                                                                      \
++    (array).i_alloc = 0;                                                    \
++    (array).i_size = 0;                                                     \
++    free( (array).p_elems ); (array).p_elems = NULL;                        \
++  } while(0)
++
++#define ARRAY_APPEND(array, elem)                                           \
++  do {                                                                      \
++    _ARRAY_GROW1(array);                                                    \
++    (array).p_elems[(array).i_size] = elem;                                 \
++    (array).i_size++;                                                       \
++  } while(0)
++
++#define ARRAY_INSERT(array,elem,pos)                                        \
++  do {                                                                      \
++    _ARRAY_GROW1(array);                                                    \
++    if( (array).i_size - pos ) {                                            \
++        memmove( (array).p_elems + pos + 1, (array).p_elems + pos,          \
++                 ((array).i_size-pos) * sizeof(*(array).p_elems) );         \
++    }                                                                       \
++    (array).p_elems[pos] = elem;                                            \
++    (array).i_size++;                                                       \
++  } while(0)
++
++#define _ARRAY_SHRINK(array) {                                              \
++    if( (array).i_size > 10 && (array).i_size < (int)((array).i_alloc / 1.5) ) {  \
++        _ARRAY_ALLOC(array, (array).i_size + 5);                            \
++    }                                                                       \
++}
++
++#define ARRAY_REMOVE(array,pos)                                             \
++  do {                                                                      \
++    if( (array).i_size - (pos) - 1 )                                        \
++    {                                                                       \
++        memmove( (array).p_elems + pos, (array).p_elems + pos + 1,          \
++                 ( (array).i_size - pos - 1 ) *sizeof(*(array).p_elems) );  \
++    }                                                                       \
++    (array).i_size--;                                                       \
++    _ARRAY_SHRINK(array);                                                   \
++  } while(0)
++
++#define ARRAY_VAL(array, pos) array.p_elems[pos]
++
++#define ARRAY_BSEARCH(array, elem, zetype, key, answer) \
++    BSEARCH( (array).p_elems, (array).i_size, elem, zetype, key, answer)
++
++#define FOREACH_ARRAY( item, array ) { \
++    int fe_idx; \
++    for( fe_idx = 0 ; fe_idx < (array).i_size ; fe_idx++ ) \
++    { \
++        item = (array).p_elems[fe_idx];
++
++#define FOREACH_END() } }
++
++
++/************************************************************************
++ * Dynamic arrays with progressive allocation (Preferred API)
++ ************************************************************************/
++typedef struct vlc_array_t
++{
++    size_t i_count;
++    void ** pp_elems;
++} vlc_array_t;
++
++static inline void vlc_array_init( vlc_array_t * p_array )
++{
++    p_array->i_count = 0;
++    p_array->pp_elems = NULL;
++}
++
++static inline void vlc_array_clear( vlc_array_t * p_array )
++{
++    free( p_array->pp_elems );
++    vlc_array_init( p_array );
++}
++
++/* Read */
++static inline size_t vlc_array_count( vlc_array_t * p_array )
++{
++    return p_array->i_count;
++}
++
++#ifndef __cplusplus
++# define vlc_array_item_at_index(ar, idx) \
++    _Generic((ar), \
++        const vlc_array_t *: ((ar)->pp_elems[idx]), \
++        vlc_array_t *: ((ar)->pp_elems[idx]))
++#else
++static inline void *vlc_array_item_at_index( vlc_array_t *ar, size_t idx )
++{
++    return ar->pp_elems[idx];
++}
++
++static inline const void *vlc_array_item_at_index( const vlc_array_t *ar,
++                                                   size_t idx )
++{
++    return ar->pp_elems[idx];
++}
++#endif
++
++static inline ssize_t vlc_array_index_of_item( const vlc_array_t *ar,
++                                               const void *elem )
++{
++    for( size_t i = 0; i < ar->i_count; i++ )
++    {
++        if( ar->pp_elems[i] == elem )
++            return i;
++    }
++    return -1;
++}
++
++/* Write */
++static inline int vlc_array_insert( vlc_array_t *ar, void *elem, int idx )
++{
++    void **pp = (void **)realloc( ar->pp_elems,
++                                  sizeof( void * ) * (ar->i_count + 1) );
++    if( unlikely(pp == NULL) )
++        return -1;
++
++    size_t tail = ar->i_count - idx;
++    if( tail > 0 )
++        memmove( pp + idx + 1, pp + idx, sizeof( void * ) * tail );
++
++    pp[idx] = elem;
++    ar->i_count++;
++    ar->pp_elems = pp;
++    return 0;
++}
++
++static inline void vlc_array_insert_or_abort( vlc_array_t *ar, void *elem, int idx )
++{
++    if( vlc_array_insert( ar, elem, idx ) )
++        abort();
++}
++
++static inline int vlc_array_append( vlc_array_t *ar, void *elem )
++{
++    void **pp = (void **)realloc( ar->pp_elems,
++                                  sizeof( void * ) * (ar->i_count + 1) );
++    if( unlikely(pp == NULL) )
++        return -1;
++
++    pp[ar->i_count++] = elem;
++    ar->pp_elems = pp;
++    return 0;
++}
++
++static inline void vlc_array_append_or_abort( vlc_array_t *ar, void *elem )
++{
++    if( vlc_array_append( ar, elem ) != 0 )
++        abort();
++}
++
++static inline void vlc_array_remove( vlc_array_t *ar, size_t idx )
++{
++    void **pp = ar->pp_elems;
++    size_t tail = ar->i_count - idx - 1;
++
++    if( tail > 0 )
++        memmove( pp + idx, pp + idx + 1, sizeof( void * ) * tail );
++
++    ar->i_count--;
++
++    if( ar->i_count > 0 )
++    {
++        pp = (void **)realloc( pp, sizeof( void * ) * ar->i_count );
++        if( likely(pp != NULL) )
++            ar->pp_elems = pp;
++    }
++    else
++    {
++        free( pp );
++        ar->pp_elems = NULL;
++    }
++}
++
++
++/************************************************************************
++ * Dictionaries
++ ************************************************************************/
++
++/* This function is not intended to be crypto-secure, we only want it to be
++ * fast and not suck too much. This one is pretty fast and did 0 collisions
++ * in wenglish's dictionary.
++ */
++static inline uint64_t DictHash( const char *psz_string, int hashsize )
++{
++    uint64_t i_hash = 0;
++    if( psz_string )
++    {
++        while( *psz_string )
++        {
++            i_hash += *psz_string++;
++            i_hash += i_hash << 10;
++            i_hash ^= i_hash >> 8;
++        }
++    }
++    return i_hash % hashsize;
++}
++
++typedef struct vlc_dictionary_entry_t
++{
++    char *   psz_key;
++    void *   p_value;
++    struct vlc_dictionary_entry_t * p_next;
++} vlc_dictionary_entry_t;
++
++typedef struct vlc_dictionary_t
++{
++    int i_size;
++    vlc_dictionary_entry_t ** p_entries;
++} vlc_dictionary_t;
++
++static void * const kVLCDictionaryNotFound = NULL;
++
++static inline void vlc_dictionary_init( vlc_dictionary_t * p_dict, int i_size )
++{
++    p_dict->p_entries = NULL;
++
++    if( i_size > 0 )
++    {
++        p_dict->p_entries = (vlc_dictionary_entry_t **)calloc( i_size, sizeof(*p_dict->p_entries) );
++        if( !p_dict->p_entries )
++            i_size = 0;
++    }
++    p_dict->i_size = i_size;
++}
++
++static inline void vlc_dictionary_clear( vlc_dictionary_t * p_dict,
++                                         void ( * pf_free )( void * p_data, void * p_obj ),
++                                         void * p_obj )
++{
++    if( p_dict->p_entries )
++    {
++        for( int i = 0; i < p_dict->i_size; i++ )
++        {
++            vlc_dictionary_entry_t * p_current, * p_next;
++            p_current = p_dict->p_entries[i];
++            while( p_current )
++            {
++                p_next = p_current->p_next;
++                if( pf_free != NULL )
++                    ( * pf_free )( p_current->p_value, p_obj );
++                free( p_current->psz_key );
++                free( p_current );
++                p_current = p_next;
++            }
++        }
++        free( p_dict->p_entries );
++        p_dict->p_entries = NULL;
++    }
++    p_dict->i_size = 0;
++}
++
++static inline int
++vlc_dictionary_has_key( const vlc_dictionary_t * p_dict, const char * psz_key )
++{
++    if( !p_dict->p_entries )
++        return 0;
++
++    int i_pos = DictHash( psz_key, p_dict->i_size );
++    const vlc_dictionary_entry_t * p_entry = p_dict->p_entries[i_pos];
++    for( ; p_entry != NULL; p_entry = p_entry->p_next )
++    {
++        if( !strcmp( psz_key, p_entry->psz_key ) )
++            break;
++    }
++    return p_entry != NULL;
++}
++
++static inline void *
++vlc_dictionary_value_for_key( const vlc_dictionary_t * p_dict, const char * psz_key )
++{
++    if( !p_dict->p_entries )
++        return kVLCDictionaryNotFound;
++
++    int i_pos = DictHash( psz_key, p_dict->i_size );
++    vlc_dictionary_entry_t * p_entry = p_dict->p_entries[i_pos];
++
++    if( !p_entry )
++        return kVLCDictionaryNotFound;
++
++    /* Make sure we return the right item. (Hash collision) */
++    do {
++        if( !strcmp( psz_key, p_entry->psz_key ) )
++            return p_entry->p_value;
++        p_entry = p_entry->p_next;
++    } while( p_entry );
++
++    return kVLCDictionaryNotFound;
++}
++
++static inline int
++vlc_dictionary_keys_count( const vlc_dictionary_t * p_dict )
++{
++    vlc_dictionary_entry_t * p_entry;
++    int i, count = 0;
++
++    if( !p_dict->p_entries )
++        return 0;
++
++    for( i = 0; i < p_dict->i_size; i++ )
++    {
++        for( p_entry = p_dict->p_entries[i]; p_entry; p_entry = p_entry->p_next ) count++;
++    }
++    return count;
++}
++
++static inline bool
++vlc_dictionary_is_empty( const vlc_dictionary_t * p_dict )
++{
++    if( p_dict->p_entries )
++        for( int i = 0; i < p_dict->i_size; i++ )
++            if( p_dict->p_entries[i] )
++                return false;
++    return true;
++}
++
++static inline char **
++vlc_dictionary_all_keys( const vlc_dictionary_t * p_dict )
++{
++    vlc_dictionary_entry_t * p_entry;
++    char ** ppsz_ret;
++    int i, count = vlc_dictionary_keys_count( p_dict );
++
++    ppsz_ret = (char**)malloc(sizeof(char *) * (count + 1));
++    if( unlikely(!ppsz_ret) )
++        return NULL;
++
++    count = 0;
++    for( i = 0; i < p_dict->i_size; i++ )
++    {
++        for( p_entry = p_dict->p_entries[i]; p_entry; p_entry = p_entry->p_next )
++            ppsz_ret[count++] = strdup( p_entry->psz_key );
++    }
++    ppsz_ret[count] = NULL;
++    return ppsz_ret;
++}
++
++static inline void
++vlc_dictionary_insert_impl_( vlc_dictionary_t * p_dict, const char * psz_key,
++                             void * p_value, bool rebuild )
++{
++    if( !p_dict->p_entries )
++        vlc_dictionary_init( p_dict, 1 );
++
++    int i_pos = DictHash( psz_key, p_dict->i_size );
++    vlc_dictionary_entry_t * p_entry;
++
++    p_entry = (vlc_dictionary_entry_t *)malloc(sizeof(*p_entry));
++    p_entry->psz_key = strdup( psz_key );
++    p_entry->p_value = p_value;
++    p_entry->p_next = p_dict->p_entries[i_pos];
++    p_dict->p_entries[i_pos] = p_entry;
++    if( rebuild )
++    {
++        /* Count how many items there was */
++        int count;
++        for( count = 1; p_entry->p_next; count++ )
++            p_entry = p_entry->p_next;
++        if( count > 3 ) /* XXX: this need tuning */
++        {
++            /* Here it starts to be not good, rebuild a bigger dictionary */
++            struct vlc_dictionary_t new_dict;
++            int i_new_size = ( (p_dict->i_size+2) * 3) / 2; /* XXX: this need tuning */
++            int i;
++            vlc_dictionary_init( &new_dict, i_new_size );
++            for( i = 0; i < p_dict->i_size; i++ )
++            {
++                p_entry = p_dict->p_entries[i];
++                while( p_entry )
++                {
++                    vlc_dictionary_insert_impl_( &new_dict, p_entry->psz_key,
++                                             p_entry->p_value,
++                                             false /* To avoid multiple rebuild loop */);
++                    p_entry = p_entry->p_next;
++                }
++            }
++
++            vlc_dictionary_clear( p_dict, NULL, NULL );
++            p_dict->i_size = new_dict.i_size;
++            p_dict->p_entries = new_dict.p_entries;
++        }
++    }
++}
++
++static inline void
++vlc_dictionary_insert( vlc_dictionary_t * p_dict, const char * psz_key, void * p_value )
++{
++    vlc_dictionary_insert_impl_( p_dict, psz_key, p_value, true );
++}
++
++static inline void
++vlc_dictionary_remove_value_for_key( const vlc_dictionary_t * p_dict, const char * psz_key,
++                                     void ( * pf_free )( void * p_data, void * p_obj ),
++                                     void * p_obj )
++{
++    if( !p_dict->p_entries )
++        return;
++
++    int i_pos = DictHash( psz_key, p_dict->i_size );
++    vlc_dictionary_entry_t * p_entry = p_dict->p_entries[i_pos];
++    vlc_dictionary_entry_t * p_prev;
++
++    if( !p_entry )
++        return; /* Not found, nothing to do */
++
++    /* Hash collision */
++    p_prev = NULL;
++    do {
++        if( !strcmp( psz_key, p_entry->psz_key ) )
++        {
++            if( pf_free != NULL )
++                ( * pf_free )( p_entry->p_value, p_obj );
++            if( !p_prev )
++                p_dict->p_entries[i_pos] = p_entry->p_next;
++            else
++                p_prev->p_next = p_entry->p_next;
++            free( p_entry->psz_key );
++            free( p_entry );
++            return;
++        }
++        p_prev = p_entry;
++        p_entry = p_entry->p_next;
++    } while( p_entry );
++
++    /* No key was found */
++}
++
++#ifdef __cplusplus
++// C++ helpers
++template <typename T>
++void vlc_delete_all( T &container )
++{
++    typename T::iterator it = container.begin();
++    while ( it != container.end() )
++    {
++        delete *it;
++        ++it;
++    }
++    container.clear();
++}
++
++#endif
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_atomic.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_atomic.h
+new file mode 100644
+index 0000000..31d1454
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_atomic.h
+@@ -0,0 +1,224 @@
++/*****************************************************************************
++ * vlc_atomic.h:
++ *****************************************************************************
++ * Copyright (C) 2010 Rémi Denis-Courmont
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_ATOMIC_H
++# define VLC_ATOMIC_H
++
++/**
++ * \file
++ * Atomic operations do not require locking, but they are not very powerful.
++ */
++
++/* Clang older versions support atomics but lacks the stdatomic.h header */
++#if defined(__clang__)
++# if !defined(__has_include) || !__has_include(<stdatomic.h>)
++#  define __STDC_NO_ATOMICS__ 1
++# endif
++#endif
++
++# ifndef __cplusplus
++#  if !defined (__STDC_NO_ATOMICS__)
++/*** Native C11 atomics ***/
++#   include <stdatomic.h>
++
++#  else
++/*** Intel/GCC atomics ***/
++
++#  define ATOMIC_FLAG_INIT false
++
++#  define ATOMIC_VAR_INIT(value) (value)
++
++#  define atomic_init(obj, value) \
++    do { *(obj) = (value); } while(0)
++
++#  define kill_dependency(y) \
++    ((void)0)
++
++#  define atomic_thread_fence(order) \
++    __sync_synchronize()
++
++#  define atomic_signal_fence(order) \
++    ((void)0)
++
++#  define atomic_is_lock_free(obj) \
++    false
++
++typedef          bool      atomic_flag;
++typedef          bool      atomic_bool;
++typedef          char      atomic_char;
++typedef   signed char      atomic_schar;
++typedef unsigned char      atomic_uchar;
++typedef          short     atomic_short;
++typedef unsigned short     atomic_ushort;
++typedef          int       atomic_int;
++typedef unsigned int       atomic_uint;
++typedef          long      atomic_long;
++typedef unsigned long      atomic_ulong;
++typedef          long long atomic_llong;
++typedef unsigned long long atomic_ullong;
++//typedef          char16_t  atomic_char16_t;
++//typedef          char32_t  atomic_char32_t;
++typedef          wchar_t   atomic_wchar_t;
++typedef       int_least8_t atomic_int_least8_t;
++typedef      uint_least8_t atomic_uint_least8_t;
++typedef      int_least16_t atomic_int_least16_t;
++typedef     uint_least16_t atomic_uint_least16_t;
++typedef      int_least32_t atomic_int_least32_t;
++typedef     uint_least32_t atomic_uint_least32_t;
++typedef      int_least64_t atomic_int_least64_t;
++typedef     uint_least64_t atomic_uint_least64_t;
++typedef       int_fast8_t atomic_int_fast8_t;
++typedef      uint_fast8_t atomic_uint_fast8_t;
++typedef      int_fast16_t atomic_int_fast16_t;
++typedef     uint_fast16_t atomic_uint_fast16_t;
++typedef      int_fast32_t atomic_int_fast32_t;
++typedef     uint_fast32_t atomic_uint_fast32_t;
++typedef      int_fast64_t atomic_int_fast64_t;
++typedef     uint_fast64_t atomic_uint_fast64_t;
++typedef          intptr_t atomic_intptr_t;
++typedef         uintptr_t atomic_uintptr_t;
++typedef            size_t atomic_size_t;
++typedef         ptrdiff_t atomic_ptrdiff_t;
++typedef          intmax_t atomic_intmax_t;
++typedef         uintmax_t atomic_uintmax_t;
++
++#  define atomic_store(object,desired) \
++    do { \
++        *(object) = (desired); \
++        __sync_synchronize(); \
++    } while (0)
++
++#  define atomic_store_explicit(object,desired,order) \
++    atomic_store(object,desired)
++
++#  define atomic_load(object) \
++    (__sync_synchronize(), *(object))
++
++#  define atomic_load_explicit(object,order) \
++    atomic_load(object)
++
++#  define atomic_exchange(object,desired) \
++({  \
++    typeof (object) _obj = (object); \
++    typeof (*object) _old; \
++    do \
++        _old = atomic_load(_obj); \
++    while (!__sync_bool_compare_and_swap(_obj, _old, (desired))); \
++    _old; \
++})
++
++#  define atomic_exchange_explicit(object,desired,order) \
++    atomic_exchange(object,desired)
++
++#  define atomic_compare_exchange(object,expected,desired) \
++({  \
++    typeof (object) _exp = (expected); \
++    typeof (*object) _old = *_exp; \
++    *_exp = __sync_val_compare_and_swap((object), _old, (desired)); \
++    *_exp == _old; \
++})
++
++#  define atomic_compare_exchange_strong(object,expected,desired) \
++    atomic_compare_exchange(object, expected, desired)
++
++#  define atomic_compare_exchange_strong_explicit(object,expected,desired,order,order_different) \
++    atomic_compare_exchange_strong(object, expected, desired)
++
++#  define atomic_compare_exchange_weak(object,expected,desired) \
++    atomic_compare_exchange(object, expected, desired)
++
++#  define atomic_compare_exchange_weak_explicit(object,expected,desired,order_equal,order_different) \
++    atomic_compare_exchange_weak(object, expected, desired)
++
++#  define atomic_fetch_add(object,operand) \
++    __sync_fetch_and_add(object, operand)
++
++#  define atomic_fetch_add_explicit(object,operand,order) \
++    atomic_fetch_add(object,operand)
++
++#  define atomic_fetch_sub(object,operand) \
++    __sync_fetch_and_sub(object, operand)
++
++#  define atomic_fetch_sub_explicit(object,operand,order) \
++    atomic_fetch_sub(object,operand)
++
++#  define atomic_fetch_or(object,operand) \
++    __sync_fetch_and_or(object, operand)
++
++#  define atomic_fetch_or_explicit(object,operand,order) \
++    atomic_fetch_or(object,operand)
++
++#  define atomic_fetch_xor(object,operand) \
++    __sync_fetch_and_sub(object, operand)
++
++#  define atomic_fetch_xor_explicit(object,operand,order) \
++    atomic_fetch_sub(object,operand)
++
++#  define atomic_fetch_and(object,operand) \
++    __sync_fetch_and_and(object, operand)
++
++#  define atomic_fetch_and_explicit(object,operand,order) \
++    atomic_fetch_and(object,operand)
++
++#  define atomic_flag_test_and_set(object) \
++    atomic_exchange(object, true)
++
++#  define atomic_flag_test_and_set_explicit(object,order) \
++    atomic_flag_test_and_set(object)
++
++#  define atomic_flag_clear(object) \
++    atomic_store(object, false)
++
++#  define atomic_flag_clear_explicit(object,order) \
++    atomic_flag_clear(object)
++
++# endif /* !C11 */
++
++typedef atomic_uint_least32_t vlc_atomic_float;
++
++static inline void vlc_atomic_init_float(vlc_atomic_float *var, float f)
++{
++    union { float f; uint32_t i; } u;
++    u.f = f;
++    atomic_init(var, u.i);
++}
++
++/** Helper to retrieve a single precision from an atom. */
++static inline float vlc_atomic_load_float(vlc_atomic_float *atom)
++{
++    union { float f; uint32_t i; } u;
++    u.i = atomic_load(atom);
++    return u.f;
++}
++
++/** Helper to store a single precision into an atom. */
++static inline void vlc_atomic_store_float(vlc_atomic_float *atom, float f)
++{
++    union { float f; uint32_t i; } u;
++    u.f = f;
++    atomic_store(atom, u.i);
++}
++
++# else /* C++ */
++/*** Native C++11 atomics ***/
++#   include <atomic>
++# endif /* C++ */
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_avcodec.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_avcodec.h
+new file mode 100644
+index 0000000..664633a
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_avcodec.h
+@@ -0,0 +1,34 @@
++/*****************************************************************************
++ * vlc_avcodec.h: VLC thread support for libavcodec
++ *****************************************************************************
++ * Copyright (C) 2009-2010 Rémi Denis-Courmont
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_AVCODEC_H
++# define VLC_AVCODEC_H 1
++
++static inline void vlc_avcodec_lock (void)
++{
++    vlc_global_lock (VLC_AVCODEC_MUTEX);
++}
++
++static inline void vlc_avcodec_unlock (void)
++{
++    vlc_global_unlock (VLC_AVCODEC_MUTEX);
++}
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_bits.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_bits.h
+new file mode 100644
+index 0000000..edd095b
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_bits.h
+@@ -0,0 +1,269 @@
++/*****************************************************************************
++ * vlc_bits.h : Bit handling helpers
++ *****************************************************************************
++ * Copyright (C) 2001, 2002, 2003, 2006, 2015 VLC authors and VideoLAN
++ * $Id: 395a789eba46ac42413f5fb5418619332589f824 $
++ *
++ * Authors: Laurent Aimar <fenrir@via.ecp.fr>
++ *          Gildas Bazin <gbazin at videolan dot org>
++ *          Rafaël Carré <funman at videolan dot org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++#ifndef VLC_BITS_H
++#define VLC_BITS_H 1
++
++#include <vlc_common.h>
++
++/**
++ * \file
++ * This file defines functions, structures for handling streams of bits in vlc
++ */
++
++typedef struct bs_s
++{
++    uint8_t *p_start;
++    uint8_t *p;
++    uint8_t *p_end;
++
++    ssize_t  i_left;    /* i_count number of available bits */
++    bool     b_read_only;
++
++     /* forward read modifier (p_start, p_end, p_fwpriv, count) */
++    uint8_t *(*pf_forward)(uint8_t *, uint8_t *, void *, size_t);
++    void    *p_fwpriv;
++} bs_t;
++
++static inline void bs_write_init( bs_t *s, void *p_data, size_t i_data )
++{
++    s->p_start = (uint8_t *)p_data;
++    s->p       = s->p_start;
++    s->p_end   = s->p_start + i_data;
++    s->i_left  = 8;
++    s->b_read_only = false;
++    s->p_fwpriv = NULL;
++    s->pf_forward = NULL;
++}
++
++static inline void bs_init( bs_t *s, const void *p_data, size_t i_data )
++{
++    bs_write_init( s, (void*) p_data, i_data );
++    s->b_read_only = true;
++}
++
++static inline int bs_pos( const bs_t *s )
++{
++    return( 8 * ( s->p - s->p_start ) + 8 - s->i_left );
++}
++
++static inline int bs_remain( const bs_t *s )
++{
++    if( s->p >= s->p_end )
++        return 0;
++    else
++    return( 8 * ( s->p_end - s->p ) - 8 + s->i_left );
++}
++
++static inline int bs_eof( const bs_t *s )
++{
++    return( s->p >= s->p_end ? 1: 0 );
++}
++
++#define bs_forward( s, i ) \
++    s->p = s->pf_forward ? s->pf_forward( s->p, s->p_end, s->p_fwpriv, i ) : s->p + i
++
++static inline uint32_t bs_read( bs_t *s, int i_count )
++{
++     static const uint32_t i_mask[33] =
++     {  0x00,
++        0x01,      0x03,      0x07,      0x0f,
++        0x1f,      0x3f,      0x7f,      0xff,
++        0x1ff,     0x3ff,     0x7ff,     0xfff,
++        0x1fff,    0x3fff,    0x7fff,    0xffff,
++        0x1ffff,   0x3ffff,   0x7ffff,   0xfffff,
++        0x1fffff,  0x3fffff,  0x7fffff,  0xffffff,
++        0x1ffffff, 0x3ffffff, 0x7ffffff, 0xfffffff,
++        0x1fffffff,0x3fffffff,0x7fffffff,0xffffffff};
++    int      i_shr, i_drop = 0;
++    uint32_t i_result = 0;
++
++    if( i_count > 32 )
++    {
++        i_drop = i_count - 32;
++        i_count = 32;
++    }
++
++    while( i_count > 0 )
++    {
++        if( s->p >= s->p_end )
++        {
++            break;
++        }
++
++        if( ( i_shr = s->i_left - i_count ) >= 0 )
++        {
++            /* more in the buffer than requested */
++            i_result |= ( *s->p >> i_shr )&i_mask[i_count];
++            s->i_left -= i_count;
++            if( s->i_left == 0 )
++            {
++                bs_forward( s, 1 );
++                s->i_left = 8;
++            }
++            break;
++        }
++        else
++        {
++            /* less in the buffer than requested */
++           if( -i_shr == 32 )
++               i_result = 0;
++           else
++               i_result |= (*s->p&i_mask[s->i_left]) << -i_shr;
++           i_count  -= s->i_left;
++           bs_forward( s, 1);
++           s->i_left = 8;
++        }
++    }
++
++    if( i_drop )
++        bs_forward( s, i_drop );
++
++    return( i_result );
++}
++
++static inline uint32_t bs_read1( bs_t *s )
++{
++    if( s->p < s->p_end )
++    {
++        unsigned int i_result;
++
++        s->i_left--;
++        i_result = ( *s->p >> s->i_left )&0x01;
++        if( s->i_left == 0 )
++        {
++            bs_forward( s, 1 );
++            s->i_left = 8;
++        }
++        return i_result;
++    }
++
++    return 0;
++}
++
++static inline uint32_t bs_show( bs_t *s, int i_count )
++{
++    bs_t     s_tmp = *s;
++    return bs_read( &s_tmp, i_count );
++}
++
++static inline void bs_skip( bs_t *s, ssize_t i_count )
++{
++    s->i_left -= i_count;
++
++    if( s->i_left <= 0 )
++    {
++        const size_t i_bytes = 1 + s->i_left / -8;
++        bs_forward( s, i_bytes );
++        if( i_bytes * 8 < i_bytes /* ofw */ )
++            s->i_left = i_bytes;
++        else
++            s->i_left += 8 * i_bytes;
++    }
++}
++
++static inline void bs_write( bs_t *s, int i_count, uint32_t i_bits )
++{
++    if( s->b_read_only )
++        return;
++
++    while( i_count > 0 )
++    {
++        if( s->p >= s->p_end )
++        {
++            break;
++        }
++
++        i_count--;
++
++        if( ( i_bits >> i_count )&0x01 )
++        {
++            *s->p |= 1 << ( s->i_left - 1 );
++        }
++        else
++        {
++            *s->p &= ~( 1 << ( s->i_left - 1 ) );
++        }
++        s->i_left--;
++        if( s->i_left == 0 )
++        {
++            bs_forward( s, 1 );
++            s->i_left = 8;
++        }
++    }
++}
++
++static inline bool bs_aligned( bs_t *s )
++{
++    return s->i_left % 8 == 0;
++}
++
++static inline void bs_align( bs_t *s )
++{
++    if( s->i_left != 8 )
++    {
++        s->i_left = 8;
++        s->p++;
++    }
++}
++
++static inline void bs_align_0( bs_t *s )
++{
++    if( s->i_left != 8 )
++    {
++        bs_write( s, s->i_left, 0 );
++    }
++}
++
++static inline void bs_align_1( bs_t *s )
++{
++    while( !s->b_read_only && s->i_left != 8 )
++    {
++        bs_write( s, 1, 1 );
++    }
++}
++
++/* Read unsigned Exp-Golomb code */
++static inline uint_fast32_t bs_read_ue( bs_t * bs )
++{
++    unsigned i = 0;
++
++    while( bs_read1( bs ) == 0 && bs->p < bs->p_end && i < 31 )
++        i++;
++
++    return (1U << i) - 1 + bs_read( bs, i );
++}
++
++/* Read signed Exp-Golomb code */
++static inline int_fast32_t bs_read_se( bs_t *s )
++{
++    uint_fast32_t val = bs_read_ue( s );
++
++    return (val & 0x01) ? (int_fast32_t)((val + 1) / 2)
++                        : -(int_fast32_t)(val / 2);
++}
++
++#undef bs_forward
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_block.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_block.h
+new file mode 100644
+index 0000000..9990104
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_block.h
+@@ -0,0 +1,626 @@
++/*****************************************************************************
++ * vlc_block.h: Data blocks management functions
++ *****************************************************************************
++ * Copyright (C) 2003 VLC authors and VideoLAN
++ * $Id: 1c9478301687233398adbb7de7da4ffc4a101f89 $
++ *
++ * Authors: Laurent Aimar <fenrir@via.ecp.fr>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_BLOCK_H
++#define VLC_BLOCK_H 1
++
++/**
++ * \defgroup block Data blocks
++ * \ingroup input
++ *
++ * Blocks of binary data.
++ *
++ * @ref block_t is a generic structure to represent a binary blob within VLC.
++ * The primary goal of the structure is to avoid memory copying as data is
++ * passed around. It is notably used between the \ref demux, the packetizer
++ * (if present) and the \ref decoder, and for audio, between the \ref decoder,
++ * the audio filters, and the \ref audio_output.
++ *
++ * @{
++ * \file
++ * Data block definition and functions
++ */
++
++#include <sys/types.h>  /* for ssize_t */
++
++/****************************************************************************
++ * block:
++ ****************************************************************************
++ * - i_flags may not always be set (ie could be 0, even for a key frame
++ *      it depends where you receive the buffer (before/after a packetizer
++ *      and the demux/packetizer implementations.
++ * - i_dts/i_pts could be VLC_TS_INVALID, it means no pts/dts
++ * - i_length: length in microseond of the packet, can be null except in the
++ *      sout where it is mandatory.
++ *
++ * - i_buffer number of valid data pointed by p_buffer
++ *      you can freely decrease it but never increase it yourself
++ *      (use block_Realloc)
++ * - p_buffer: pointer over datas. You should never overwrite it, you can
++ *   only incremment it to skip datas, in others cases use block_Realloc
++ *   (don't duplicate yourself in a bigger buffer, block_Realloc is
++ *   optimised for preheader/postdatas increase)
++ ****************************************************************************/
++
++/** The content doesn't follow the last block, possible some blocks in between
++ *  have been lost */
++#define BLOCK_FLAG_DISCONTINUITY 0x0001
++/** Intra frame */
++#define BLOCK_FLAG_TYPE_I        0x0002
++/** Inter frame with backward reference only */
++#define BLOCK_FLAG_TYPE_P        0x0004
++/** Inter frame with backward and forward reference */
++#define BLOCK_FLAG_TYPE_B        0x0008
++/** For inter frame when you don't know the real type */
++#define BLOCK_FLAG_TYPE_PB       0x0010
++/** Warn that this block is a header one */
++#define BLOCK_FLAG_HEADER        0x0020
++/** This block contains the last part of a sequence  */
++#define BLOCK_FLAG_END_OF_SEQUENCE 0x0040
++/** This block contains a clock reference */
++#define BLOCK_FLAG_CLOCK         0x0080
++/** This block is scrambled */
++#define BLOCK_FLAG_SCRAMBLED     0x0100
++/** This block has to be decoded but not be displayed */
++#define BLOCK_FLAG_PREROLL       0x0200
++/** This block is corrupted and/or there is data loss  */
++#define BLOCK_FLAG_CORRUPTED     0x0400
++/** This block contains an interlaced picture with top field stored first */
++#define BLOCK_FLAG_TOP_FIELD_FIRST 0x0800
++/** This block contains an interlaced picture with bottom field stored first */
++#define BLOCK_FLAG_BOTTOM_FIELD_FIRST 0x1000
++/** This block contains a single field from interlaced picture. */
++#define BLOCK_FLAG_SINGLE_FIELD  0x2000
++
++/** This block contains an interlaced picture */
++#define BLOCK_FLAG_INTERLACED_MASK \
++    (BLOCK_FLAG_TOP_FIELD_FIRST|BLOCK_FLAG_BOTTOM_FIELD_FIRST|BLOCK_FLAG_SINGLE_FIELD)
++
++#define BLOCK_FLAG_TYPE_MASK \
++    (BLOCK_FLAG_TYPE_I|BLOCK_FLAG_TYPE_P|BLOCK_FLAG_TYPE_B|BLOCK_FLAG_TYPE_PB)
++
++/* These are for input core private usage only */
++#define BLOCK_FLAG_CORE_PRIVATE_MASK  0x00ff0000
++#define BLOCK_FLAG_CORE_PRIVATE_SHIFT 16
++
++/* These are for module private usage only */
++#define BLOCK_FLAG_PRIVATE_MASK  0xff000000
++#define BLOCK_FLAG_PRIVATE_SHIFT 24
++
++typedef void (*block_free_t) (block_t *);
++
++struct block_t
++{
++    block_t    *p_next;
++
++    uint8_t    *p_buffer; /**< Payload start */
++    size_t      i_buffer; /**< Payload length */
++    uint8_t    *p_start; /**< Buffer start */
++    size_t      i_size; /**< Buffer total size */
++
++    uint32_t    i_flags;
++    unsigned    i_nb_samples; /* Used for audio */
++
++    mtime_t     i_pts;
++    mtime_t     i_dts;
++    mtime_t     i_length;
++
++    /* Rudimentary support for overloading block (de)allocation. */
++    block_free_t pf_release;
++};
++
++VLC_API void block_Init( block_t *, void *, size_t );
++
++/**
++ * Allocates a block.
++ *
++ * Creates a new block with the requested size.
++ * The block must be released with block_Release().
++ *
++ * @param size size in bytes (possibly zero)
++ * @return the created block, or NULL on memory error.
++ */
++VLC_API block_t *block_Alloc(size_t size) VLC_USED VLC_MALLOC;
++
++VLC_API block_t *block_TryRealloc(block_t *, ssize_t pre, size_t body) VLC_USED;
++
++/**
++ * Reallocates a block.
++ *
++ * This function expands, shrinks or moves a data block.
++ * In many cases, this function can return without any memory allocation by
++ * reusing spare buffer space. Otherwise, a new block is created and data is
++ * copied.
++ *
++ * @param pre count of bytes to prepend if positive,
++ *            count of leading bytes to discard if negative
++ * @param body new bytes size of the block
++ *
++ * @return the reallocated block on succes, NULL on error.
++ *
++ * @note Skipping leading bytes can be achieved directly by subtracting from
++ * block_t.i_buffer and adding block_t.p_buffer.
++ * @note Discard trailing bytes can be achieved directly by subtracting from
++ * block_t.i_buffer.
++ * @note On error, the block is discarded.
++ * To avoid that, use block_TryRealloc() instead.
++ */
++VLC_API block_t *block_Realloc(block_t *, ssize_t pre, size_t body) VLC_USED;
++
++/**
++ * Releases a block.
++ *
++ * This function works for any @ref block_t block, regardless of the way it was
++ * allocated.
++ *
++ * @note
++ * If the block is in a chain, this function does <b>not</b> release any
++ * subsequent block in the chain. Use block_ChainRelease() for that purpose. 
++ *
++ * @param block block to release (cannot be NULL)
++ */
++static inline void block_Release(block_t *block)
++{
++    block->pf_release(block);
++}
++
++static inline void block_CopyProperties( block_t *dst, block_t *src )
++{
++    dst->i_flags   = src->i_flags;
++    dst->i_nb_samples = src->i_nb_samples;
++    dst->i_dts     = src->i_dts;
++    dst->i_pts     = src->i_pts;
++    dst->i_length  = src->i_length;
++}
++
++/**
++ * Duplicates a block.
++ *
++ * Creates a writeable duplicate of a block.
++ *
++ * @return the duplicate on success, NULL on error.
++ */
++VLC_USED
++static inline block_t *block_Duplicate( block_t *p_block )
++{
++    block_t *p_dup = block_Alloc( p_block->i_buffer );
++    if( p_dup == NULL )
++        return NULL;
++
++    block_CopyProperties( p_dup, p_block );
++    memcpy( p_dup->p_buffer, p_block->p_buffer, p_block->i_buffer );
++
++    return p_dup;
++}
++
++/**
++ * Wraps heap in a block.
++ *
++ * Creates a @ref block_t out of an existing heap allocation.
++ * This is provided by LibVLC so that manually heap-allocated blocks can safely
++ * be deallocated even after the origin plugin has been unloaded from memory.
++ *
++ * When block_Release() is called, VLC will free() the specified pointer.
++ *
++ * @param addr base address of the heap allocation (will be free()'d)
++ * @param length bytes length of the heap allocation
++ * @return NULL in case of error (ptr free()'d in that case), or a valid
++ * block_t pointer.
++ */
++VLC_API block_t *block_heap_Alloc(void *, size_t) VLC_USED VLC_MALLOC;
++
++/**
++ * Wraps a memory mapping in a block
++ *
++ * Creates a @ref block_t from a virtual address memory mapping (mmap).
++ * This is provided by LibVLC so that mmap blocks can safely be deallocated
++ * even after the allocating plugin has been unloaded from memory.
++ *
++ * @param addr base address of the mapping (as returned by mmap)
++ * @param length length (bytes) of the mapping (as passed to mmap)
++ * @return NULL if addr is MAP_FAILED, or an error occurred (in the later
++ * case, munmap(addr, length) is invoked before returning).
++ */
++VLC_API block_t *block_mmap_Alloc(void *addr, size_t length) VLC_USED VLC_MALLOC;
++
++/**
++ * Wraps a System V memory segment in a block
++ *
++ * Creates a @ref block_t from a System V shared memory segment (shmget()).
++ * This is provided by LibVLC so that segments can safely be deallocated
++ * even after the allocating plugin has been unloaded from memory.
++ *
++ * @param addr base address of the segment (as returned by shmat())
++ * @param length length (bytes) of the segment (as passed to shmget())
++ * @return NULL if an error occurred (in that case, shmdt(addr) is invoked
++ * before returning NULL).
++ */
++VLC_API block_t * block_shm_Alloc(void *addr, size_t length) VLC_USED VLC_MALLOC;
++
++/**
++ * Maps a file handle in memory.
++ *
++ * Loads a file into a block of memory through a file descriptor.
++ * If possible a private file mapping is created. Otherwise, the file is read
++ * normally. This function is a cancellation point.
++ *
++ * @note On 32-bits platforms,
++ * this function will not work for very large files,
++ * due to memory space constraints.
++ *
++ * @param fd file descriptor to load from
++ * @param write If true, request a read/write private mapping.
++ *              If false, request a read-only potentially shared mapping.
++ *
++ * @return a new block with the file content at p_buffer, and file length at
++ * i_buffer (release it with block_Release()), or NULL upon error (see errno).
++ */
++VLC_API block_t *block_File(int fd, bool write) VLC_USED VLC_MALLOC;
++
++/**
++ * Maps a file in memory.
++ *
++ * Loads a file into a block of memory from a path to the file.
++ * See also block_File().
++ *
++ * @param write If true, request a read/write private mapping.
++ *              If false, request a read-only potentially shared mapping.
++ */
++VLC_API block_t *block_FilePath(const char *, bool write) VLC_USED VLC_MALLOC;
++
++static inline void block_Cleanup (void *block)
++{
++    block_Release ((block_t *)block);
++}
++#define block_cleanup_push( block ) vlc_cleanup_push (block_Cleanup, block)
++
++/**
++ * \defgroup block_fifo Block chain
++ * @{
++ */
++
++/****************************************************************************
++ * Chains of blocks functions helper
++ ****************************************************************************
++ * - block_ChainAppend : append a block to the last block of a chain. Try to
++ *      avoid using with a lot of data as it's really slow, prefer
++ *      block_ChainLastAppend, p_block can be NULL
++ * - block_ChainLastAppend : use a pointer over a pointer to the next blocks,
++ *      and update it.
++ * - block_ChainRelease : release a chain of block
++ * - block_ChainExtract : extract data from a chain, return real bytes counts
++ * - block_ChainGather : gather a chain, free it and return one block.
++ ****************************************************************************/
++static inline void block_ChainAppend( block_t **pp_list, block_t *p_block )
++{
++    if( *pp_list == NULL )
++    {
++        *pp_list = p_block;
++    }
++    else
++    {
++        block_t *p = *pp_list;
++
++        while( p->p_next ) p = p->p_next;
++        p->p_next = p_block;
++    }
++}
++
++static inline void block_ChainLastAppend( block_t ***ppp_last, block_t *p_block )
++{
++    block_t *p_last = p_block;
++
++    **ppp_last = p_block;
++
++    while( p_last->p_next ) p_last = p_last->p_next;
++    *ppp_last = &p_last->p_next;
++}
++
++static inline void block_ChainRelease( block_t *p_block )
++{
++    while( p_block )
++    {
++        block_t *p_next = p_block->p_next;
++        block_Release( p_block );
++        p_block = p_next;
++    }
++}
++
++static size_t block_ChainExtract( block_t *p_list, void *p_data, size_t i_max )
++{
++    size_t  i_total = 0;
++    uint8_t *p = (uint8_t*)p_data;
++
++    while( p_list && i_max )
++    {
++        size_t i_copy = __MIN( i_max, p_list->i_buffer );
++        memcpy( p, p_list->p_buffer, i_copy );
++        i_max   -= i_copy;
++        i_total += i_copy;
++        p       += i_copy;
++
++        p_list = p_list->p_next;
++    }
++    return i_total;
++}
++
++static inline void block_ChainProperties( block_t *p_list, int *pi_count, size_t *pi_size, mtime_t *pi_length )
++{
++    size_t i_size = 0;
++    mtime_t i_length = 0;
++    int i_count = 0;
++
++    while( p_list )
++    {
++        i_size += p_list->i_buffer;
++        i_length += p_list->i_length;
++        i_count++;
++
++        p_list = p_list->p_next;
++    }
++
++    if( pi_size )
++        *pi_size = i_size;
++    if( pi_length )
++        *pi_length = i_length;
++    if( pi_count )
++        *pi_count = i_count;
++}
++
++static inline block_t *block_ChainGather( block_t *p_list )
++{
++    size_t  i_total = 0;
++    mtime_t i_length = 0;
++    block_t *g;
++
++    if( p_list->p_next == NULL )
++        return p_list;  /* Already gathered */
++
++    block_ChainProperties( p_list, NULL, &i_total, &i_length );
++
++    g = block_Alloc( i_total );
++    if( !g )
++        return NULL;
++    block_ChainExtract( p_list, g->p_buffer, g->i_buffer );
++
++    g->i_flags = p_list->i_flags;
++    g->i_pts   = p_list->i_pts;
++    g->i_dts   = p_list->i_dts;
++    g->i_length = i_length;
++
++    /* free p_list */
++    block_ChainRelease( p_list );
++    return g;
++}
++
++/**
++ * @}
++ * \defgroup fifo Block FIFO
++ * Thread-safe block queue functions
++ * @{
++ */
++
++/**
++ * Creates a thread-safe FIFO queue of blocks.
++ *
++ * See also block_FifoPut() and block_FifoGet().
++ * The created queue must be released with block_FifoRelease().
++ *
++ * @return the FIFO or NULL on memory error
++ */
++VLC_API block_fifo_t *block_FifoNew(void) VLC_USED VLC_MALLOC;
++
++/**
++ * Destroys a FIFO created by block_FifoNew().
++ *
++ * @note Any queued blocks are also destroyed.
++ * @warning No other threads may be using the FIFO when this function is
++ * called. Otherwise, undefined behaviour will occur.
++ */
++VLC_API void block_FifoRelease(block_fifo_t *);
++
++/**
++ * Clears all blocks in a FIFO.
++ */
++VLC_API void block_FifoEmpty(block_fifo_t *);
++
++/**
++ * Immediately queue one block at the end of a FIFO.
++ *
++ * @param fifo queue
++ * @param block head of a block list to queue (may be NULL)
++ */
++VLC_API void block_FifoPut(block_fifo_t *fifo, block_t *block);
++
++/**
++ * Dequeue the first block from the FIFO. If necessary, wait until there is
++ * one block in the queue. This function is (always) cancellation point.
++ *
++ * @return a valid block
++ */
++VLC_API block_t *block_FifoGet(block_fifo_t *) VLC_USED;
++
++/**
++ * Peeks the first block in the FIFO.
++ *
++ * @warning This function leaves the block in the FIFO.
++ * You need to protect against concurrent threads who could dequeue the block.
++ * Preferably, there should be only one thread reading from the FIFO.
++ *
++ * @warning This function is undefined if the FIFO is empty.
++ *
++ * @return a valid block.
++ */
++VLC_API block_t *block_FifoShow(block_fifo_t *);
++
++size_t block_FifoSize(block_fifo_t *) VLC_USED VLC_DEPRECATED;
++VLC_API size_t block_FifoCount(block_fifo_t *) VLC_USED VLC_DEPRECATED;
++
++typedef struct block_fifo_t vlc_fifo_t;
++
++/**
++ * Locks a block FIFO.
++ *
++ * No more than one thread can lock the FIFO at any given
++ * time, and no other thread can modify the FIFO while it is locked.
++ * vlc_fifo_Unlock() releases the lock.
++ *
++ * @note If the FIFO is already locked by another thread, this function waits.
++ * This function is not a cancellation point.
++ *
++ * @warning Recursively locking a single FIFO is undefined. Locking more than
++ * one FIFO at a time may lead to lock inversion; mind the locking order.
++ */
++VLC_API void vlc_fifo_Lock(vlc_fifo_t *);
++
++/**
++ * Unlocks a block FIFO.
++ *
++ * The calling thread must have locked the FIFO previously with
++ * vlc_fifo_Lock(). Otherwise, the behaviour is undefined.
++ *
++ * @note This function is not a cancellation point.
++ */
++VLC_API void vlc_fifo_Unlock(vlc_fifo_t *);
++
++/**
++ * Wakes up one thread waiting on the FIFO, if any.
++ *
++ * @note This function is not a cancellation point.
++ *
++ * @warning For race-free operations, the FIFO should be locked by the calling
++ * thread. The function can be called on a unlocked FIFO however.
++ */
++VLC_API void vlc_fifo_Signal(vlc_fifo_t *);
++
++/**
++ * Waits on the FIFO.
++ *
++ * Atomically unlocks the FIFO and waits until one thread signals the FIFO,
++ * then locks the FIFO again. A signal can be sent by queueing a block to the
++ * previously empty FIFO or by calling vlc_fifo_Signal() directly.
++ * This function may also return spuriously at any moment.
++ *
++ * @note This function is a cancellation point. In case of cancellation, the
++ * the FIFO will be locked before cancellation cleanup handlers are processed.
++ */
++VLC_API void vlc_fifo_Wait(vlc_fifo_t *);
++
++VLC_API void vlc_fifo_WaitCond(vlc_fifo_t *, vlc_cond_t *);
++
++/**
++ * Timed variant of vlc_fifo_WaitCond().
++ *
++ * Atomically unlocks the FIFO and waits until one thread signals the FIFO up
++ * to a certain date, then locks the FIFO again. See vlc_fifo_Wait().
++ */
++int vlc_fifo_TimedWaitCond(vlc_fifo_t *, vlc_cond_t *, mtime_t);
++
++/**
++ * Queues a linked-list of blocks into a locked FIFO.
++ *
++ * @param block the head of the list of blocks
++ *              (if NULL, this function has no effects)
++ *
++ * @note This function is not a cancellation point.
++ *
++ * @warning The FIFO must be locked by the calling thread using
++ * vlc_fifo_Lock(). Otherwise behaviour is undefined.
++ */
++VLC_API void vlc_fifo_QueueUnlocked(vlc_fifo_t *, block_t *);
++
++/**
++ * Dequeues the first block from a locked FIFO, if any.
++ *
++ * @note This function is not a cancellation point.
++ *
++ * @warning The FIFO must be locked by the calling thread using
++ * vlc_fifo_Lock(). Otherwise behaviour is undefined.
++ *
++ * @return the first block in the FIFO or NULL if the FIFO is empty
++ */
++VLC_API block_t *vlc_fifo_DequeueUnlocked(vlc_fifo_t *) VLC_USED;
++
++/**
++ * Dequeues the all blocks from a locked FIFO.
++ *
++ * This is equivalent to calling vlc_fifo_DequeueUnlocked() repeatedly until
++ * the FIFO is emptied, but this function is much faster.
++ *
++ * @note This function is not a cancellation point.
++ *
++ * @warning The FIFO must be locked by the calling thread using
++ * vlc_fifo_Lock(). Otherwise behaviour is undefined.
++ *
++ * @return a linked-list of all blocks in the FIFO (possibly NULL)
++ */
++VLC_API block_t *vlc_fifo_DequeueAllUnlocked(vlc_fifo_t *) VLC_USED;
++
++/**
++ * Counts blocks in a FIFO.
++ *
++ * Checks how many blocks are queued in a locked FIFO.
++ *
++ * @note This function is not cancellation point.
++ *
++ * @warning The FIFO must be locked by the calling thread using
++ * vlc_fifo_Lock(). Otherwise behaviour is undefined.
++ *
++ * @return the number of blocks in the FIFO (zero if it is empty)
++ */
++VLC_API size_t vlc_fifo_GetCount(const vlc_fifo_t *) VLC_USED;
++
++/**
++ * Counts bytes in a FIFO.
++ *
++ * Checks how many bytes are queued in a locked FIFO.
++ *
++ * @note This function is not cancellation point.
++ *
++ * @warning The FIFO must be locked by the calling thread using
++ * vlc_fifo_Lock(). Otherwise behaviour is undefined.
++ *
++ * @return the total number of bytes
++ *
++ * @note Zero bytes does not necessarily mean that the FIFO is empty since
++ * a block could contain zero bytes. Use vlc_fifo_GetCount() to determine if
++ * a FIFO is empty.
++ */
++VLC_API size_t vlc_fifo_GetBytes(const vlc_fifo_t *) VLC_USED;
++
++VLC_USED static inline bool vlc_fifo_IsEmpty(const vlc_fifo_t *fifo)
++{
++    return vlc_fifo_GetCount(fifo) == 0;
++}
++
++static inline void vlc_fifo_Cleanup(void *fifo)
++{
++    vlc_fifo_Unlock((vlc_fifo_t *)fifo);
++}
++#define vlc_fifo_CleanupPush(fifo) vlc_cleanup_push(vlc_fifo_Cleanup, fifo)
++
++/** @} */
++
++/** @} */
++
++#endif /* VLC_BLOCK_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_block_helper.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_block_helper.h
+new file mode 100644
+index 0000000..4071c2b
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_block_helper.h
+@@ -0,0 +1,369 @@
++/*****************************************************************************
++ * vlc_block_helper.h: Helper functions for data blocks management.
++ *****************************************************************************
++ * Copyright (C) 2003-2017 VLC authors and VideoLAN
++ *
++ * Authors: Gildas Bazin <gbazin@netcourrier.com>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_BLOCK_HELPER_H
++#define VLC_BLOCK_HELPER_H 1
++
++#include <vlc_block.h>
++
++typedef struct block_bytestream_t
++{
++    block_t *p_chain;  /**< byte stream head block */
++    block_t **pp_last; /**< tail ppointer for appends */
++    block_t *p_block;  /**< byte stream read pointer block */
++    size_t   i_block_offset; /**< byte stream read pointer offset within block */
++    size_t   i_base_offset; /**< block base offset (previous blocks total size) */
++    size_t   i_total;  /**< total bytes over all linked blocks */
++} block_bytestream_t;
++
++/*****************************************************************************
++ * block_bytestream_t management
++ *****************************************************************************/
++static inline void block_BytestreamInit( block_bytestream_t *p_bytestream )
++{
++    p_bytestream->p_chain = p_bytestream->p_block = NULL;
++    p_bytestream->pp_last = &p_bytestream->p_chain;
++    p_bytestream->i_block_offset = 0;
++    p_bytestream->i_base_offset = 0;
++    p_bytestream->i_total = 0;
++}
++
++static inline void block_BytestreamRelease( block_bytestream_t *p_bytestream )
++{
++    block_ChainRelease( p_bytestream->p_chain );
++}
++
++/**
++ * It flush all data (read and unread) from a block_bytestream_t.
++ */
++static inline void block_BytestreamEmpty( block_bytestream_t *p_bytestream )
++{
++    block_BytestreamRelease( p_bytestream );
++    block_BytestreamInit( p_bytestream );
++}
++
++/**
++ * It flushes all already read data from a block_bytestream_t.
++ */
++static inline void block_BytestreamFlush( block_bytestream_t *p_bytestream )
++{
++    block_t *block = p_bytestream->p_chain;
++
++    while( block != p_bytestream->p_block )
++    {
++        block_t *p_next = block->p_next;
++
++        p_bytestream->i_total -= block->i_buffer;
++        p_bytestream->i_base_offset -= block->i_buffer;
++        block_Release( block );
++        block = p_next;
++    }
++
++    while( block != NULL && block->i_buffer == p_bytestream->i_block_offset )
++    {
++        block_t *p_next = block->p_next;
++
++        p_bytestream->i_total -= block->i_buffer;
++        block_Release( block );
++        block = p_next;
++        p_bytestream->i_block_offset = 0;
++    }
++
++    p_bytestream->p_chain = p_bytestream->p_block = block;
++    if( p_bytestream->p_chain == NULL )
++        p_bytestream->pp_last = &p_bytestream->p_chain;
++}
++
++static inline void block_BytestreamPush( block_bytestream_t *p_bytestream,
++                                         block_t *p_block )
++{
++    block_ChainLastAppend( &p_bytestream->pp_last, p_block );
++    if( !p_bytestream->p_block ) p_bytestream->p_block = p_block;
++    for( ; p_block; p_block = p_block->p_next )
++        p_bytestream->i_total += p_block->i_buffer;
++}
++
++static inline size_t block_BytestreamRemaining( const block_bytestream_t *p_bytestream )
++{
++    return ( p_bytestream->i_total > p_bytestream->i_base_offset + p_bytestream->i_block_offset ) ?
++             p_bytestream->i_total - p_bytestream->i_base_offset - p_bytestream->i_block_offset : 0;
++}
++
++VLC_USED
++static inline block_t *block_BytestreamPop( block_bytestream_t *p_bytestream )
++{
++    block_t *p_block;
++
++    block_BytestreamFlush( p_bytestream );
++
++    p_block = p_bytestream->p_block;
++    if( unlikely( p_block == NULL ) )
++    {
++        return NULL;
++    }
++    else if( !p_block->p_next )
++    {
++        p_block->p_buffer += p_bytestream->i_block_offset;
++        p_block->i_buffer -= p_bytestream->i_block_offset;
++        p_bytestream->i_block_offset = 0;
++        p_bytestream->i_total = 0;
++        p_bytestream->p_chain = p_bytestream->p_block = NULL;
++        p_bytestream->pp_last = &p_bytestream->p_chain;
++        return p_block;
++    }
++
++    while( p_block->p_next && p_block->p_next->p_next )
++        p_block = p_block->p_next;
++
++    block_t *p_block_old = p_block;
++    p_block = p_block->p_next;
++    p_block_old->p_next = NULL;
++    p_bytestream->pp_last = &p_block_old->p_next;
++    if( p_block )
++        p_bytestream->i_total -= p_block->i_buffer;
++
++    return p_block;
++}
++
++static inline int block_WaitBytes( block_bytestream_t *p_bytestream,
++                                   size_t i_data )
++{
++    if( block_BytestreamRemaining( p_bytestream ) >= i_data )
++        return VLC_SUCCESS;
++    return VLC_EGENERIC;
++}
++
++static inline int block_PeekBytes( block_bytestream_t *p_bytestream,
++                                   uint8_t *p_data, size_t i_data )
++{
++    if( block_BytestreamRemaining( p_bytestream ) < i_data )
++        return VLC_EGENERIC;
++
++    /* Copy the data */
++    size_t i_offset = p_bytestream->i_block_offset;
++    size_t i_size = i_data;
++    for( block_t *p_block = p_bytestream->p_block;
++         p_block != NULL; p_block = p_block->p_next )
++    {
++        size_t i_copy = __MIN( i_size, p_block->i_buffer - i_offset );
++        i_size -= i_copy;
++
++        if( i_copy )
++        {
++            memcpy( p_data, p_block->p_buffer + i_offset, i_copy );
++            p_data += i_copy;
++        }
++
++        i_offset = 0;
++
++        if( !i_size ) break;
++    }
++
++    return VLC_SUCCESS;
++}
++
++static inline int block_GetBytes( block_bytestream_t *p_bytestream,
++                                  uint8_t *p_data, size_t i_data )
++{
++    if( block_BytestreamRemaining( p_bytestream ) < i_data )
++        return VLC_EGENERIC;
++
++    /* Copy the data */
++    size_t i_offset = p_bytestream->i_block_offset;
++    size_t i_size = i_data;
++    size_t i_copy = 0;
++    block_t *p_block;
++    for( p_block = p_bytestream->p_block;
++         p_block != NULL; p_block = p_block->p_next )
++    {
++        i_copy = __MIN( i_size, p_block->i_buffer - i_offset );
++        i_size -= i_copy;
++
++        if( i_copy && p_data != NULL )
++        {
++            memcpy( p_data, p_block->p_buffer + i_offset, i_copy );
++            p_data += i_copy;
++        }
++
++        if( i_size == 0 )
++            break;
++
++        p_bytestream->i_base_offset += p_block->i_buffer;
++        i_offset = 0;
++    }
++
++    p_bytestream->p_block = p_block;
++    p_bytestream->i_block_offset = i_offset + i_copy;
++
++    return VLC_SUCCESS;
++}
++
++static inline int block_SkipBytes( block_bytestream_t *p_bytestream,
++                                   size_t i_data )
++{
++    return block_GetBytes( p_bytestream, NULL, i_data );
++}
++
++static inline int block_SkipByte( block_bytestream_t *p_bytestream )
++{
++    return block_GetBytes( p_bytestream, NULL, 1 );
++}
++
++static inline int block_PeekOffsetBytes( block_bytestream_t *p_bytestream,
++    size_t i_peek_offset, uint8_t *p_data, size_t i_data )
++{
++    const size_t i_remain = block_BytestreamRemaining( p_bytestream );
++    if( i_remain < i_data + i_peek_offset )
++        return VLC_EGENERIC;
++
++    /* Find the right place */
++    size_t i_offset = p_bytestream->i_block_offset;
++    size_t i_size = i_peek_offset;
++    size_t i_copy = 0;
++    block_t *p_block;
++    for( p_block = p_bytestream->p_block;
++         p_block != NULL; p_block = p_block->p_next )
++    {
++        i_copy = __MIN( i_size, p_block->i_buffer - i_offset );
++        i_size -= i_copy;
++
++        if( !i_size ) break;
++
++        i_offset = 0;
++    }
++
++    /* Copy the data */
++    i_offset += i_copy;
++    i_size = i_data;
++    for( ; p_block != NULL; p_block = p_block->p_next )
++    {
++        i_copy = __MIN( i_size, p_block->i_buffer - i_offset );
++        i_size -= i_copy;
++
++        if( i_copy )
++        {
++            memcpy( p_data, p_block->p_buffer + i_offset, i_copy );
++            p_data += i_copy;
++        }
++
++        i_offset = 0;
++
++        if( !i_size ) break;
++    }
++
++    return VLC_SUCCESS;
++}
++
++typedef const uint8_t * (*block_startcode_helper_t)( const uint8_t *, const uint8_t * );
++typedef bool (*block_startcode_matcher_t)( uint8_t, size_t, const uint8_t * );
++
++static inline int block_FindStartcodeFromOffset(
++    block_bytestream_t *p_bytestream, size_t *pi_offset,
++    const uint8_t *p_startcode, int i_startcode_length,
++    block_startcode_helper_t p_startcode_helper,
++    block_startcode_matcher_t p_startcode_matcher )
++{
++    block_t *p_block, *p_block_backup = 0;
++    ssize_t i_size = 0;
++    size_t i_offset, i_offset_backup = 0;
++    int i_caller_offset_backup = 0, i_match;
++
++    /* Find the right place */
++    i_size = *pi_offset + p_bytestream->i_block_offset;
++    for( p_block = p_bytestream->p_block;
++         p_block != NULL; p_block = p_block->p_next )
++    {
++        i_size -= p_block->i_buffer;
++        if( i_size < 0 ) break;
++    }
++
++    if( unlikely( i_size >= 0 ) )
++    {
++        /* Not enough data, bail out */
++        return VLC_EGENERIC;
++    }
++
++    /* Begin the search.
++     * We first look for an occurrence of the 1st startcode byte and
++     * if found, we do a more thorough check. */
++    i_size += p_block->i_buffer;
++    *pi_offset -= i_size;
++    i_match = 0;
++    for( ; p_block != NULL; p_block = p_block->p_next )
++    {
++        for( i_offset = i_size; i_offset < p_block->i_buffer; i_offset++ )
++        {
++            /* Use optimized helper when possible */
++            if( p_startcode_helper && !i_match &&
++               (p_block->i_buffer - i_offset) > ((size_t)i_startcode_length - 1) )
++            {
++                const uint8_t *p_res = p_startcode_helper( &p_block->p_buffer[i_offset],
++                                                           &p_block->p_buffer[p_block->i_buffer] );
++                if( p_res )
++                {
++                    *pi_offset += i_offset + (p_res - &p_block->p_buffer[i_offset]);
++                    return VLC_SUCCESS;
++                }
++                /* Then parsing boundary with legacy code */
++                i_offset = p_block->i_buffer - (i_startcode_length - 1);
++            }
++
++            bool b_matched = ( p_startcode_matcher )
++                           ? p_startcode_matcher( p_block->p_buffer[i_offset], i_match, p_startcode )
++                           : p_block->p_buffer[i_offset] == p_startcode[i_match];
++            if( b_matched )
++            {
++                if( i_match == 0 )
++                {
++                    p_block_backup = p_block;
++                    i_offset_backup = i_offset;
++                    i_caller_offset_backup = *pi_offset;
++                }
++
++                if( i_match + 1 == i_startcode_length )
++                {
++                    /* We have it */
++                    *pi_offset += i_offset - i_match;
++                    return VLC_SUCCESS;
++                }
++
++                i_match++;
++            }
++            else if ( i_match > 0 )
++            {
++                /* False positive */
++                p_block = p_block_backup;
++                i_offset = i_offset_backup;
++                *pi_offset = i_caller_offset_backup;
++                i_match = 0;
++            }
++
++        }
++        i_size = 0;
++        *pi_offset += i_offset;
++    }
++
++    *pi_offset -= i_match;
++    return VLC_EGENERIC;
++}
++
++#endif /* VLC_BLOCK_HELPER_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_boxes.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_boxes.h
+new file mode 100644
+index 0000000..aa02ffa
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_boxes.h
+@@ -0,0 +1,165 @@
++/*****************************************************************************
++ * vlc_boxes.h : Boxes/Atoms handling helpers
++ *****************************************************************************
++ * Copyright (C) 2001, 2002, 2003, 2006, 2015 VLC authors and VideoLAN
++ *
++ * Authors: Laurent Aimar <fenrir@via.ecp.fr>
++ *          Gildas Bazin <gbazin at videolan dot org>
++ *          Rafaël Carré <funman at videolan dot org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++#ifndef VLC_BOXES_H
++#define VLC_BOXES_H
++
++#include <vlc_common.h>
++#include <vlc_block.h>
++
++/**
++ * \file
++ * This file defines functions, structures for handling boxes/atoms in vlc
++ */
++
++typedef struct bo_t
++{
++    block_t     *b;
++    size_t      basesize;
++} bo_t;
++
++static inline bool bo_init(bo_t *p_bo, int i_size)
++{
++    p_bo->b = block_Alloc(i_size);
++    if (p_bo->b == NULL)
++        return false;
++
++    p_bo->b->i_buffer = 0;
++    p_bo->basesize = i_size;
++
++    return true;
++}
++
++static inline void bo_deinit(bo_t *p_bo)
++{
++    if(p_bo->b)
++        block_Release(p_bo->b);
++}
++
++static inline void bo_free(bo_t *p_bo)
++{
++    if(!p_bo)
++        return;
++    bo_deinit(p_bo);
++    free(p_bo);
++}
++
++static inline int bo_extend(bo_t *p_bo, size_t i_total)
++{
++    if(!p_bo->b)
++        return false;
++    const size_t i_size = p_bo->b->i_size - (p_bo->b->p_buffer - p_bo->b->p_start);
++    if (i_total >= i_size)
++    {
++        int i_growth = p_bo->basesize;
++        while(i_total >= i_size + i_growth)
++            i_growth += p_bo->basesize;
++
++        int i = p_bo->b->i_buffer; /* Realloc would set payload size == buffer size */
++        p_bo->b = block_Realloc(p_bo->b, 0, i_size + i_growth);
++        if (!p_bo->b)
++            return false;
++        p_bo->b->i_buffer = i;
++    }
++    return true;
++}
++
++#define BO_SET_DECL_S(func, handler, type) static inline bool func(bo_t *p_bo, size_t i_offset, type val)\
++    {\
++        if (!bo_extend(p_bo, i_offset + sizeof(type)))\
++            return false;\
++        handler(&p_bo->b->p_buffer[i_offset], val);\
++        return true;\
++    }
++
++#define BO_ADD_DECL_S(func, handler, type) static inline bool func(bo_t *p_bo, type val)\
++    {\
++        if(!p_bo->b || !handler(p_bo, p_bo->b->i_buffer, val))\
++            return false;\
++        p_bo->b->i_buffer += sizeof(type);\
++        return true;\
++    }
++
++#define BO_FUNC_DECL(suffix, handler, type ) \
++    BO_SET_DECL_S( bo_set_ ## suffix ## be, handler ## BE, type )\
++    BO_SET_DECL_S( bo_set_ ## suffix ## le, handler ## LE, type )\
++    BO_ADD_DECL_S( bo_add_ ## suffix ## be, bo_set_ ## suffix ## be, type )\
++    BO_ADD_DECL_S( bo_add_ ## suffix ## le, bo_set_ ## suffix ## le, type )
++
++static inline bool bo_set_8(bo_t *p_bo, size_t i_offset, uint8_t i)
++{
++    if (!bo_extend(p_bo, i_offset + 1))
++        return false;
++    p_bo->b->p_buffer[i_offset] = i;
++    return true;
++}
++
++static inline bool bo_add_8(bo_t *p_bo, uint8_t i)
++{
++    if(!p_bo->b || !bo_set_8( p_bo, p_bo->b->i_buffer, i ))
++        return false;
++    p_bo->b->i_buffer++;
++    return true;
++}
++
++/* declares all bo_[set,add]_[16,32,64] */
++BO_FUNC_DECL( 16, SetW,  uint16_t )
++BO_FUNC_DECL( 32, SetDW, uint32_t )
++BO_FUNC_DECL( 64, SetQW, uint64_t )
++
++#undef BO_FUNC_DECL
++#undef BO_SET_DECL_S
++#undef BO_ADD_DECL_S
++
++static inline bool bo_add_24be(bo_t *p_bo, uint32_t i)
++{
++    if(!p_bo->b || !bo_extend(p_bo, p_bo->b->i_buffer + 3))
++        return false;
++    p_bo->b->p_buffer[p_bo->b->i_buffer++] = ((i >> 16) & 0xff);
++    p_bo->b->p_buffer[p_bo->b->i_buffer++] = ((i >> 8) & 0xff);
++    p_bo->b->p_buffer[p_bo->b->i_buffer++] = (i & 0xff);
++    return true;
++}
++
++static inline void bo_swap_32be (bo_t *p_bo, size_t i_pos, uint32_t i)
++{
++    if (!p_bo->b || p_bo->b->i_buffer < i_pos + 4)
++        return;
++    p_bo->b->p_buffer[i_pos    ] = (i >> 24)&0xff;
++    p_bo->b->p_buffer[i_pos + 1] = (i >> 16)&0xff;
++    p_bo->b->p_buffer[i_pos + 2] = (i >>  8)&0xff;
++    p_bo->b->p_buffer[i_pos + 3] = (i      )&0xff;
++}
++
++static inline bool bo_add_mem(bo_t *p_bo, size_t i_size, const void *p_mem)
++{
++    if(!p_bo->b || !bo_extend(p_bo, p_bo->b->i_buffer + i_size))
++        return false;
++    memcpy(&p_bo->b->p_buffer[p_bo->b->i_buffer], p_mem, i_size);
++    p_bo->b->i_buffer += i_size;
++    return true;
++}
++
++#define bo_add_fourcc(p_bo, fcc) bo_add_mem(p_bo, 4, fcc)
++
++#endif // VLC_BOXES_H
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_charset.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_charset.h
+new file mode 100644
+index 0000000..cdf3159
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_charset.h
+@@ -0,0 +1,291 @@
++/*****************************************************************************
++ * vlc_charset.h: Unicode UTF-8 wrappers function
++ *****************************************************************************
++ * Copyright (C) 2003-2005 VLC authors and VideoLAN
++ * Copyright © 2005-2010 Rémi Denis-Courmont
++ * $Id: 05092257a4a1f09451dc1e956d07b02093908dd4 $
++ *
++ * Author: Rémi Denis-Courmont <rem # videolan,org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_CHARSET_H
++#define VLC_CHARSET_H 1
++
++/**
++ * \file
++ * Characters sets handling
++ *
++ * \ingroup strings
++ * @{
++ */
++
++/**
++ * Decodes a code point from UTF-8.
++ *
++ * Converts the first character in a UTF-8 sequence into a Unicode code point.
++ *
++ * \param str an UTF-8 bytes sequence [IN]
++ * \param pwc address of a location to store the code point [OUT]
++ *
++ * \return the number of bytes occupied by the decoded code point
++ *
++ * \retval (size_t)-1 not a valid UTF-8 sequence
++ * \retval 0 null character (i.e. str points to an empty string)
++ * \retval 1 (non-null) ASCII character
++ * \retval 2-4 non-ASCII character
++ */
++VLC_API size_t vlc_towc(const char *str, uint32_t *restrict pwc);
++
++/**
++ * Checks UTF-8 validity.
++ *
++ * Checks whether a null-terminated string is a valid UTF-8 bytes sequence.
++ *
++ * \param str string to check
++ *
++ * \retval str the string is a valid null-terminated UTF-8 sequence
++ * \retval NULL the string is not an UTF-8 sequence
++ */
++VLC_USED static inline const char *IsUTF8(const char *str)
++{
++    size_t n;
++    uint32_t cp;
++
++    while ((n = vlc_towc(str, &cp)) != 0)
++        if (likely(n != (size_t)-1))
++            str += n;
++        else
++            return NULL;
++    return str;
++}
++
++/**
++ * Removes non-UTF-8 sequences.
++ *
++ * Replaces invalid or <i>over-long</i> UTF-8 bytes sequences within a
++ * null-terminated string with question marks. This is so that the string can
++ * be printed at least partially.
++ *
++ * \warning Do not use this were correctness is critical. use IsUTF8() and
++ * handle the error case instead. This function is mainly for display or debug.
++ *
++ * \note Converting from Latin-1 to UTF-8 in place is not possible (the string
++ * size would be increased). So it is not attempted even if it would otherwise
++ * be less disruptive.
++ *
++ * \retval str the string is a valid null-terminated UTF-8 sequence
++ *             (i.e. no changes were made)
++ * \retval NULL the string is not an UTF-8 sequence
++ */
++static inline char *EnsureUTF8(char *str)
++{
++    char *ret = str;
++    size_t n;
++    uint32_t cp;
++
++    while ((n = vlc_towc(str, &cp)) != 0)
++        if (likely(n != (size_t)-1))
++            str += n;
++        else
++        {
++            *str++ = '?';
++            ret = NULL;
++        }
++    return ret;
++}
++
++/* iconv wrappers (defined in src/extras/libc.c) */
++#define VLC_ICONV_ERR ((size_t) -1)
++typedef void *vlc_iconv_t;
++VLC_API vlc_iconv_t vlc_iconv_open( const char *, const char * ) VLC_USED;
++VLC_API size_t vlc_iconv( vlc_iconv_t, const char **, size_t *, char **, size_t * ) VLC_USED;
++VLC_API int vlc_iconv_close( vlc_iconv_t );
++
++#include <stdarg.h>
++
++VLC_API int utf8_vfprintf( FILE *stream, const char *fmt, va_list ap );
++VLC_API int utf8_fprintf( FILE *, const char *, ... ) VLC_FORMAT( 2, 3 );
++VLC_API char * vlc_strcasestr(const char *, const char *) VLC_USED;
++
++VLC_API char * FromCharset( const char *charset, const void *data, size_t data_size ) VLC_USED;
++VLC_API void * ToCharset( const char *charset, const char *in, size_t *outsize ) VLC_USED;
++
++#ifdef _WIN32
++VLC_USED
++static inline char *FromWide (const wchar_t *wide)
++{
++    size_t len = WideCharToMultiByte (CP_UTF8, 0, wide, -1, NULL, 0, NULL, NULL);
++    if (len == 0)
++        return NULL;
++
++    char *out = (char *)malloc (len);
++
++    if (likely(out))
++        WideCharToMultiByte (CP_UTF8, 0, wide, -1, out, len, NULL, NULL);
++    return out;
++}
++
++VLC_USED
++static inline wchar_t *ToWide (const char *utf8)
++{
++    int len = MultiByteToWideChar (CP_UTF8, 0, utf8, -1, NULL, 0);
++    if (len == 0)
++        return NULL;
++
++    wchar_t *out = (wchar_t *)malloc (len * sizeof (wchar_t));
++
++    if (likely(out))
++        MultiByteToWideChar (CP_UTF8, 0, utf8, -1, out, len);
++    return out;
++}
++
++VLC_USED VLC_MALLOC
++static inline char *ToCodePage (unsigned cp, const char *utf8)
++{
++    wchar_t *wide = ToWide (utf8);
++    if (wide == NULL)
++        return NULL;
++
++    size_t len = WideCharToMultiByte (cp, 0, wide, -1, NULL, 0, NULL, NULL);
++    if (len == 0) {
++        free(wide);
++        return NULL;
++    }
++
++    char *out = (char *)malloc (len);
++    if (likely(out != NULL))
++        WideCharToMultiByte (cp, 0, wide, -1, out, len, NULL, NULL);
++    free (wide);
++    return out;
++}
++
++VLC_USED VLC_MALLOC
++static inline char *FromCodePage (unsigned cp, const char *mb)
++{
++    int len = MultiByteToWideChar (cp, 0, mb, -1, NULL, 0);
++    if (len == 0)
++        return NULL;
++
++    wchar_t *wide = (wchar_t *)malloc (len * sizeof (wchar_t));
++    if (unlikely(wide == NULL))
++        return NULL;
++    MultiByteToWideChar (cp, 0, mb, -1, wide, len);
++
++    char *utf8 = FromWide (wide);
++    free (wide);
++    return utf8;
++}
++
++VLC_USED VLC_MALLOC
++static inline char *FromANSI (const char *ansi)
++{
++    return FromCodePage (GetACP (), ansi);
++}
++
++VLC_USED VLC_MALLOC
++static inline char *ToANSI (const char *utf8)
++{
++    return ToCodePage (GetACP (), utf8);
++}
++
++# ifdef UNICODE
++#  define FromT FromWide
++#  define ToT   ToWide
++# else
++#  define FromT FromANSI
++#  define ToT   ToANSI
++# endif
++# define FromLocale    FromANSI
++# define ToLocale      ToANSI
++# define LocaleFree(s) free((char *)(s))
++# define FromLocaleDup FromANSI
++# define ToLocaleDup   ToANSI
++
++#elif defined(__OS2__)
++
++VLC_USED static inline char *FromLocale (const char *locale)
++{
++    return locale ? FromCharset ((char *)"", locale, strlen(locale)) : NULL;
++}
++
++VLC_USED static inline char *ToLocale (const char *utf8)
++{
++    size_t outsize;
++    return utf8 ? (char *)ToCharset ("", utf8, &outsize) : NULL;
++}
++
++VLC_USED static inline void LocaleFree (const char *str)
++{
++    free ((char *)str);
++}
++
++VLC_USED static inline char *FromLocaleDup (const char *locale)
++{
++    return FromCharset ("", locale, strlen(locale));
++}
++
++VLC_USED static inline char *ToLocaleDup (const char *utf8)
++{
++    size_t outsize;
++    return (char *)ToCharset ("", utf8, &outsize);
++}
++
++#else
++
++# define FromLocale(l) (l)
++# define ToLocale(u)   (u)
++# define LocaleFree(s) ((void)(s))
++# define FromLocaleDup strdup
++# define ToLocaleDup   strdup
++#endif
++
++/**
++ * Converts a nul-terminated string from ISO-8859-1 to UTF-8.
++ */
++static inline char *FromLatin1 (const char *latin)
++{
++    char *str = (char *)malloc (2 * strlen (latin) + 1), *utf8 = str;
++    unsigned char c;
++
++    if (str == NULL)
++        return NULL;
++
++    while ((c = *(latin++)) != '\0')
++    {
++         if (c >= 0x80)
++         {
++             *(utf8++) = 0xC0 | (c >> 6);
++             *(utf8++) = 0x80 | (c & 0x3F);
++         }
++         else
++             *(utf8++) = c;
++    }
++    *(utf8++) = '\0';
++
++    utf8 = (char *)realloc (str, utf8 - str);
++    return utf8 ? utf8 : str;
++}
++
++/** @} */
++
++VLC_API double us_strtod( const char *, char ** ) VLC_USED;
++VLC_API float us_strtof( const char *, char ** ) VLC_USED;
++VLC_API double us_atof( const char * ) VLC_USED;
++VLC_API int us_vasprintf( char **, const char *, va_list );
++VLC_API int us_asprintf( char **, const char *, ... ) VLC_USED;
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_codec.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_codec.h
+new file mode 100644
+index 0000000..6c77776
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_codec.h
+@@ -0,0 +1,422 @@
++/*****************************************************************************
++ * vlc_codec.h: Definition of the decoder and encoder structures
++ *****************************************************************************
++ * Copyright (C) 1999-2003 VLC authors and VideoLAN
++ * $Id: 3499ede27c1dbb94ff665a51d000c55bd45f2794 $
++ *
++ * Authors: Gildas Bazin <gbazin@netcourrier.com>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_CODEC_H
++#define VLC_CODEC_H 1
++
++#include <assert.h>
++
++#include <vlc_block.h>
++#include <vlc_es.h>
++#include <vlc_picture.h>
++#include <vlc_subpicture.h>
++
++/**
++ * \defgroup codec Codec
++ * Decoders and encoders
++ * @{
++ * \file
++ * Decoder and encoder modules interface
++ *
++ * \defgroup decoder Decoder
++ * Audio, video and text decoders
++ * @{
++ */
++
++typedef struct decoder_owner_sys_t decoder_owner_sys_t;
++
++typedef struct decoder_cc_desc_t decoder_cc_desc_t;
++
++/*
++ * BIG FAT WARNING : the code relies in the first 4 members of filter_t
++ * and decoder_t to be the same, so if you have anything to add, do it
++ * at the end of the structure.
++ */
++struct decoder_t
++{
++    VLC_COMMON_MEMBERS
++
++    /* Module properties */
++    module_t *          p_module;
++    decoder_sys_t *     p_sys;
++
++    /* Input format ie from demuxer (XXX: a lot of field could be invalid) */
++    es_format_t         fmt_in;
++
++    /* Output format of decoder/packetizer */
++    es_format_t         fmt_out;
++
++    /* Tell the decoder if it is allowed to drop frames */
++    bool                b_frame_drop_allowed;
++
++#   define VLCDEC_SUCCESS   VLC_SUCCESS
++#   define VLCDEC_ECRITICAL VLC_EGENERIC
++#   define VLCDEC_RELOAD    (-100)
++    /* This function is called to decode one packetized block.
++     *
++     * The module implementation will own the input block (p_block) and should
++     * process and release it. Depending of the decoder type, the module should
++     * send output frames/blocks via decoder_QueueVideo(), decoder_QueueAudio()
++     * or decoder_QueueSub().
++     *
++     * If p_block is NULL, the decoder asks the module to drain itself. The
++     * module should return all available output frames/block via the queue
++     * functions.
++     *
++     * Return values can be:
++     *  VLCDEC_SUCCESS: pf_decode will be called again
++     *  VLCDEC_ECRITICAL: in case of critical error, pf_decode won't be called
++     *  again.
++     *  VLCDEC_RELOAD: Request that the decoder should be reloaded. The current
++     *  module will be unloaded. Reloading a module may cause a loss of frames.
++     *  When returning this status, the implementation shouldn't release or
++     *  modify the p_block in argument (The same p_block will be feed to the
++     *  next decoder module).
++     */
++    int                 ( * pf_decode )   ( decoder_t *, block_t *p_block );
++
++    /* This function is called in a loop with the same pp_block argument until
++     * it returns NULL. This allows a module implementation to return more than
++     * one output blocks for one input block.
++     *
++     * pp_block or *pp_block can be NULL.
++     *
++     * If pp_block and *pp_block are not NULL, the module implementation will
++     * own the input block (*pp_block) and should process and release it. The
++     * module can also process a part of the block. In that case, it should
++     * modify (*pp_block)->p_buffer/i_buffer accordingly and return a valid
++     * output block. The module can also set *pp_block to NULL when the input
++     * block is consumed.
++     *
++     * If pp_block is not NULL but *pp_block is NULL, a previous call of the pf
++     * function has set the *pp_block to NULL. Here, the module can return new
++     * output block for the same, already processed, input block (the
++     * pf_packetize function will be called as long as the module return an
++     * output block).
++     *
++     * When the pf function returns NULL, the next call to this function will
++     * have a new a valid pp_block (if the packetizer is not drained).
++     *
++     * If pp_block is NULL, the packetizer asks the module to drain itself. In
++     * that case, the module has to return all output frames available (the
++     * pf_packetize function will be called as long as the module return an
++     * output block).
++     */
++    block_t *           ( * pf_packetize )( decoder_t *, block_t **pp_block );
++    /* */
++    void                ( * pf_flush ) ( decoder_t * );
++
++    /* Closed Caption (CEA 608/708) extraction.
++     * If set, it *may* be called after pf_packetize returned data. It should
++     * return CC for the pictures returned by the last pf_packetize call only,
++     * channel bitmaps will be used to known which cc channel are present (but
++     * globaly, not necessary for the current packet. Video decoders should use
++     * the decoder_QueueCc() function to pass closed captions. */
++    block_t *           ( * pf_get_cc )      ( decoder_t *, decoder_cc_desc_t * );
++
++    /* Meta data at codec level
++     *  The decoder owner set it back to NULL once it has retreived what it needs.
++     *  The decoder owner is responsible of its release except when you overwrite it.
++     */
++    vlc_meta_t          *p_description;
++
++    /*
++     * Owner fields
++     * XXX You MUST not use them directly.
++     */
++
++    /* Video output callbacks
++     * XXX use decoder_NewPicture */
++    int             (*pf_vout_format_update)( decoder_t * );
++    picture_t      *(*pf_vout_buffer_new)( decoder_t * );
++
++    /**
++     * Number of extra (ie in addition to the DPB) picture buffers
++     * needed for decoding.
++     */
++    int             i_extra_picture_buffers;
++
++    /* Audio output callbacks */
++    int             (*pf_aout_format_update)( decoder_t * );
++
++    /* SPU output callbacks
++     * XXX use decoder_NewSubpicture */
++    subpicture_t   *(*pf_spu_buffer_new)( decoder_t *, const subpicture_updater_t * );
++
++    /* Input attachments
++     * XXX use decoder_GetInputAttachments */
++    int             (*pf_get_attachments)( decoder_t *p_dec, input_attachment_t ***ppp_attachment, int *pi_attachment );
++
++    /* Display date
++     * XXX use decoder_GetDisplayDate */
++    mtime_t         (*pf_get_display_date)( decoder_t *, mtime_t );
++
++    /* Display rate
++     * XXX use decoder_GetDisplayRate */
++    int             (*pf_get_display_rate)( decoder_t * );
++
++    /* XXX use decoder_QueueVideo or decoder_QueueVideoWithCc */
++    int             (*pf_queue_video)( decoder_t *, picture_t * );
++    /* XXX use decoder_QueueAudio */
++    int             (*pf_queue_audio)( decoder_t *, block_t * );
++    /* XXX use decoder_QueueCC */
++    int             (*pf_queue_cc)( decoder_t *, block_t *, const decoder_cc_desc_t * );
++    /* XXX use decoder_QueueSub */
++    int             (*pf_queue_sub)( decoder_t *, subpicture_t *);
++    void             *p_queue_ctx;
++
++    /* Private structure for the owner of the decoder */
++    decoder_owner_sys_t *p_owner;
++};
++
++/* struct for packetizer get_cc polling/decoder queue_cc
++ * until we have a proper metadata way */
++struct decoder_cc_desc_t
++{
++    uint8_t i_608_channels;  /* 608 channels bitmap */
++    uint64_t i_708_channels; /* 708 */
++    int i_reorder_depth;     /* reorder depth, -1 for no reorder, 0 for old P/B flag based */
++};
++
++/**
++ * @}
++ */
++
++/**
++ * \defgroup encoder Encoder
++ * Audio, video and text encoders
++ * @{
++ */
++
++struct encoder_t
++{
++    VLC_COMMON_MEMBERS
++
++    /* Module properties */
++    module_t *          p_module;
++    encoder_sys_t *     p_sys;
++
++    /* Properties of the input data fed to the encoder */
++    es_format_t         fmt_in;
++
++    /* Properties of the output of the encoder */
++    es_format_t         fmt_out;
++
++    block_t *           ( * pf_encode_video )( encoder_t *, picture_t * );
++    block_t *           ( * pf_encode_audio )( encoder_t *, block_t * );
++    block_t *           ( * pf_encode_sub )( encoder_t *, subpicture_t * );
++
++    /* Common encoder options */
++    int i_threads;               /* Number of threads to use during encoding */
++    int i_iframes;               /* One I frame per i_iframes */
++    int i_bframes;               /* One B frame per i_bframes */
++    int i_tolerance;             /* Bitrate tolerance */
++
++    /* Encoder config */
++    config_chain_t *p_cfg;
++};
++
++/**
++ * @}
++ *
++ * \ingroup decoder
++ * @{
++ */
++
++/**
++ * Updates the video output format.
++ *
++ * This function notifies the video output pipeline of a new video output
++ * format (fmt_out.video). If there was no video output from the decoder so far
++ * or if the video output format has changed, a new video output will be set
++ * up. decoder_NewPicture() can then be used to allocate picture buffers.
++ *
++ * If the format is unchanged, this function has no effects and returns zero.
++ *
++ * \note
++ * This function is not reentrant.
++ *
++ * @return 0 if the video output was set up successfully, -1 otherwise.
++ */
++VLC_USED
++static inline int decoder_UpdateVideoFormat( decoder_t *dec )
++{
++    assert( dec->fmt_in.i_cat == VIDEO_ES );
++    if( dec->fmt_in.i_cat == VIDEO_ES && dec->pf_vout_format_update != NULL )
++        return dec->pf_vout_format_update( dec );
++    else
++        return -1;
++}
++
++/**
++ * Allocates an output picture buffer.
++ *
++ * This function pulls an output picture buffer for the decoder from the
++ * buffer pool of the video output. The picture must be released with
++ * picture_Release() when it is no longer referenced by the decoder.
++ *
++ * \note
++ * This function is reentrant. However, decoder_UpdateVideoFormat() cannot be
++ * used concurrently; the caller is responsible for serialization.
++ *
++ * \warning
++ * The behaviour is undefined if decoder_UpdateVideoFormat() was not called or
++ * if the last call returned an error.
++ *
++ * \return a picture buffer on success, NULL on error
++ */
++VLC_USED
++static inline picture_t *decoder_NewPicture( decoder_t *dec )
++{
++    return dec->pf_vout_buffer_new( dec );
++}
++
++/**
++ * Abort any calls of decoder_NewPicture
++ *
++ * If b_abort is true, all pending and futures calls of decoder_NewPicture
++ * will be aborted. This function can be used by asynchronous video decoders
++ * to unblock a thread that is waiting for a picture.
++ */
++VLC_API void decoder_AbortPictures( decoder_t *dec, bool b_abort );
++
++/**
++ * This function queues a single picture to the video output.
++ *
++ * \note
++ * The caller doesn't own the picture anymore after this call (even in case of
++ * error).
++ * FIXME: input_DecoderFrameNext won't work if a module use this function.
++ *
++ * \return 0 if the picture is queued, -1 on error
++ */
++static inline int decoder_QueueVideo( decoder_t *dec, picture_t *p_pic )
++{
++    assert( p_pic->p_next == NULL );
++    assert( dec->pf_queue_video != NULL );
++    return dec->pf_queue_video( dec, p_pic );
++}
++
++/**
++ * This function queues the Closed Captions
++ *
++ * \param dec the decoder object
++ * \param p_cc the closed-caption to queue
++ * \param p_desc decoder_cc_desc_t description structure
++ * \return 0 if queued, -1 on error
++ */
++static inline int decoder_QueueCc( decoder_t *dec, block_t *p_cc,
++                                   const decoder_cc_desc_t *p_desc )
++{
++    if( dec->pf_queue_cc == NULL )
++    {
++        block_Release( p_cc );
++        return -1;
++    }
++    return dec->pf_queue_cc( dec, p_cc, p_desc );
++}
++
++/**
++ * This function queues a single audio block to the audio output.
++ *
++ * \note
++ * The caller doesn't own the audio block anymore after this call (even in case
++ * of error).
++ *
++ * \return 0 if the block is queued, -1 on error
++ */
++static inline int decoder_QueueAudio( decoder_t *dec, block_t *p_aout_buf )
++{
++    assert( p_aout_buf->p_next == NULL );
++    assert( dec->pf_queue_audio != NULL );
++    return dec->pf_queue_audio( dec, p_aout_buf );
++}
++
++/**
++ * This function queues a single subtitle to the video output.
++ *
++ * \note
++ * The caller doesn't own the subtitle anymore after this call (even in case of
++ * error).
++ *
++ * \return 0 if the subtitle is queued, -1 on error
++ */
++static inline int decoder_QueueSub( decoder_t *dec, subpicture_t *p_spu )
++{
++    assert( p_spu->p_next == NULL );
++    assert( dec->pf_queue_sub != NULL );
++    return dec->pf_queue_sub( dec, p_spu );
++}
++
++/**
++ * This function notifies the audio output pipeline of a new audio output
++ * format (fmt_out.audio). If there is currently no audio output or if the
++ * audio output format has changed, a new audio output will be set up.
++ * @return 0 if the audio output is working, -1 if not. */
++VLC_USED
++static inline int decoder_UpdateAudioFormat( decoder_t *dec )
++{
++    assert(dec->fmt_in.i_cat == AUDIO_ES);
++    if( dec->fmt_in.i_cat == AUDIO_ES && dec->pf_aout_format_update != NULL )
++        return dec->pf_aout_format_update( dec );
++    else
++        return -1;
++}
++
++/**
++ * This function will return a new audio buffer usable by a decoder as an
++ * output buffer. It must be released with block_Release() or returned it to
++ * the caller as a decoder_QueueAudio parameter.
++ */
++VLC_API block_t * decoder_NewAudioBuffer( decoder_t *, int i_nb_samples ) VLC_USED;
++
++/**
++ * This function will return a new subpicture usable by a decoder as an output
++ * buffer. You have to release it using subpicture_Delete() or by returning
++ * it to the caller as a decoder_QueueSub parameter.
++ */
++VLC_API subpicture_t * decoder_NewSubpicture( decoder_t *, const subpicture_updater_t * ) VLC_USED;
++
++/**
++ * This function gives all input attachments at once.
++ *
++ * You MUST release the returned values
++ */
++VLC_API int decoder_GetInputAttachments( decoder_t *, input_attachment_t ***ppp_attachment, int *pi_attachment );
++
++/**
++ * This function converts a decoder timestamp into a display date comparable
++ * to mdate().
++ * You MUST use it *only* for gathering statistics about speed.
++ */
++VLC_API mtime_t decoder_GetDisplayDate( decoder_t *, mtime_t ) VLC_USED;
++
++/**
++ * This function returns the current input rate.
++ * You MUST use it *only* for gathering statistics about speed.
++ */
++VLC_API int decoder_GetDisplayRate( decoder_t * ) VLC_USED;
++
++/** @} */
++/** @} */
++#endif /* _VLC_CODEC_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_common.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_common.h
+new file mode 100644
+index 0000000..12a36ec
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_common.h
+@@ -0,0 +1,1049 @@
++/*****************************************************************************
++ * vlc_common.h: common definitions
++ * Collection of useful common types and macros definitions
++ *****************************************************************************
++ * Copyright (C) 1998-2011 VLC authors and VideoLAN
++ *
++ * Authors: Samuel Hocevar <sam@via.ecp.fr>
++ *          Vincent Seguin <seguin@via.ecp.fr>
++ *          Gildas Bazin <gbazin@videolan.org>
++ *          Rémi Denis-Courmont
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++/**
++ * \file
++ * This file is a collection of common definitions and types
++ */
++
++#ifndef VLC_COMMON_H
++# define VLC_COMMON_H 1
++
++/*****************************************************************************
++ * Required vlc headers
++ *****************************************************************************/
++#include "vlc_config.h"
++
++/*****************************************************************************
++ * Required system headers
++ *****************************************************************************/
++#include <stdlib.h>
++#include <stdarg.h>
++
++#include <string.h>
++#include <stdio.h>
++#include <inttypes.h>
++#include <stddef.h>
++
++#ifndef __cplusplus
++# include <stdbool.h>
++#endif
++
++/*****************************************************************************
++ * Compilers definitions
++ *****************************************************************************/
++/* Helper for GCC version checks */
++#ifdef __GNUC__
++# define VLC_GCC_VERSION(maj,min) \
++    ((__GNUC__ > (maj)) || (__GNUC__ == (maj) && __GNUC_MINOR__ >= (min)))
++#else
++# define VLC_GCC_VERSION(maj,min) (0)
++#endif
++
++/* Try to fix format strings for all versions of mingw and mingw64 */
++#if defined( _WIN32 ) && defined( __USE_MINGW_ANSI_STDIO )
++ #undef PRId64
++ #define PRId64 "lld"
++ #undef PRIi64
++ #define PRIi64 "lli"
++ #undef PRIu64
++ #define PRIu64 "llu"
++ #undef PRIo64
++ #define PRIo64 "llo"
++ #undef PRIx64
++ #define PRIx64 "llx"
++ #define snprintf __mingw_snprintf
++ #define vsnprintf __mingw_vsnprintf
++ #define swprintf _snwprintf
++#endif
++
++/* Function attributes for compiler warnings */
++#ifdef __GNUC__
++# define VLC_DEPRECATED __attribute__((deprecated))
++# if VLC_GCC_VERSION(6,0)
++#  define VLC_DEPRECATED_ENUM __attribute__((deprecated))
++# else
++#  define VLC_DEPRECATED_ENUM
++# endif
++
++# if defined( _WIN32 )
++#  define VLC_FORMAT(x,y) __attribute__ ((format(gnu_printf,x,y)))
++# else
++#  define VLC_FORMAT(x,y) __attribute__ ((format(printf,x,y)))
++# endif
++# define VLC_FORMAT_ARG(x) __attribute__ ((format_arg(x)))
++# define VLC_MALLOC __attribute__ ((malloc))
++# define VLC_USED __attribute__ ((warn_unused_result))
++
++#else
++# define VLC_DEPRECATED
++# define VLC_DEPRECATED_ENUM
++# define VLC_FORMAT(x,y)
++# define VLC_FORMAT_ARG(x)
++# define VLC_MALLOC
++# define VLC_USED
++#endif
++
++
++/* Branch prediction */
++#ifdef __GNUC__
++# define likely(p)     __builtin_expect(!!(p), 1)
++# define unlikely(p)   __builtin_expect(!!(p), 0)
++# define unreachable() __builtin_unreachable()
++#else
++# define likely(p)     (!!(p))
++# define unlikely(p)   (!!(p))
++# define unreachable() ((void)0)
++#endif
++
++#define vlc_assert_unreachable() (assert(!"unreachable"), unreachable())
++
++/* Linkage */
++#ifdef __cplusplus
++# define VLC_EXTERN extern "C"
++#else
++# define VLC_EXTERN
++#endif
++
++#if defined (_WIN32) && defined (DLL_EXPORT)
++# define VLC_EXPORT __declspec(dllexport)
++#elif defined (__GNUC__)
++# define VLC_EXPORT __attribute__((visibility("default")))
++#else
++# define VLC_EXPORT
++#endif
++
++#define VLC_API VLC_EXTERN VLC_EXPORT
++
++
++/*****************************************************************************
++ * Basic types definitions
++ *****************************************************************************/
++/**
++ * High precision date or time interval
++ *
++ * Store a high precision date or time interval. The maximum precision is the
++ * microsecond, and a 64 bits integer is used to avoid overflows (maximum
++ * time interval is then 292271 years, which should be long enough for any
++ * video). Dates are stored as microseconds since a common date (usually the
++ * epoch). Note that date and time intervals can be manipulated using regular
++ * arithmetic operators, and that no special functions are required.
++ */
++typedef int64_t mtime_t;
++
++/**
++ * The vlc_fourcc_t type.
++ *
++ * See http://www.webartz.com/fourcc/ for a very detailed list.
++ */
++typedef uint32_t vlc_fourcc_t;
++
++#ifdef WORDS_BIGENDIAN
++#   define VLC_FOURCC( a, b, c, d ) \
++        ( ((uint32_t)d) | ( ((uint32_t)c) << 8 ) \
++           | ( ((uint32_t)b) << 16 ) | ( ((uint32_t)a) << 24 ) )
++#   define VLC_TWOCC( a, b ) \
++        ( (uint16_t)(b) | ( (uint16_t)(a) << 8 ) )
++
++#else
++#   define VLC_FOURCC( a, b, c, d ) \
++        ( ((uint32_t)a) | ( ((uint32_t)b) << 8 ) \
++           | ( ((uint32_t)c) << 16 ) | ( ((uint32_t)d) << 24 ) )
++#   define VLC_TWOCC( a, b ) \
++        ( (uint16_t)(a) | ( (uint16_t)(b) << 8 ) )
++
++#endif
++
++/**
++ * Translate a vlc_fourcc into its string representation. This function
++ * assumes there is enough room in psz_fourcc to store 4 characters in.
++ *
++ * \param fcc a vlc_fourcc_t
++ * \param psz_fourcc string to store string representation of vlc_fourcc in
++ */
++static inline void vlc_fourcc_to_char( vlc_fourcc_t fcc, char *psz_fourcc )
++{
++    memcpy( psz_fourcc, &fcc, 4 );
++}
++
++/*****************************************************************************
++ * Classes declaration
++ *****************************************************************************/
++
++/* Internal types */
++typedef struct vlc_list_t vlc_list_t;
++typedef struct vlc_object_t vlc_object_t;
++typedef struct libvlc_int_t libvlc_int_t;
++typedef struct date_t date_t;
++
++/* Playlist */
++
++typedef struct playlist_t playlist_t;
++typedef struct playlist_item_t playlist_item_t;
++typedef struct services_discovery_t services_discovery_t;
++typedef struct services_discovery_sys_t services_discovery_sys_t;
++typedef struct vlc_renderer_discovery_t vlc_renderer_discovery_t;
++typedef struct vlc_renderer_item_t vlc_renderer_item_t;
++
++/* Modules */
++typedef struct module_t module_t;
++typedef struct module_config_t module_config_t;
++
++typedef struct config_category_t config_category_t;
++
++/* Input */
++typedef struct input_thread_t input_thread_t;
++typedef struct input_item_t input_item_t;
++typedef struct input_item_node_t input_item_node_t;
++typedef struct access_sys_t access_sys_t;
++typedef struct stream_t     stream_t;
++typedef struct stream_sys_t stream_sys_t;
++typedef struct demux_t  demux_t;
++typedef struct demux_sys_t demux_sys_t;
++typedef struct es_out_t     es_out_t;
++typedef struct es_out_id_t  es_out_id_t;
++typedef struct es_out_sys_t es_out_sys_t;
++typedef struct seekpoint_t seekpoint_t;
++typedef struct info_t info_t;
++typedef struct info_category_t info_category_t;
++typedef struct input_attachment_t input_attachment_t;
++
++/* Format */
++typedef struct audio_format_t audio_format_t;
++typedef struct video_format_t video_format_t;
++typedef struct subs_format_t subs_format_t;
++typedef struct es_format_t es_format_t;
++typedef struct video_palette_t video_palette_t;
++
++/* Audio */
++typedef struct audio_output audio_output_t;
++typedef struct aout_sys_t aout_sys_t;
++typedef audio_format_t audio_sample_format_t;
++
++/* Video */
++typedef struct vout_thread_t vout_thread_t;
++typedef struct vlc_viewpoint_t vlc_viewpoint_t;
++
++typedef video_format_t video_frame_format_t;
++typedef struct picture_t picture_t;
++typedef struct picture_sys_t picture_sys_t;
++
++/* Subpictures */
++typedef struct spu_t spu_t;
++typedef struct subpicture_t subpicture_t;
++typedef struct subpicture_region_t subpicture_region_t;
++
++typedef struct image_handler_t image_handler_t;
++
++/* Stream output */
++typedef struct sout_instance_t sout_instance_t;
++
++typedef struct sout_input_t sout_input_t;
++typedef struct sout_packetizer_input_t sout_packetizer_input_t;
++
++typedef struct sout_access_out_t sout_access_out_t;
++typedef struct sout_access_out_sys_t   sout_access_out_sys_t;
++
++typedef struct sout_mux_t sout_mux_t;
++typedef struct sout_mux_sys_t sout_mux_sys_t;
++
++typedef struct sout_stream_t    sout_stream_t;
++typedef struct sout_stream_sys_t sout_stream_sys_t;
++
++typedef struct config_chain_t       config_chain_t;
++typedef struct session_descriptor_t session_descriptor_t;
++
++/* Decoders */
++typedef struct decoder_t         decoder_t;
++typedef struct decoder_sys_t     decoder_sys_t;
++typedef struct decoder_synchro_t decoder_synchro_t;
++
++/* Encoders */
++typedef struct encoder_t      encoder_t;
++typedef struct encoder_sys_t  encoder_sys_t;
++
++/* Filters */
++typedef struct filter_t filter_t;
++typedef struct filter_sys_t filter_sys_t;
++
++/* Network */
++typedef struct vlc_url_t vlc_url_t;
++
++/* Misc */
++typedef struct iso639_lang_t iso639_lang_t;
++
++/* block */
++typedef struct block_t      block_t;
++typedef struct block_fifo_t block_fifo_t;
++
++/* Hashing */
++typedef struct md5_s md5_t;
++
++/* XML */
++typedef struct xml_t xml_t;
++typedef struct xml_sys_t xml_sys_t;
++typedef struct xml_reader_t xml_reader_t;
++typedef struct xml_reader_sys_t xml_reader_sys_t;
++
++/* vod server */
++typedef struct vod_t     vod_t;
++typedef struct vod_sys_t vod_sys_t;
++typedef struct vod_media_t vod_media_t;
++
++/* VLM */
++typedef struct vlm_t         vlm_t;
++typedef struct vlm_message_t vlm_message_t;
++
++/* misc */
++typedef struct vlc_meta_t    vlc_meta_t;
++typedef struct input_stats_t input_stats_t;
++typedef struct addon_entry_t addon_entry_t;
++
++/* Update */
++typedef struct update_t update_t;
++
++/**
++ * VLC value structure
++ */
++typedef union
++{
++    int64_t         i_int;
++    bool            b_bool;
++    float           f_float;
++    char *          psz_string;
++    void *          p_address;
++    vlc_list_t *    p_list;
++    struct { int32_t x; int32_t y; } coords;
++
++} vlc_value_t;
++
++/**
++ * VLC list structure
++ */
++struct vlc_list_t
++{
++    int          i_type;
++    int          i_count;
++    vlc_value_t *p_values;
++};
++
++/*****************************************************************************
++ * Error values (shouldn't be exposed)
++ *****************************************************************************/
++#define VLC_SUCCESS        (-0) /**< No error */
++#define VLC_EGENERIC       (-1) /**< Unspecified error */
++#define VLC_ENOMEM         (-2) /**< Not enough memory */
++#define VLC_ETIMEOUT       (-3) /**< Timeout */
++#define VLC_ENOMOD         (-4) /**< Module not found */
++#define VLC_ENOOBJ         (-5) /**< Object not found */
++#define VLC_ENOVAR         (-6) /**< Variable not found */
++#define VLC_EBADVAR        (-7) /**< Bad variable value */
++#define VLC_ENOITEM        (-8) /**< Item not found */
++
++/*****************************************************************************
++ * Variable callbacks: called when the value is modified
++ *****************************************************************************/
++typedef int ( * vlc_callback_t ) ( vlc_object_t *,      /* variable's object */
++                                   char const *,            /* variable name */
++                                   vlc_value_t,                 /* old value */
++                                   vlc_value_t,                 /* new value */
++                                   void * );                /* callback data */
++
++/*****************************************************************************
++ * List callbacks: called when elements are added/removed from the list
++ *****************************************************************************/
++typedef int ( * vlc_list_callback_t ) ( vlc_object_t *,      /* variable's object */
++                                        char const *,            /* variable name */
++                                        int,                  /* VLC_VAR_* action */
++                                        vlc_value_t *,      /* new/deleted value  */
++                                        void *);                 /* callback data */
++
++/*****************************************************************************
++ * OS-specific headers and thread types
++ *****************************************************************************/
++#if defined( _WIN32 )
++#   include <malloc.h>
++#   ifndef PATH_MAX
++#       define PATH_MAX MAX_PATH
++#   endif
++#   include <windows.h>
++#endif
++
++#ifdef __APPLE__
++#include <sys/syslimits.h>
++#include <AvailabilityMacros.h>
++#endif
++
++#ifdef __OS2__
++#   define OS2EMX_PLAIN_CHAR
++#   define INCL_BASE
++#   define INCL_PM
++#   include <os2safe.h>
++#   include <os2.h>
++#endif
++
++#include "vlc_mtime.h"
++#include "vlc_threads.h"
++
++/**
++ * Common structure members
++ *****************************************************************************/
++
++/**
++ * VLC object common members
++ *
++ * Common public properties for all VLC objects.
++ * Object also have private properties maintained by the core, see
++ * \ref vlc_object_internals_t
++ */
++struct vlc_common_members
++{
++    /** Object type name
++     *
++     * A constant string identifying the type of the object (for logging)
++     */
++    const char *object_type;
++
++    /** Log messages header
++     *
++     * Human-readable header for log messages. This is not thread-safe and
++     * only used by VLM and Lua interfaces.
++     */
++    char *header;
++
++    int  flags;
++
++    /** Module probe flag
++     *
++     * A boolean during module probing when the probe is "forced".
++     * See \ref module_need().
++     */
++    bool force;
++
++    /** LibVLC instance
++     *
++     * Root VLC object of the objects tree that this object belongs in.
++     */
++    libvlc_int_t *libvlc;
++
++    /** Parent object
++     *
++     * The parent VLC object in the objects tree. For the root (the LibVLC
++     * instance) object, this is NULL.
++     */
++    vlc_object_t *parent;
++};
++
++/**
++ * Backward compatibility macro
++ */
++#define VLC_COMMON_MEMBERS struct vlc_common_members obj;
++
++/**
++ * Type-safe vlc_object_t cast
++ *
++ * This macro attempts to cast a pointer to a compound type to a
++ * \ref vlc_object_t pointer in a type-safe manner.
++ * It checks if the compound type actually starts with an embedded
++ * \ref vlc_object_t structure.
++ */
++#if !defined(__cplusplus)
++# define VLC_OBJECT(x) \
++    _Generic((x)->obj, \
++        struct vlc_common_members: (vlc_object_t *)(&(x)->obj), \
++        const struct vlc_common_members: (const vlc_object_t *)(&(x)->obj) \
++    )
++#else
++# define VLC_OBJECT( x ) ((vlc_object_t *)&(x)->obj)
++#endif
++
++/*****************************************************************************
++ * Macros and inline functions
++ *****************************************************************************/
++
++/* __MAX and __MIN: self explanatory */
++#ifndef __MAX
++#   define __MAX(a, b)   ( ((a) > (b)) ? (a) : (b) )
++#endif
++#ifndef __MIN
++#   define __MIN(a, b)   ( ((a) < (b)) ? (a) : (b) )
++#endif
++
++/* clip v in [min, max] */
++#define VLC_CLIP(v, min, max)    __MIN(__MAX((v), (min)), (max))
++
++VLC_USED
++static inline int64_t GCD ( int64_t a, int64_t b )
++{
++    while( b )
++    {
++        int64_t c = a % b;
++        a = b;
++        b = c;
++    }
++    return a;
++}
++
++/* function imported from libavutil/common.h */
++VLC_USED
++static inline uint8_t clip_uint8_vlc( int32_t a )
++{
++    if( a&(~255) ) return (-a)>>31;
++    else           return a;
++}
++
++/** Count leading zeroes */
++VLC_USED
++static inline unsigned (clz)(unsigned x)
++{
++#ifdef __GNUC__
++    return __builtin_clz (x);
++#else
++    unsigned i = sizeof (x) * 8;
++
++    while (x)
++    {
++        x >>= 1;
++        i--;
++    }
++    return i;
++#endif
++}
++
++#define clz8( x ) (clz(x) - ((sizeof(unsigned) - sizeof (uint8_t)) * 8))
++#define clz16( x ) (clz(x) - ((sizeof(unsigned) - sizeof (uint16_t)) * 8))
++/* XXX: this assumes that int is 32-bits or more */
++#define clz32( x ) (clz(x) - ((sizeof(unsigned) - sizeof (uint32_t)) * 8))
++
++/** Count trailing zeroes */
++VLC_USED
++static inline unsigned (ctz)(unsigned x)
++{
++#ifdef __GNUC__
++    return __builtin_ctz (x);
++#else
++    unsigned i = sizeof (x) * 8;
++
++    while (x)
++    {
++        x <<= 1;
++        i--;
++    }
++    return i;
++#endif
++}
++
++#if !defined(__NetBSD__)
++/** Bit weight */
++VLC_USED
++static inline unsigned (popcount)(unsigned x)
++{
++#ifdef __GNUC__
++    return __builtin_popcount (x);
++#else
++    unsigned count = 0;
++    while (x)
++    {
++        count += x & 1;
++        x = x >> 1;
++    }
++    return count;
++#endif
++}
++
++/** Bit weight of long long */
++VLC_USED
++static inline int (popcountll)(unsigned long long x)
++{
++#ifdef __GNUC__
++    return __builtin_popcountll(x);
++#else
++    int count = 0;
++    while (x)
++    {
++        count += x & 1;
++        x = x >> 1;
++    }
++    return count;
++#endif
++}
++#endif
++
++VLC_USED
++static inline unsigned (parity)(unsigned x)
++{
++#ifdef __GNUC__
++    return __builtin_parity (x);
++#else
++    for (unsigned i = 4 * sizeof (x); i > 0; i /= 2)
++        x ^= x >> i;
++    return x & 1;
++#endif
++}
++
++#if !defined(__NetBSD__)
++/** Byte swap (16 bits) */
++VLC_USED
++static inline uint16_t (bswap16)(uint16_t x)
++{
++    return (x << 8) | (x >> 8);
++}
++
++/** Byte swap (32 bits) */
++VLC_USED
++static inline uint32_t (bswap32)(uint32_t x)
++{
++#if defined (__GNUC__) || defined(__clang__)
++    return __builtin_bswap32 (x);
++#else
++    return ((x & 0x000000FF) << 24)
++         | ((x & 0x0000FF00) <<  8)
++         | ((x & 0x00FF0000) >>  8)
++         | ((x & 0xFF000000) >> 24);
++#endif
++}
++
++/** Byte swap (64 bits) */
++VLC_USED
++static inline uint64_t (bswap64)(uint64_t x)
++{
++#if defined (__GNUC__) || defined(__clang__)
++    return __builtin_bswap64 (x);
++#elif !defined (__cplusplus)
++    return ((x & 0x00000000000000FF) << 56)
++         | ((x & 0x000000000000FF00) << 40)
++         | ((x & 0x0000000000FF0000) << 24)
++         | ((x & 0x00000000FF000000) <<  8)
++         | ((x & 0x000000FF00000000) >>  8)
++         | ((x & 0x0000FF0000000000) >> 24)
++         | ((x & 0x00FF000000000000) >> 40)
++         | ((x & 0xFF00000000000000) >> 56);
++#else
++    return ((x & 0x00000000000000FFULL) << 56)
++         | ((x & 0x000000000000FF00ULL) << 40)
++         | ((x & 0x0000000000FF0000ULL) << 24)
++         | ((x & 0x00000000FF000000ULL) <<  8)
++         | ((x & 0x000000FF00000000ULL) >>  8)
++         | ((x & 0x0000FF0000000000ULL) >> 24)
++         | ((x & 0x00FF000000000000ULL) >> 40)
++         | ((x & 0xFF00000000000000ULL) >> 56);
++#endif
++}
++#endif
++
++/* Integer overflow */
++static inline bool uadd_overflow(unsigned a, unsigned b, unsigned *res)
++{
++#if VLC_GCC_VERSION(5,0) || defined(__clang__)
++     return __builtin_uadd_overflow(a, b, res);
++#else
++     *res = a + b;
++     return (a + b) < a;
++#endif
++}
++
++static inline bool uaddl_overflow(unsigned long a, unsigned long b,
++                                  unsigned long *res)
++{
++#if VLC_GCC_VERSION(5,0) || defined(__clang__)
++     return __builtin_uaddl_overflow(a, b, res);
++#else
++     *res = a + b;
++     return (a + b) < a;
++#endif
++}
++
++static inline bool uaddll_overflow(unsigned long long a, unsigned long long b,
++                                   unsigned long long *res)
++{
++#if VLC_GCC_VERSION(5,0) || defined(__clang__)
++     return __builtin_uaddll_overflow(a, b, res);
++#else
++     *res = a + b;
++     return (a + b) < a;
++#endif
++}
++
++#ifndef __cplusplus
++# define add_overflow(a,b,r) \
++    _Generic(*(r), \
++        unsigned: uadd_overflow(a, b, (unsigned *)(r)), \
++        unsigned long: uaddl_overflow(a, b, (unsigned long *)(r)), \
++        unsigned long long: uaddll_overflow(a, b, (unsigned long long *)(r)))
++#else
++static inline bool add_overflow(unsigned a, unsigned b, unsigned *res)
++{
++    return uadd_overflow(a, b, res);
++}
++
++static inline bool add_overflow(unsigned long a, unsigned long b,
++                                unsigned long *res)
++{
++    return uaddl_overflow(a, b, res);
++}
++
++static inline bool add_overflow(unsigned long long a, unsigned long long b,
++                                unsigned long long *res)
++{
++    return uaddll_overflow(a, b, res);
++}
++#endif
++
++#if !(VLC_GCC_VERSION(5,0) || defined(__clang__))
++# include <limits.h>
++#endif
++
++static inline bool umul_overflow(unsigned a, unsigned b, unsigned *res)
++{
++#if VLC_GCC_VERSION(5,0) || defined(__clang__)
++     return __builtin_umul_overflow(a, b, res);
++#else
++     *res = a * b;
++     return b > 0 && a > (UINT_MAX / b);
++#endif
++}
++
++static inline bool umull_overflow(unsigned long a, unsigned long b,
++                                  unsigned long *res)
++{
++#if VLC_GCC_VERSION(5,0) || defined(__clang__)
++     return __builtin_umull_overflow(a, b, res);
++#else
++     *res = a * b;
++     return b > 0 && a > (ULONG_MAX / b);
++#endif
++}
++
++static inline bool umulll_overflow(unsigned long long a, unsigned long long b,
++                                   unsigned long long *res)
++{
++#if VLC_GCC_VERSION(5,0) || defined(__clang__)
++     return __builtin_umulll_overflow(a, b, res);
++#else
++     *res = a * b;
++     return b > 0 && a > (ULLONG_MAX / b);
++#endif
++}
++
++#ifndef __cplusplus
++#define mul_overflow(a,b,r) \
++    _Generic(*(r), \
++        unsigned: umul_overflow(a, b, (unsigned *)(r)), \
++        unsigned long: umull_overflow(a, b, (unsigned long *)(r)), \
++        unsigned long long: umulll_overflow(a, b, (unsigned long long *)(r)))
++#else
++static inline bool mul_overflow(unsigned a, unsigned b, unsigned *res)
++{
++    return umul_overflow(a, b, res);
++}
++
++static inline bool mul_overflow(unsigned long a, unsigned long b,
++                                unsigned long *res)
++{
++    return umull_overflow(a, b, res);
++}
++
++static inline bool mul_overflow(unsigned long long a, unsigned long long b,
++                                unsigned long long *res)
++{
++    return umulll_overflow(a, b, res);
++}
++#endif
++
++/* Free and set set the variable to NULL */
++#define FREENULL(a) do { free( a ); a = NULL; } while(0)
++
++#define EMPTY_STR(str) (!str || !*str)
++
++VLC_API char const * vlc_error( int ) VLC_USED;
++
++#include <vlc_arrays.h>
++
++/* MSB (big endian)/LSB (little endian) conversions - network order is always
++ * MSB, and should be used for both network communications and files. */
++
++#ifdef WORDS_BIGENDIAN
++# define hton16(i) ((uint16_t)(i))
++# define hton32(i) ((uint32_t)(i))
++# define hton64(i) ((uint64_t)(i))
++#else
++# define hton16(i) bswap16(i)
++# define hton32(i) bswap32(i)
++# define hton64(i) bswap64(i)
++#endif
++#define ntoh16(i) hton16(i)
++#define ntoh32(i) hton32(i)
++#define ntoh64(i) hton64(i)
++
++/** Reads 16 bits in network byte order */
++VLC_USED
++static inline uint16_t U16_AT (const void *p)
++{
++    uint16_t x;
++
++    memcpy (&x, p, sizeof (x));
++    return ntoh16 (x);
++}
++
++/** Reads 32 bits in network byte order */
++VLC_USED
++static inline uint32_t U32_AT (const void *p)
++{
++    uint32_t x;
++
++    memcpy (&x, p, sizeof (x));
++    return ntoh32 (x);
++}
++
++/** Reads 64 bits in network byte order */
++VLC_USED
++static inline uint64_t U64_AT (const void *p)
++{
++    uint64_t x;
++
++    memcpy (&x, p, sizeof (x));
++    return ntoh64 (x);
++}
++
++#define GetWBE(p)  U16_AT(p)
++#define GetDWBE(p) U32_AT(p)
++#define GetQWBE(p) U64_AT(p)
++
++/** Reads 16 bits in little-endian order */
++VLC_USED
++static inline uint16_t GetWLE (const void *p)
++{
++    uint16_t x;
++
++    memcpy (&x, p, sizeof (x));
++#ifdef WORDS_BIGENDIAN
++    x = bswap16 (x);
++#endif
++    return x;
++}
++
++/** Reads 32 bits in little-endian order */
++VLC_USED
++static inline uint32_t GetDWLE (const void *p)
++{
++    uint32_t x;
++
++    memcpy (&x, p, sizeof (x));
++#ifdef WORDS_BIGENDIAN
++    x = bswap32 (x);
++#endif
++    return x;
++}
++
++/** Reads 64 bits in little-endian order */
++VLC_USED
++static inline uint64_t GetQWLE (const void *p)
++{
++    uint64_t x;
++
++    memcpy (&x, p, sizeof (x));
++#ifdef WORDS_BIGENDIAN
++    x = bswap64 (x);
++#endif
++    return x;
++}
++
++/** Writes 16 bits in network byte order */
++static inline void SetWBE (void *p, uint16_t w)
++{
++    w = hton16 (w);
++    memcpy (p, &w, sizeof (w));
++}
++
++/** Writes 32 bits in network byte order */
++static inline void SetDWBE (void *p, uint32_t dw)
++{
++    dw = hton32 (dw);
++    memcpy (p, &dw, sizeof (dw));
++}
++
++/** Writes 64 bits in network byte order */
++static inline void SetQWBE (void *p, uint64_t qw)
++{
++    qw = hton64 (qw);
++    memcpy (p, &qw, sizeof (qw));
++}
++
++/** Writes 16 bits in little endian order */
++static inline void SetWLE (void *p, uint16_t w)
++{
++#ifdef WORDS_BIGENDIAN
++    w = bswap16 (w);
++#endif
++    memcpy (p, &w, sizeof (w));
++}
++
++/** Writes 32 bits in little endian order */
++static inline void SetDWLE (void *p, uint32_t dw)
++{
++#ifdef WORDS_BIGENDIAN
++    dw = bswap32 (dw);
++#endif
++    memcpy (p, &dw, sizeof (dw));
++}
++
++/** Writes 64 bits in little endian order */
++static inline void SetQWLE (void *p, uint64_t qw)
++{
++#ifdef WORDS_BIGENDIAN
++    qw = bswap64 (qw);
++#endif
++    memcpy (p, &qw, sizeof (qw));
++}
++
++/* */
++#define VLC_UNUSED(x) (void)(x)
++
++/* Stuff defined in src/extras/libc.c */
++
++#if defined(_WIN32)
++/* several type definitions */
++#   if defined( __MINGW32__ )
++#       if !defined( _OFF_T_ )
++            typedef long long _off_t;
++            typedef _off_t off_t;
++#           define _OFF_T_
++#       else
++#           ifdef off_t
++#               undef off_t
++#           endif
++#           define off_t long long
++#       endif
++#   endif
++
++#   ifndef O_NONBLOCK
++#       define O_NONBLOCK 0
++#   endif
++
++#   include <tchar.h>
++#endif /* _WIN32 */
++
++typedef struct {
++    unsigned num, den;
++} vlc_rational_t;
++
++VLC_API bool vlc_ureduce( unsigned *, unsigned *, uint64_t, uint64_t, uint64_t );
++
++#define container_of(ptr, type, member) \
++    ((type *)(((char *)(ptr)) - offsetof(type, member)))
++
++VLC_USED VLC_MALLOC
++static inline void *vlc_alloc(size_t count, size_t size)
++{
++    return mul_overflow(count, size, &size) ? NULL : malloc(size);
++}
++
++/*****************************************************************************
++ * I18n stuff
++ *****************************************************************************/
++VLC_API char *vlc_gettext( const char *msgid ) VLC_FORMAT_ARG(1);
++VLC_API char *vlc_ngettext( const char *s, const char *p, unsigned long n ) VLC_FORMAT_ARG(1) VLC_FORMAT_ARG(2);
++
++#define vlc_pgettext( ctx, id ) \
++        vlc_pgettext_aux( ctx "\004" id, id )
++
++VLC_FORMAT_ARG(2)
++static inline const char *vlc_pgettext_aux( const char *ctx, const char *id )
++{
++    const char *tr = vlc_gettext( ctx );
++    return (tr == ctx) ? id : tr;
++}
++
++/*****************************************************************************
++ * Loosy memory allocation functions. Do not use in new code.
++ *****************************************************************************/
++static inline void *xmalloc(size_t len)
++{
++    void *ptr = malloc(len);
++    if (unlikely(ptr == NULL && len > 0))
++        abort();
++    return ptr;
++}
++
++static inline void *xrealloc(void *ptr, size_t len)
++{
++    void *nptr = realloc(ptr, len);
++    if (unlikely(nptr == NULL && len > 0))
++        abort();
++    return nptr;
++}
++
++static inline void *xcalloc(size_t n, size_t size)
++{
++    void *ptr = calloc(n, size);
++    if (unlikely(ptr == NULL && (n > 0 || size > 0)))
++        abort ();
++    return ptr;
++}
++
++static inline char *xstrdup (const char *str)
++{
++    char *ptr = strdup (str);
++    if (unlikely(ptr == NULL))
++        abort ();
++    return ptr;
++}
++
++/*****************************************************************************
++ * libvlc features
++ *****************************************************************************/
++VLC_API const char * VLC_CompileBy( void ) VLC_USED;
++VLC_API const char * VLC_CompileHost( void ) VLC_USED;
++VLC_API const char * VLC_Compiler( void ) VLC_USED;
++
++/*****************************************************************************
++ * Additional vlc stuff
++ *****************************************************************************/
++#include "vlc_messages.h"
++#include "vlc_objects.h"
++#include "vlc_variables.h"
++#include "vlc_main.h"
++#include "vlc_configuration.h"
++
++#if defined( _WIN32 ) || defined( __OS2__ )
++#   define DIR_SEP_CHAR '\\'
++#   define DIR_SEP "\\"
++#   define PATH_SEP_CHAR ';'
++#   define PATH_SEP ";"
++#else
++#   define DIR_SEP_CHAR '/'
++#   define DIR_SEP "/"
++#   define PATH_SEP_CHAR ':'
++#   define PATH_SEP ":"
++#endif
++
++#define LICENSE_MSG \
++  _("This program comes with NO WARRANTY, to the extent permitted by " \
++    "law.\nYou may redistribute it under the terms of the GNU General " \
++    "Public License;\nsee the file named COPYING for details.\n" \
++    "Written by the VideoLAN team; see the AUTHORS file.\n")
++
++#endif /* !VLC_COMMON_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_config.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_config.h
+new file mode 100644
+index 0000000..50b4887
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_config.h
+@@ -0,0 +1,114 @@
++/*****************************************************************************
++ * vlc_config.h: limits and configuration
++ * Defines all compilation-time configuration constants and size limits
++ *****************************************************************************
++ * Copyright (C) 1999-2003 VLC authors and VideoLAN
++ *
++ * Authors: Vincent Seguin <seguin@via.ecp.fr>
++ *          Samuel Hocevar <sam@via.ecp.fr>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++/**
++ * \file
++ * This file defines of values used in interface, vout, aout and vlc core functions.
++ */
++
++/* Conventions regarding names of symbols and variables
++ * ----------------------------------------------------
++ *
++ * - Symbols should begin with a prefix indicating in which module they are
++ *   used, such as INTF_, VOUT_ or AOUT_.
++ */
++
++/*****************************************************************************
++ * General configuration
++ *****************************************************************************/
++
++/* All timestamp below or equal to this define are invalid/unset
++ * XXX the numerical value is 0 because of historical reason and will change.*/
++#define VLC_TS_INVALID INT64_C(0)
++#define VLC_TS_0 INT64_C(1)
++
++#define CLOCK_FREQ INT64_C(1000000)
++
++/*****************************************************************************
++ * Interface configuration
++ *****************************************************************************/
++
++/* Base delay in micro second for interface sleeps */
++#define INTF_IDLE_SLEEP                 (CLOCK_FREQ/20)
++
++/*****************************************************************************
++ * Input thread configuration
++ *****************************************************************************/
++
++/* Used in ErrorThread */
++#define INPUT_IDLE_SLEEP                (CLOCK_FREQ/10)
++
++/*
++ * General limitations
++ */
++
++/* Duration between the time we receive the data packet, and the time we will
++ * mark it to be presented */
++#define DEFAULT_PTS_DELAY               (3*CLOCK_FREQ/10)
++
++/*****************************************************************************
++ * SPU configuration
++ *****************************************************************************/
++
++/* Buffer must avoid arriving more than SPU_MAX_PREPARE_TIME in advanced to
++ * the SPU */
++#define SPU_MAX_PREPARE_TIME            (CLOCK_FREQ/2)
++
++/*****************************************************************************
++ * Video configuration
++ *****************************************************************************/
++
++/*
++ * Default settings for video output threads
++ */
++
++/* Multiplier value for aspect ratio calculation (2^7 * 3^3 * 5^3) */
++#define VOUT_ASPECT_FACTOR              432000
++
++/* Maximum width of a scaled source picture - this should be relatively high,
++ * since higher stream values will result in no display at all. */
++#define VOUT_MAX_WIDTH                  4096
++
++/* Number of planes in a picture */
++#define VOUT_MAX_PLANES                 5
++
++/*
++ * Time settings
++ */
++
++/* Time to sleep when waiting for a buffer (from vout or the video fifo).
++ * It should be approximately the time needed to perform a complete picture
++ * loop. Since it only happens when the video heap is full, it does not need
++ * to be too low, even if it blocks the decoder. */
++#define VOUT_OUTMEM_SLEEP               (CLOCK_FREQ/50)
++
++/* The default video output window title */
++#define VOUT_TITLE                      "VLC"
++
++/*****************************************************************************
++ * Messages and console interfaces configuration
++ *****************************************************************************/
++
++/* Maximal depth of the object tree output by vlc_dumpstructure */
++#define MAX_DUMPSTRUCTURE_DEPTH         100
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_config_cat.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_config_cat.h
+new file mode 100644
+index 0000000..e35345b
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_config_cat.h
+@@ -0,0 +1,271 @@
++/*****************************************************************************
++ * vlc_config_cat.h : Definition of configuration categories
++ *****************************************************************************
++ * Copyright (C) 2003 VLC authors and VideoLAN
++ * $Id: 55d2e468d1ccc3fcd8d165dcecc10ec753021a5e $
++ *
++ * Authors: Clément Stenac <zorglub@videolan.org>
++ *          Anil Daoud <anil@videolan.org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_HELP_H
++#define VLC_HELP_H 1
++# include <vlc_plugin.h>
++
++/*
++ *  First, we need help strings for the General Settings and for the
++ *  Plugins screen
++ */
++#define MAIN_TITLE N_( "VLC preferences" )
++#define MAIN_HELP N_( \
++    "Select \"Advanced Options\" to see all options." )
++
++/* Interface */
++#define INTF_TITLE N_("Interface")
++#define INTF_HELP  N_( "Settings for VLC's interfaces" )
++
++#define INTF_GENERAL_HELP N_( "Main interfaces settings" )
++
++#define INTF_MAIN_TITLE  N_( "Main interfaces" )
++#define INTF_MAIN_HELP N_( "Settings for the main interface" )
++
++#define INTF_CONTROL_TITLE N_( "Control interfaces" )
++#define INTF_CONTROL_HELP N_( "Settings for VLC's control interfaces" )
++
++#define INTF_HOTKEYS_TITLE N_( "Hotkeys settings" )
++#define INTF_HOTKEYS_HELP N_( "Hotkeys settings" )
++
++/* Audio */
++#define AUDIO_TITLE N_( "Audio" )
++#define AUDIO_HELP N_( "Audio settings" )
++
++#define AUDIO_GENERAL_HELP N_("General audio settings")
++
++#define AFILTER_TITLE N_("Filters")
++#define AFILTER_HELP N_( "Audio filters are used to process the audio stream." )
++
++#define ARESAMPLER_TITLE N_("Audio resampler")
++
++#define AVISUAL_TITLE N_("Visualizations")
++#define AVISUAL_HELP N_( "Audio visualizations" )
++
++#define AOUT_TITLE N_( "Output modules" )
++#define AOUT_HELP N_("General settings for audio output modules.")
++
++#define AMISC_TITLE N_("Miscellaneous")
++#define AMISC_HELP N_( "Miscellaneous audio settings and modules." )
++
++/* Video */
++#define VIDEO_TITLE N_("Video")
++#define VIDEO_HELP N_("Video settings")
++
++#define VIDEO_GENERAL_HELP N_( "General video settings" )
++
++#define _VOUT_TITLE N_("Output modules" )
++#define VOUT_HELP N_("General settings for video output modules.")
++
++#define VFILTER_TITLE N_("Filters" )
++#define VFILTER_HELP N_("Video filters are used to process the video stream." )
++
++#define SUBPIC_TITLE N_( "Subtitles / OSD")
++#define SUBPIC_HELP N_( "Settings related to On-Screen-Display,"\
++        " subtitles and \"overlay subpictures\"")
++
++#define SPLITTER_TITLE N_("Splitters")
++#define SPLITTER_HELP N_("Video splitters separate the stream into multiple videos.")
++
++/*
++#define TEXT_HELP N_( \
++    "Use the settings of the \"freetype\" module to choose the font you " \
++    "want VLC to use for text rendering (to display subtitles for example).")
++*/
++/* Input */
++#define INPUT_TITLE N_( "Input / Codecs" )
++#define INPUT_HELP N_( "Settings for input, demultiplexing, " \
++         "decoding and encoding")
++
++#define ACCESS_TITLE N_( "Access modules" )
++#define ACCESS_HELP N_( \
++    "Settings related to the various access methods. " \
++    "Common settings you may want to alter are HTTP proxy or " \
++    "caching settings." )
++
++#define STREAM_FILTER_TITLE N_( "Stream filters" )
++#define STREAM_FILTER_HELP N_( \
++    "Stream filters are special modules that allow advanced operations on " \
++    "the input side of VLC. Use with care..." )
++
++#define DEMUX_TITLE N_("Demuxers")
++#define DEMUX_HELP N_( "Demuxers are used to separate audio and video streams." )
++
++#define VDEC_TITLE  N_( "Video codecs" )
++#define VDEC_HELP N_( "Settings for the video, images or video+audio decoders and encoders." )
++
++#define ADEC_TITLE  N_( "Audio codecs" )
++#define ADEC_HELP N_( "Settings for the audio-only decoders and encoders." )
++
++#define SDEC_TITLE N_( "Subtitle codecs")
++#define SDEC_HELP N_( "Settings for subtitle, teletext and CC decoders and encoders." )
++
++#define ADVANCED_HELP N_( "General input settings. Use with care..." )
++
++/* Sout */
++#define SOUT_TITLE N_( "Stream output" )
++#define SOUT_HELP N_( \
++      "Stream output settings are used when acting as a streaming server " \
++      "or when saving incoming streams.\n" \
++      "Streams are first muxed and then sent through an \"access output\" "\
++      "module that can either save the stream to a file, or stream " \
++      "it (UDP, HTTP, RTP/RTSP).\n" \
++      "Sout streams modules allow advanced stream processing (transcoding, "\
++      "duplicating...).")
++
++#define SOUT_GENERAL_HELP N_( "General stream output settings")
++
++#define SOUT_MUX_TITLE N_( "Muxers" )
++#define SOUT_MUX_HELP N_( \
++       "Muxers create the encapsulation formats that are used to " \
++       "put all the elementary streams (video, audio, ...) " \
++       "together. This setting allows you to always force a specific muxer. " \
++       "You should probably not do that.\n" \
++       "You can also set default parameters for each muxer." )
++
++#define SOUT_ACO_TITLE N_( "Access output" )
++#define SOUT_ACO_HELP N_( \
++   "Access output modules control the ways the muxed streams are sent. " \
++   "This setting allows you to always force a specific access output method. " \
++   "You should probably not do that.\n" \
++   "You can also set default parameters for each access output.")
++
++#define SOUT_PACKET_TITLE N_( "Packetizers" )
++#define SOUT_PACKET_HELP N_( \
++        "Packetizers are used to \"preprocess\" the elementary "\
++        "streams before muxing. " \
++        "This setting allows you to always force a packetizer. " \
++        "You should probably not do that.\n" \
++        "You can also set default parameters for each packetizer." )
++
++#define SOUT_STREAM_TITLE N_("Sout stream")
++#define SOUT_STREAM_HELP N_( "Sout stream modules allow to build a sout " \
++                "processing chain. Please refer to the Streaming Howto for " \
++                "more information. You can configure default options for " \
++                "each sout stream module here.")
++
++#define SOUT_VOD_TITLE N_( "VOD" )
++#define SOUT_VOD_HELP N_( "VLC's implementation of Video On Demand" )
++
++
++/* Playlist */
++#define PLAYLIST_TITLE N_( "Playlist" )
++#define PLAYLIST_HELP N_( "Settings related to playlist behaviour " \
++        "(e.g. playback mode) and to modules that automatically add "\
++        "items to the playlist (\"service discovery\" modules).")
++
++#define PGENERAL_HELP N_( "General playlist behaviour")
++#define SD_TITLE N_("Services discovery")
++#define SD_HELP N_("Services discovery modules are facilities "\
++        "that automatically add items to playlist.")
++
++/* Advanced */
++#define AADVANCED_TITLE N_( "Advanced" )
++#define AADVANCED_HELP N_( "Advanced settings. Use with care...")
++
++#define MISC_TITLE N_( "Advanced settings" )
++
++/* This function is deprecated and is kept only for compatibility */
++static const struct config_category_t categories_array[] =
++{
++    /* Interface */
++    { CAT_INTERFACE, INTF_TITLE, INTF_HELP },
++    { SUBCAT_INTERFACE_GENERAL, INTF_TITLE, INTF_GENERAL_HELP },
++    { SUBCAT_INTERFACE_MAIN, INTF_MAIN_TITLE, INTF_MAIN_HELP },
++    { SUBCAT_INTERFACE_CONTROL, INTF_CONTROL_TITLE, INTF_CONTROL_HELP },
++    { SUBCAT_INTERFACE_HOTKEYS, INTF_HOTKEYS_TITLE, INTF_HOTKEYS_HELP },
++
++    { CAT_AUDIO, AUDIO_TITLE, AUDIO_HELP },
++    { SUBCAT_AUDIO_GENERAL, AUDIO_TITLE, AUDIO_GENERAL_HELP },
++    { SUBCAT_AUDIO_AOUT, AOUT_TITLE, AOUT_HELP },
++    { SUBCAT_AUDIO_AFILTER, AFILTER_TITLE, AFILTER_HELP },
++    { SUBCAT_AUDIO_RESAMPLER, ARESAMPLER_TITLE, AFILTER_HELP },
++    { SUBCAT_AUDIO_VISUAL, AVISUAL_TITLE, AVISUAL_HELP },
++    { SUBCAT_AUDIO_MISC, AMISC_TITLE, AMISC_HELP },
++
++    { CAT_VIDEO, VIDEO_TITLE, VIDEO_HELP },
++    { SUBCAT_VIDEO_GENERAL, VIDEO_TITLE, VIDEO_GENERAL_HELP },
++    { SUBCAT_VIDEO_VOUT, _VOUT_TITLE, VOUT_HELP },
++    { SUBCAT_VIDEO_VFILTER, VFILTER_TITLE, VFILTER_HELP },
++    { SUBCAT_VIDEO_SUBPIC, SUBPIC_TITLE, SUBPIC_HELP },
++    { SUBCAT_VIDEO_SPLITTER, SPLITTER_TITLE, SPLITTER_HELP },
++
++    { CAT_INPUT, INPUT_TITLE, INPUT_HELP },
++    { SUBCAT_INPUT_GENERAL, INPUT_TITLE, INPUT_HELP },
++    { SUBCAT_INPUT_ACCESS, ACCESS_TITLE, ACCESS_HELP },
++    { SUBCAT_INPUT_DEMUX, DEMUX_TITLE, DEMUX_HELP },
++    { SUBCAT_INPUT_VCODEC, VDEC_TITLE, VDEC_HELP },
++    { SUBCAT_INPUT_ACODEC, ADEC_TITLE, ADEC_HELP },
++    { SUBCAT_INPUT_SCODEC, SDEC_TITLE, SDEC_HELP },
++    { SUBCAT_INPUT_STREAM_FILTER, STREAM_FILTER_TITLE, STREAM_FILTER_HELP },
++
++    { CAT_SOUT, SOUT_TITLE, SOUT_HELP },
++    { SUBCAT_SOUT_GENERAL, SOUT_TITLE, SOUT_GENERAL_HELP },
++    { SUBCAT_SOUT_STREAM, SOUT_STREAM_TITLE, SOUT_STREAM_HELP },
++    { SUBCAT_SOUT_MUX, SOUT_MUX_TITLE, SOUT_MUX_HELP },
++    { SUBCAT_SOUT_ACO, SOUT_ACO_TITLE, SOUT_ACO_HELP },
++    { SUBCAT_SOUT_PACKETIZER, SOUT_PACKET_TITLE, SOUT_PACKET_HELP },
++    { SUBCAT_SOUT_VOD, SOUT_VOD_TITLE, SOUT_VOD_HELP },
++
++    { CAT_PLAYLIST, PLAYLIST_TITLE , PLAYLIST_HELP },
++    { SUBCAT_PLAYLIST_GENERAL, PLAYLIST_TITLE, PGENERAL_HELP },
++    { SUBCAT_PLAYLIST_SD, SD_TITLE, SD_HELP },
++
++    { CAT_ADVANCED, AADVANCED_TITLE, AADVANCED_HELP },
++    { SUBCAT_ADVANCED_MISC, MISC_TITLE, AADVANCED_HELP },
++
++    { -1, NULL, NULL }
++};
++
++VLC_USED
++static inline const char *config_CategoryNameGet( int i_value )
++{
++    int i = 0;
++    while( categories_array[i].psz_name != NULL )
++    {
++        if( categories_array[i].i_id == i_value )
++        {
++            return vlc_gettext(categories_array[i].psz_name);
++        }
++        i++;
++    }
++    return NULL;
++}
++
++VLC_USED
++static inline const char *config_CategoryHelpGet( int i_value )
++{
++    int i = 0;
++    while( categories_array[i].psz_help != NULL )
++    {
++        if( categories_array[i].i_id == i_value )
++        {
++            return vlc_gettext(categories_array[i].psz_help);
++        }
++        i++;
++    }
++    return NULL;
++}
++
++#endif /* VLC_HELP_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_configuration.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_configuration.h
+new file mode 100644
+index 0000000..a9b06c0
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_configuration.h
+@@ -0,0 +1,237 @@
++/*****************************************************************************
++ * vlc_configuration.h : configuration management module
++ * This file describes the programming interface for the configuration module.
++ * It includes functions allowing to declare, get or set configuration options.
++ *****************************************************************************
++ * Copyright (C) 1999-2006 VLC authors and VideoLAN
++ * $Id: 209168615be2a7bc5db889282b32389093ab262e $
++ *
++ * Authors: Gildas Bazin <gbazin@videolan.org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_CONFIGURATION_H
++#define VLC_CONFIGURATION_H 1
++
++/**
++ * \file
++ * This file describes the programming interface for the configuration module.
++ * It includes functions allowing to declare, get or set configuration options.
++ */
++
++#include <sys/types.h>  /* for ssize_t */
++
++# ifdef __cplusplus
++extern "C" {
++# endif
++
++struct config_category_t
++{
++    int         i_id;
++    const char *psz_name;
++    const char *psz_help;
++};
++
++typedef union
++{
++    char       *psz;
++    int64_t     i;
++    float       f;
++} module_value_t;
++
++typedef int (*vlc_string_list_cb)(vlc_object_t *, const char *,
++                                  char ***, char ***);
++typedef int (*vlc_integer_list_cb)(vlc_object_t *, const char *,
++                                   int64_t **, char ***);
++
++struct module_config_t
++{
++    uint8_t     i_type;                        /* Configuration type */
++    char        i_short;               /* Optional short option name */
++    unsigned    b_advanced:1;                     /* Advanced option */
++    unsigned    b_internal:1;          /* Hidden from prefs and help */
++    unsigned    b_unsaveable:1;       /* Not stored in configuration */
++    unsigned    b_safe:1;       /* Safe in web plugins and playlists */
++    unsigned    b_removed:1;                           /* Deprecated */
++
++    const char *psz_type;                           /* Configuration subtype */
++    const char *psz_name;                                     /* Option name */
++    const char *psz_text;       /* Short comment on the configuration option */
++    const char *psz_longtext;    /* Long comment on the configuration option */
++
++    module_value_t value;                                    /* Option value */
++    module_value_t orig;
++    module_value_t min;
++    module_value_t max;
++
++    /* Values list */
++    uint16_t list_count;                                /* Options list size */
++    union
++    {
++        const char **psz;          /* List of possible values for the option */
++        const int  *i;
++        vlc_string_list_cb psz_cb;
++        vlc_integer_list_cb i_cb;
++    } list;
++    const char **list_text;                /* Friendly names for list values */
++    const char *list_cb_name;
++    void *owner;
++};
++
++/*****************************************************************************
++ * Prototypes - these methods are used to get, set or manipulate configuration
++ * data.
++ *****************************************************************************/
++VLC_API int config_GetType(const char *) VLC_USED;
++VLC_API int64_t config_GetInt(vlc_object_t *, const char *) VLC_USED;
++VLC_API void config_PutInt(vlc_object_t *, const char *, int64_t);
++VLC_API float config_GetFloat(vlc_object_t *, const char *) VLC_USED;
++VLC_API void config_PutFloat(vlc_object_t *, const char *, float);
++VLC_API char * config_GetPsz(vlc_object_t *, const char *) VLC_USED VLC_MALLOC;
++VLC_API void config_PutPsz(vlc_object_t *, const char *, const char *);
++VLC_API ssize_t config_GetIntChoices(vlc_object_t *, const char *,
++                                     int64_t **, char ***) VLC_USED;
++VLC_API ssize_t config_GetPszChoices(vlc_object_t *, const char *,
++                                     char ***, char ***) VLC_USED;
++
++VLC_API int config_SaveConfigFile( vlc_object_t * );
++#define config_SaveConfigFile(a) config_SaveConfigFile(VLC_OBJECT(a))
++
++VLC_API void config_ResetAll( vlc_object_t * );
++#define config_ResetAll(a) config_ResetAll(VLC_OBJECT(a))
++
++VLC_API module_config_t * config_FindConfig(const char *) VLC_USED;
++VLC_API char * config_GetDataDir(void) VLC_USED VLC_MALLOC;
++VLC_API char *config_GetLibDir(void) VLC_USED;
++
++typedef enum vlc_userdir
++{
++    VLC_HOME_DIR, /* User's home */
++    VLC_CONFIG_DIR, /* VLC-specific configuration directory */
++    VLC_DATA_DIR, /* VLC-specific data directory */
++    VLC_CACHE_DIR, /* VLC-specific user cached data directory */
++    /* Generic directories (same as XDG) */
++    VLC_DESKTOP_DIR=0x80,
++    VLC_DOWNLOAD_DIR,
++    VLC_TEMPLATES_DIR,
++    VLC_PUBLICSHARE_DIR,
++    VLC_DOCUMENTS_DIR,
++    VLC_MUSIC_DIR,
++    VLC_PICTURES_DIR,
++    VLC_VIDEOS_DIR,
++} vlc_userdir_t;
++
++VLC_API char * config_GetUserDir( vlc_userdir_t ) VLC_USED VLC_MALLOC;
++
++VLC_API void config_AddIntf( vlc_object_t *, const char * );
++VLC_API void config_RemoveIntf( vlc_object_t *, const char * );
++VLC_API bool config_ExistIntf( vlc_object_t *, const char * ) VLC_USED;
++
++#define config_GetInt(a,b) config_GetInt(VLC_OBJECT(a),b)
++#define config_PutInt(a,b,c) config_PutInt(VLC_OBJECT(a),b,c)
++#define config_GetFloat(a,b) config_GetFloat(VLC_OBJECT(a),b)
++#define config_PutFloat(a,b,c) config_PutFloat(VLC_OBJECT(a),b,c)
++#define config_GetPsz(a,b) config_GetPsz(VLC_OBJECT(a),b)
++#define config_PutPsz(a,b,c) config_PutPsz(VLC_OBJECT(a),b,c)
++
++#define config_AddIntf(a,b) config_AddIntf(VLC_OBJECT(a),b)
++#define config_RemoveIntf(a,b) config_RemoveIntf(VLC_OBJECT(a),b)
++#define config_ExistIntf(a,b) config_ExistIntf(VLC_OBJECT(a),b)
++
++/****************************************************************************
++ * config_chain_t:
++ ****************************************************************************/
++struct config_chain_t
++{
++    config_chain_t *p_next;     /**< Pointer on the next config_chain_t element */
++
++    char        *psz_name;      /**< Option name */
++    char        *psz_value;     /**< Option value */
++};
++
++/**
++ * This function will
++ * - create all options in the array ppsz_options (var_Create).
++ * - parse the given linked list of config_chain_t and set the value (var_Set).
++ *
++ * The option names will be created by adding the psz_prefix prefix.
++ */
++VLC_API void config_ChainParse( vlc_object_t *, const char *psz_prefix, const char *const *ppsz_options, config_chain_t * );
++#define config_ChainParse( a, b, c, d ) config_ChainParse( VLC_OBJECT(a), b, c, d )
++
++/**
++ * This function will parse a configuration string (psz_opts) and
++ * - set all options for this module in a chained list (*pp_cfg)
++ * - returns a pointer on the next module if any.
++ *
++ * The string format is
++ *   module{option=*,option=*}
++ *
++ * The options values are unescaped using config_StringUnescape.
++ */
++VLC_API const char *config_ChainParseOptions( config_chain_t **pp_cfg, const char *ppsz_opts );
++
++/**
++ * This function will parse a configuration string (psz_string) and
++ * - set the module name (*ppsz_name)
++ * - set all options for this module in a chained list (*pp_cfg)
++ * - returns a pointer on the next module if any.
++ *
++ * The string format is
++ *   module{option=*,option=*}[:modulenext{option=*,...}]
++ *
++ * The options values are unescaped using config_StringUnescape.
++ */
++VLC_API char *config_ChainCreate( char **ppsz_name, config_chain_t **pp_cfg, const char *psz_string ) VLC_USED VLC_MALLOC;
++
++/**
++ * This function will release a linked list of config_chain_t
++ * (Including the head)
++ */
++VLC_API void config_ChainDestroy( config_chain_t * );
++
++/**
++ * This function will duplicate a linked list of config_chain_t
++ */
++VLC_API config_chain_t * config_ChainDuplicate( const config_chain_t * ) VLC_USED VLC_MALLOC;
++
++/**
++ * This function will unescape a string in place and will return a pointer on
++ * the given string.
++ * No memory is allocated by it (unlike config_StringEscape).
++ * If NULL is given as parameter nothing will be done (NULL will be returned).
++ *
++ * The following sequences will be unescaped (only one time):
++ * \\ \' and \"
++ */
++VLC_API char * config_StringUnescape( char *psz_string );
++
++/**
++ * This function will escape a string that can be unescaped by
++ * config_StringUnescape.
++ * The returned value is allocated by it. You have to free it once you
++ * do not need it anymore (unlike config_StringUnescape).
++ * If NULL is given as parameter nothing will be done (NULL will be returned).
++ *
++ * The escaped characters are ' " and \
++ */
++VLC_API char * config_StringEscape( const char *psz_string ) VLC_USED VLC_MALLOC;
++
++# ifdef __cplusplus
++}
++# endif
++
++#endif /* _VLC_CONFIGURATION_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_cpu.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_cpu.h
+new file mode 100644
+index 0000000..b2f0f45
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_cpu.h
+@@ -0,0 +1,192 @@
++/*****************************************************************************
++ * vlc_cpu.h: CPU capabilities
++ *****************************************************************************
++ * Copyright (C) 1998-2009 VLC authors and VideoLAN
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++/**
++ * \file
++ * This file provides CPU features detection.
++ */
++
++#ifndef VLC_CPU_H
++# define VLC_CPU_H 1
++
++VLC_API unsigned vlc_CPU(void);
++
++# if defined (__i386__) || defined (__x86_64__)
++#  define HAVE_FPU 1
++#  define VLC_CPU_MMX    0x00000008
++#  define VLC_CPU_3dNOW  0x00000010
++#  define VLC_CPU_MMXEXT 0x00000020
++#  define VLC_CPU_SSE    0x00000040
++#  define VLC_CPU_SSE2   0x00000080
++#  define VLC_CPU_SSE3   0x00000100
++#  define VLC_CPU_SSSE3  0x00000200
++#  define VLC_CPU_SSE4_1 0x00000400
++#  define VLC_CPU_SSE4_2 0x00000800
++#  define VLC_CPU_SSE4A  0x00001000
++#  define VLC_CPU_AVX    0x00002000
++#  define VLC_CPU_AVX2   0x00004000
++#  define VLC_CPU_XOP    0x00008000
++#  define VLC_CPU_FMA4   0x00010000
++
++# if defined (__MMX__)
++#  define vlc_CPU_MMX() (1)
++#  define VLC_MMX
++# else
++#  define vlc_CPU_MMX() ((vlc_CPU() & VLC_CPU_MMX) != 0)
++#  define VLC_MMX __attribute__ ((__target__ ("mmx")))
++# endif
++
++# if defined (__SSE__)
++#  define vlc_CPU_MMXEXT() (1)
++#  define vlc_CPU_SSE() (1)
++#  define VLC_SSE
++# else
++#  define vlc_CPU_MMXEXT() ((vlc_CPU() & VLC_CPU_MMXEXT) != 0)
++#  define vlc_CPU_SSE() ((vlc_CPU() & VLC_CPU_SSE) != 0)
++#  define VLC_SSE __attribute__ ((__target__ ("sse")))
++# endif
++
++# ifdef __SSE2__
++#  define vlc_CPU_SSE2() (1)
++# else
++#  define vlc_CPU_SSE2() ((vlc_CPU() & VLC_CPU_SSE2) != 0)
++# endif
++
++# ifdef __SSE3__
++#  define vlc_CPU_SSE3() (1)
++# else
++#  define vlc_CPU_SSE3() ((vlc_CPU() & VLC_CPU_SSE3) != 0)
++# endif
++
++# ifdef __SSSE3__
++#  define vlc_CPU_SSSE3() (1)
++# else
++#  define vlc_CPU_SSSE3() ((vlc_CPU() & VLC_CPU_SSSE3) != 0)
++# endif
++
++# ifdef __SSE4_1__
++#  define vlc_CPU_SSE4_1() (1)
++# else
++#  define vlc_CPU_SSE4_1() ((vlc_CPU() & VLC_CPU_SSE4_1) != 0)
++# endif
++
++# ifdef __SSE4_2__
++#  define vlc_CPU_SSE4_2() (1)
++# else
++#  define vlc_CPU_SSE4_2() ((vlc_CPU() & VLC_CPU_SSE4_2) != 0)
++# endif
++
++# ifdef __SSE4A__
++#  define vlc_CPU_SSE4A() (1)
++# else
++#  define vlc_CPU_SSE4A() ((vlc_CPU() & VLC_CPU_SSE4A) != 0)
++# endif
++
++# ifdef __AVX__
++#  define vlc_CPU_AVX() (1)
++# else
++#  define vlc_CPU_AVX() ((vlc_CPU() & VLC_CPU_AVX) != 0)
++# endif
++
++# ifdef __AVX2__
++#  define vlc_CPU_AVX2() (1)
++# else
++#  define vlc_CPU_AVX2() ((vlc_CPU() & VLC_CPU_AVX2) != 0)
++# endif
++
++# ifdef __3dNOW__
++#  define vlc_CPU_3dNOW() (1)
++# else
++#  define vlc_CPU_3dNOW() ((vlc_CPU() & VLC_CPU_3dNOW) != 0)
++# endif
++
++# ifdef __XOP__
++#  define vlc_CPU_XOP() (1)
++# else
++#  define vlc_CPU_XOP() ((vlc_CPU() & VLC_CPU_XOP) != 0)
++# endif
++
++# ifdef __FMA4__
++#  define vlc_CPU_FMA4() (1)
++# else
++#  define vlc_CPU_FMA4() ((vlc_CPU() & VLC_CPU_FMA4) != 0)
++# endif
++
++# elif defined (__ppc__) || defined (__ppc64__) || defined (__powerpc__)
++#  define HAVE_FPU 1
++#  define VLC_CPU_ALTIVEC 2
++
++#  ifdef ALTIVEC
++#   define vlc_CPU_ALTIVEC() (1)
++#  else
++#   define vlc_CPU_ALTIVEC() ((vlc_CPU() & VLC_CPU_ALTIVEC) != 0)
++#  endif
++
++# elif defined (__arm__)
++#  if defined (__VFP_FP__) && !defined (__SOFTFP__)
++#   define HAVE_FPU 1
++#  else
++#   define HAVE_FPU 0
++#  endif
++#  define VLC_CPU_ARMv6    4
++#  define VLC_CPU_ARM_NEON 2
++
++#  if defined (__ARM_ARCH_7A__)
++#   define VLC_CPU_ARM_ARCH 7
++#  elif defined (__ARM_ARCH_6__) || defined (__ARM_ARCH_6T2__)
++#   define VLC_CPU_ARM_ARCH 6
++#  else
++#   define VLC_CPU_ARM_ARCH 4
++#  endif
++
++#  if (VLC_CPU_ARM_ARCH >= 6)
++#   define vlc_CPU_ARMv6() (1)
++#  else
++#   define vlc_CPU_ARMv6() ((vlc_CPU() & VLC_CPU_ARMv6) != 0)
++#  endif
++
++#  ifdef __ARM_NEON__
++#   define vlc_CPU_ARM_NEON() (1)
++#  else
++#   define vlc_CPU_ARM_NEON() ((vlc_CPU() & VLC_CPU_ARM_NEON) != 0)
++#  endif
++
++# elif defined (__aarch64__)
++#  define HAVE_FPU 1
++// NEON is mandatory for general purpose ARMv8-a CPUs
++#  define vlc_CPU_ARM64_NEON() (1)
++
++# elif defined (__sparc__)
++#  define HAVE_FPU 1
++
++# elif defined (__mips_hard_float)
++#  define HAVE_FPU 1
++
++# else
++/**
++ * Are single precision floating point operations "fast"?
++ * If this preprocessor constant is zero, floating point should be avoided
++ * (especially relevant for audio codecs).
++ */
++#  define HAVE_FPU 0
++
++# endif
++
++#endif /* !VLC_CPU_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_demux.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_demux.h
+new file mode 100644
+index 0000000..74bd29a
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_demux.h
+@@ -0,0 +1,525 @@
++/*****************************************************************************
++ * vlc_demux.h: Demuxer descriptor, queries and methods
++ *****************************************************************************
++ * Copyright (C) 1999-2005 VLC authors and VideoLAN
++ * $Id: f359f547fa79d9818ed74420d906a6683be3d037 $
++ *
++ * Authors: Laurent Aimar <fenrir@via.ecp.fr>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_DEMUX_H
++#define VLC_DEMUX_H 1
++
++#include <stdlib.h>
++#include <string.h>
++
++#include <vlc_es.h>
++#include <vlc_stream.h>
++#include <vlc_es_out.h>
++
++/**
++ * \defgroup demux Demultiplexer
++ * \ingroup input
++ * Demultiplexers (file format parsers)
++ * @{
++ * \file
++ * Demultiplexer modules interface
++ */
++
++struct demux_t
++{
++    VLC_COMMON_MEMBERS
++
++    /* Module properties */
++    module_t    *p_module;
++
++    /* eg informative but needed (we can have access+demux) */
++    char        *psz_access;
++    char        *psz_demux;
++    char        *psz_location;
++    char        *psz_file;
++
++    union {
++        /**
++         * Input stream
++         *
++         * Depending on the module capability:
++         * - "demux": input byte stream (not NULL)
++         * - "access_demux": a NULL pointer
++         * - "demux_filter": undefined
++         */
++        stream_t *s;
++        /**
++         * Input demuxer
++         *
++         * If the module capability is "demux_filter", this is the upstream
++         * demuxer or demux filter. Otherwise, this is undefined.
++         */
++        demux_t *p_next;
++    };
++
++    /* es output */
++    es_out_t    *out;   /* our p_es_out */
++
++    bool         b_preparsing; /* True if the demux is used to preparse */
++
++    /* set by demuxer */
++    int (*pf_demux)  ( demux_t * );   /* demux one frame only */
++    int (*pf_control)( demux_t *, int i_query, va_list args);
++
++    /* Demux has to maintain them uptodate
++     * when it is responsible of seekpoint/title */
++    struct
++    {
++        unsigned int i_update;  /* Demux sets them on change,
++                                   Input removes them once take into account*/
++        /* Seekpoint/Title at demux level */
++        int          i_title;       /* idem, start from 0 (could be menu) */
++        int          i_seekpoint;   /* idem, start from 0 */
++    } info;
++    demux_sys_t *p_sys;
++
++    /* Weak link to parent input */
++    input_thread_t *p_input;
++};
++
++/* pf_demux return values */
++#define VLC_DEMUXER_EOF       0
++#define VLC_DEMUXER_EGENERIC -1
++#define VLC_DEMUXER_SUCCESS   1
++
++/* demux_t.info.i_update field */
++#define INPUT_UPDATE_TITLE      0x0010
++#define INPUT_UPDATE_SEEKPOINT  0x0020
++#define INPUT_UPDATE_META       0x0040
++#define INPUT_UPDATE_TITLE_LIST 0x0100
++
++/* demux_meta_t is returned by "meta reader" module to the demuxer */
++typedef struct demux_meta_t
++{
++    VLC_COMMON_MEMBERS
++    input_item_t *p_item; /***< the input item that is being read */
++
++    vlc_meta_t *p_meta;                 /**< meta data */
++
++    int i_attachments;                  /**< number of attachments */
++    input_attachment_t **attachments;    /**< array of attachments */
++} demux_meta_t;
++
++/**
++ * Control query identifiers for use with demux_t.pf_control
++ *
++ * In the individual identifier description, the input stream refers to
++ * demux_t.s if non-NULL, and the output refers to demux_t.out.
++ *
++ * A demuxer is synchronous if it only accesses its input stream and the
++ * output from within its demux_t callbacks, i.e. demux.pf_demux and
++ * demux_t.pf_control.
++ *
++ * A demuxer is threaded if it accesses either or both input and output
++ * asynchronously.
++ *
++ * An access-demuxer is a demuxer without input, i.e. demux_t.s == NULL).
++ */
++enum demux_query_e
++{
++    /** Checks whether the stream supports seeking.
++     * Can fail if seeking is not supported (same as returning false).
++     * \bug Failing should not be allowed.
++     *
++     * arg1 = bool * */
++    DEMUX_CAN_SEEK,
++
++    /** Checks whether (long) pause then stream resumption is supported.
++     * Can fail only if synchronous and <b>not</b> an access-demuxer. The
++     * underlying input stream then determines if pause is supported.
++     * \bug Failing should not be allowed.
++     *
++     * arg1= bool * */
++    DEMUX_CAN_PAUSE = 0x002,
++
++    /** Whether the stream can be read at an arbitrary pace.
++     * Cannot fail.
++     *
++     * arg1= bool * */
++    DEMUX_CAN_CONTROL_PACE,
++
++    /** Retrieves the PTS delay (roughly the default buffer duration).
++     * Can fail only if synchronous and <b>not</b> an access-demuxer. The
++     * underlying input stream then determines the PTS delay.
++     *
++     * arg1= int64_t * */
++    DEMUX_GET_PTS_DELAY = 0x101,
++
++    /** Retrieves stream meta-data.
++     * Should fail if no meta-data were retrieved.
++     *
++     * arg1= vlc_meta_t * */
++    DEMUX_GET_META = 0x105,
++
++    /** Retrieves an estimate of signal quality and strength.
++     * Can fail.
++     *
++     * arg1=double *quality, arg2=double *strength */
++    DEMUX_GET_SIGNAL = 0x107,
++
++    /** Sets the paused or playing/resumed state.
++     *
++     * Streams are initially in playing state. The control always specifies a
++     * change from paused to playing (false) or from playing to paused (true)
++     * and streams are initially playing; a no-op cannot be requested.
++     *
++     * The control is never used if DEMUX_CAN_PAUSE fails.
++     * Can fail.
++     *
++     * arg1= bool */
++    DEMUX_SET_PAUSE_STATE = 0x200,
++
++    /** Seeks to the beginning of a title.
++     *
++     * The control is never used if DEMUX_GET_TITLE_INFO fails.
++     * Can fail.
++     *
++     * arg1= int */
++    DEMUX_SET_TITLE,
++
++    /** Seeks to the beginning of a chapter of the current title.
++     *
++     * The control is never used if DEMUX_GET_TITLE_INFO fails.
++     * Can fail.
++     *
++     * arg1= int */
++    DEMUX_SET_SEEKPOINT,        /* arg1= int            can fail */
++
++    /** Check which INPUT_UPDATE_XXX flag is set and reset the ones set.
++     *
++     * The unsigned* argument is set with the flags needed to be checked,
++     * on return it contains the values that were reset during the call
++     *
++     * This can can fail, in which case flags from demux_t.info.i_update
++     * are read/reset
++     *
++     * arg1= unsigned * */
++    DEMUX_TEST_AND_CLEAR_FLAGS, /* arg1= unsigned*      can fail */
++
++    /** Read the title number currently playing
++     *
++     * Can fail, in which case demux_t.info.i_title is used
++     *
++     * arg1= int * */
++    DEMUX_GET_TITLE,            /* arg1= int*           can fail */
++
++    /* Read the seekpoint/chapter currently playing
++     *
++     * Can fail, in which case demux_t.info.i_seekpoint is used
++     *
++     * arg1= int * */
++    DEMUX_GET_SEEKPOINT,        /* arg1= int*           can fail */
++
++    /* I. Common queries to access_demux and demux */
++    /* POSITION double between 0.0 and 1.0 */
++    DEMUX_GET_POSITION = 0x300, /* arg1= double *       res=    */
++    DEMUX_SET_POSITION,         /* arg1= double arg2= bool b_precise    res=can fail    */
++
++    /* LENGTH/TIME in microsecond, 0 if unknown */
++    DEMUX_GET_LENGTH,           /* arg1= int64_t *      res=    */
++    DEMUX_GET_TIME,             /* arg1= int64_t *      res=    */
++    DEMUX_SET_TIME,             /* arg1= int64_t arg2= bool b_precise   res=can fail    */
++
++    /**
++     * \todo Document
++     *
++     * \warning The prototype is different from STREAM_GET_TITLE_INFO
++     *
++     * Can fail, meaning there is only one title and one chapter.
++     *
++     * arg1= input_title_t ***, arg2=int *, arg3=int *pi_title_offset(0),
++     * arg4= int *pi_seekpoint_offset(0) */
++    DEMUX_GET_TITLE_INFO,
++
++    /* DEMUX_SET_GROUP/SET_ES only a hint for demuxer (mainly DVB) to allow not
++     * reading everything (you should not use this to call es_out_Control)
++     * if you don't know what to do with it, just IGNORE it, it is safe(r)
++     * -1 means all group, 0 default group (first es added) */
++    DEMUX_SET_GROUP,            /* arg1= int, arg2=const vlc_list_t *   can fail */
++    DEMUX_SET_ES,               /* arg1= int                            can fail */
++
++    /* Ask the demux to demux until the given date at the next pf_demux call
++     * but not more (and not less, at the precision available of course).
++     * XXX: not mandatory (except for subtitle demux) but will help a lot
++     * for multi-input
++     */
++    DEMUX_SET_NEXT_DEMUX_TIME,  /* arg1= int64_t        can fail */
++    /* FPS for correct subtitles handling */
++    DEMUX_GET_FPS,              /* arg1= double *       res=can fail    */
++
++    /* Meta data */
++    DEMUX_HAS_UNSUPPORTED_META, /* arg1= bool *   res can fail    */
++
++    /* Attachments */
++    DEMUX_GET_ATTACHMENTS,      /* arg1=input_attachment_t***, int* res=can fail */
++
++    /* RECORD you are ensured that it is never called twice with the same state
++     * you should accept it only if the stream can be recorded without
++     * any modification or header addition. */
++    DEMUX_CAN_RECORD,           /* arg1=bool*   res=can fail(assume false) */
++    /**
++     * \todo Document
++     *
++     * \warning The prototype is different from STREAM_SET_RECORD_STATE
++     *
++     * The control is never used if DEMUX_CAN_RECORD fails or returns false.
++     * Can fail.
++     *
++     * arg1= bool */
++    DEMUX_SET_RECORD_STATE,
++
++    /* II. Specific access_demux queries */
++
++    /* DEMUX_CAN_CONTROL_RATE is called only if DEMUX_CAN_CONTROL_PACE has
++     *  returned false. *pb_rate should be true when the rate can be changed
++     * (using DEMUX_SET_RATE). */
++    DEMUX_CAN_CONTROL_RATE,     /* arg1= bool*pb_rate */
++    /* DEMUX_SET_RATE is called only if DEMUX_CAN_CONTROL_RATE has returned true.
++     * It should return the value really used in *pi_rate */
++    DEMUX_SET_RATE,             /* arg1= int*pi_rate                                        can fail */
++
++    /** Checks whether the stream is actually a playlist, rather than a real
++     * stream.
++     *
++     * \warning The prototype is different from STREAM_IS_DIRECTORY.
++     *
++     * Can fail if the stream is not a playlist (same as returning false).
++     *
++     * arg1= bool * */
++    DEMUX_IS_PLAYLIST,
++
++    /* Menu (VCD/DVD/BD) Navigation */
++    /** Activate the navigation item selected. Can fail */
++    DEMUX_NAV_ACTIVATE,
++    /** Use the up arrow to select a navigation item above. Can fail */
++    DEMUX_NAV_UP,
++    /** Use the down arrow to select a navigation item under. Can fail */
++    DEMUX_NAV_DOWN,
++    /** Use the left arrow to select a navigation item on the left. Can fail */
++    DEMUX_NAV_LEFT,
++    /** Use the right arrow to select a navigation item on the right. Can fail */
++    DEMUX_NAV_RIGHT,
++    /** Activate the popup Menu (for BD). Can fail */
++    DEMUX_NAV_POPUP,
++    /** Activate disc Root Menu. Can fail */
++    DEMUX_NAV_MENU,            /* res=can fail */
++    /** Enable/Disable a demux filter
++     * \warning This has limited support, and is likely to break if more than
++     * a single demux_filter is present in the chain. This is not guaranteed to
++     * work in future VLC versions, nor with all demux filters
++     */
++    DEMUX_FILTER_ENABLE,
++    DEMUX_FILTER_DISABLE
++};
++
++/*************************************************************************
++ * Main Demux
++ *************************************************************************/
++
++/* stream_t *s could be null and then it mean a access+demux in one */
++VLC_API demux_t *demux_New( vlc_object_t *p_obj, const char *psz_name,
++                            const char *psz_path, stream_t *s, es_out_t *out );
++
++VLC_API void demux_Delete( demux_t * );
++
++
++VLC_API int demux_vaControlHelper( stream_t *, int64_t i_start, int64_t i_end,
++                                   int64_t i_bitrate, int i_align, int i_query, va_list args );
++
++VLC_USED static inline int demux_Demux( demux_t *p_demux )
++{
++    if( !p_demux->pf_demux )
++        return VLC_DEMUXER_SUCCESS;
++
++    return p_demux->pf_demux( p_demux );
++}
++
++VLC_API int demux_vaControl( demux_t *p_demux, int i_query, va_list args );
++
++static inline int demux_Control( demux_t *p_demux, int i_query, ... )
++{
++    va_list args;
++    int     i_result;
++
++    va_start( args, i_query );
++    i_result = demux_vaControl( p_demux, i_query, args );
++    va_end( args );
++    return i_result;
++}
++
++/*************************************************************************
++ * Miscellaneous helpers for demuxers
++ *************************************************************************/
++
++static inline void demux_UpdateTitleFromStream( demux_t *demux )
++{
++    stream_t *s = demux->s;
++    unsigned title, seekpoint;
++
++    if( vlc_stream_Control( s, STREAM_GET_TITLE, &title ) == VLC_SUCCESS
++     && title != (unsigned)demux->info.i_title )
++    {
++        demux->info.i_title = title;
++        demux->info.i_update |= INPUT_UPDATE_TITLE;
++    }
++
++    if( vlc_stream_Control( s, STREAM_GET_SEEKPOINT,
++                            &seekpoint ) == VLC_SUCCESS
++     && seekpoint != (unsigned)demux->info.i_seekpoint )
++    {
++        demux->info.i_seekpoint = seekpoint;
++        demux->info.i_update |= INPUT_UPDATE_SEEKPOINT;
++    }
++}
++
++VLC_USED
++static inline bool demux_IsPathExtension( demux_t *p_demux, const char *psz_extension )
++{
++    const char *name = (p_demux->psz_file != NULL) ? p_demux->psz_file
++                                                   : p_demux->psz_location;
++    const char *psz_ext = strrchr ( name, '.' );
++    if( !psz_ext || strcasecmp( psz_ext, psz_extension ) )
++        return false;
++    return true;
++}
++
++VLC_USED
++static inline bool demux_IsContentType(demux_t *demux, const char *type)
++{
++    return stream_IsMimeType(demux->s, type);
++}
++
++VLC_USED
++static inline bool demux_IsForced( demux_t *p_demux, const char *psz_name )
++{
++   if( !p_demux->psz_demux || strcmp( p_demux->psz_demux, psz_name ) )
++        return false;
++    return true;
++}
++
++/**
++ * This function will create a packetizer suitable for a demuxer that parses
++ * elementary stream.
++ *
++ * The provided es_format_t will be cleaned on error or by
++ * demux_PacketizerDestroy.
++ */
++VLC_API decoder_t * demux_PacketizerNew( demux_t *p_demux, es_format_t *p_fmt, const char *psz_msg ) VLC_USED;
++
++/**
++ * This function will destroy a packetizer create by demux_PacketizerNew.
++ */
++VLC_API void demux_PacketizerDestroy( decoder_t *p_packetizer );
++
++/* */
++#define DEMUX_INIT_COMMON() do {            \
++    p_demux->pf_control = Control;          \
++    p_demux->pf_demux = Demux;              \
++    p_demux->p_sys = calloc( 1, sizeof( demux_sys_t ) ); \
++    if( !p_demux->p_sys ) return VLC_ENOMEM;\
++    } while(0)
++
++/**
++ * \defgroup chained_demux Chained demultiplexer
++ * Demultiplexers wrapped by another demultiplexer
++ * @{
++ */
++
++typedef struct vlc_demux_chained_t vlc_demux_chained_t;
++
++/**
++ * Creates a chained demuxer.
++ *
++ * This creates a thread running a demuxer whose input stream is generated
++ * directly by the caller. This typically handles some sort of stream within a
++ * stream, e.g. MPEG-TS within something else.
++ *
++ * \note There are a number of limitations to this approach. The chained
++ * demuxer is run asynchronously in a separate thread. Most demuxer controls
++ * are synchronous and therefore unavailable in this case. Also the input
++ * stream is a simple FIFO, so the chained demuxer cannot perform seeks.
++ * Lastly, most errors cannot be detected.
++ *
++ * \param parent parent VLC object
++ * \param name chained demux module name (e.g. "ts")
++ * \param out elementary stream output for the chained demux
++ * \return a non-NULL pointer on success, NULL on failure.
++ */
++VLC_API vlc_demux_chained_t *vlc_demux_chained_New(vlc_object_t *parent,
++                                                   const char *name,
++                                                   es_out_t *out);
++
++/**
++ * Destroys a chained demuxer.
++ *
++ * Sends an end-of-stream to the chained demuxer, and releases all underlying
++ * allocated resources.
++ */
++VLC_API void vlc_demux_chained_Delete(vlc_demux_chained_t *);
++
++/**
++ * Sends data to a chained demuxer.
++ *
++ * This queues data for a chained demuxer to consume.
++ *
++ * \param block data block to queue
++ */
++VLC_API void vlc_demux_chained_Send(vlc_demux_chained_t *, block_t *block);
++
++/**
++ * Controls a chained demuxer.
++ *
++ * This performs a <b>demux</b> (i.e. DEMUX_...) control request on a chained
++ * demux.
++ *
++ * \note In most cases, vlc_demux_chained_Control() should be used instead.
++ * \warning As per vlc_demux_chained_New(), most demux controls are not, and
++ * cannot be, supported; VLC_EGENERIC is returned.
++ *
++ * \param query demux control (see \ref demux_query_e)
++ * \param args variable arguments (depending on the query)
++ */
++VLC_API int vlc_demux_chained_ControlVa(vlc_demux_chained_t *, int query,
++                                        va_list args);
++
++static inline int vlc_demux_chained_Control(vlc_demux_chained_t *dc, int query,
++                                            ...)
++{
++    va_list ap;
++    int ret;
++
++    va_start(ap, query);
++    ret = vlc_demux_chained_ControlVa(dc, query, ap);
++    va_end(ap);
++    return ret;
++}
++
++/**
++ * @}
++ */
++
++/**
++ * @}
++ */
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_dialog.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_dialog.h
+new file mode 100644
+index 0000000..23df3cb
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_dialog.h
+@@ -0,0 +1,483 @@
++/*****************************************************************************
++ * vlc_dialog.h: user interaction dialogs
++ *****************************************************************************
++ * Copyright (C) 2009 Rémi Denis-Courmont
++ * Copyright (C) 2016 VLC authors and VideoLAN
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_DIALOG_H_
++#define VLC_DIALOG_H_
++# include <stdarg.h>
++
++typedef struct vlc_dialog_provider vlc_dialog_provider;
++typedef struct vlc_dialog_id vlc_dialog_id;
++typedef struct extension_dialog_t extension_dialog_t;
++
++/* Called from src/libvlc.c */
++int
++libvlc_InternalDialogInit(libvlc_int_t *p_libvlc);
++
++/* Called from src/libvlc.c */
++void
++libvlc_InternalDialogClean(libvlc_int_t *p_libvlc);
++
++/**
++ * @defgroup vlc_dialog VLC dialog
++ * @ingroup interface
++ * @{
++ * @file
++ * This file declares VLC dialog functions
++ * @defgroup vlc_dialog_api VLC dialog functions
++ * In order to interact with the user
++ * @{
++ */
++
++/**
++ * Dialog question type, see vlc_dialog_wait_question()
++ */
++typedef enum vlc_dialog_question_type
++{
++    VLC_DIALOG_QUESTION_NORMAL,
++    VLC_DIALOG_QUESTION_WARNING,
++    VLC_DIALOG_QUESTION_CRITICAL,
++} vlc_dialog_question_type;
++
++/**
++ * Sends an error message
++ *
++ * This function returns immediately
++ *
++ * @param p_obj the VLC object emitting the error
++ * @param psz_title title of the error dialog
++ * @param psz_fmt format string for the error message
++ * @return VLC_SUCCESS on success, or a VLC error code on error
++ */
++VLC_API int
++vlc_dialog_display_error(vlc_object_t *p_obj, const char *psz_title,
++                         const char *psz_fmt, ...) VLC_FORMAT(3,4);
++#define vlc_dialog_display_error(a, b, c, ...) \
++    vlc_dialog_display_error(VLC_OBJECT(a), b, c, ##__VA_ARGS__)
++
++/**
++ * Sends an error message
++ *
++ * Equivalent to vlc_dialog_display_error() expect that it's called with a
++ * va_list.
++ */
++VLC_API int
++vlc_dialog_display_error_va(vlc_object_t *p_obj, const char *psz_title,
++                            const char *psz_fmt, va_list ap);
++
++/**
++ * Requests an user name and a password
++ *
++ * This function waits until the user dismisses the dialog or responds. It's
++ * interruptible via vlc_interrupt. In that case, vlc_dialog_cbs.pf_cancel()
++ * will be invoked. If p_store is not NULL, the user will be asked to store the
++ * password or not.
++ *
++ * @param p_obj the VLC object emitting the dialog
++ * @param ppsz_username a pointer to the user name provided by the user, it
++ * must be freed with free() on success
++ * @param ppsz_password a pointer to the password provided by the user, it must
++ * be freed with free() on success
++ * @param p_store a pointer to the store answer provided by the user (optional)
++ * @param psz_default_username default user name proposed
++ * @param psz_title title of the login dialog
++ * @param psz_fmt format string for the login message
++ * @return < 0 on error, 0 if the user cancelled it, and 1 if ppsz_username and
++ * ppsz_password are valid.
++ */
++VLC_API int
++vlc_dialog_wait_login(vlc_object_t *p_obj, char **ppsz_username,
++                      char **ppsz_password, bool *p_store,
++                      const char *psz_default_username,
++                      const char *psz_title, const char *psz_fmt, ...)
++                      VLC_FORMAT(7,8);
++#define vlc_dialog_wait_login(a, b, c, d, e, f, g, ...) \
++    vlc_dialog_wait_login(VLC_OBJECT(a), b, c, d, e, f, g, ##__VA_ARGS__)
++
++/**
++ * Requests an user name and a password
++ *
++ * Equivalent to vlc_dialog_wait_login() expect that it's called with a
++ * va_list.
++ */
++VLC_API int
++vlc_dialog_wait_login_va(vlc_object_t *p_obj, char **ppsz_username,
++                         char **ppsz_password, bool *p_store,
++                         const char *psz_default_username,
++                         const char *psz_title, const char *psz_fmt, va_list ap);
++
++/**
++ * Asks a total (Yes/No/Cancel) question
++ *
++ * This function waits until the user dismisses the dialog or responds. It's
++ * interruptible via vlc_interrupt. In that case, vlc_dialog_cbs.pf_cancel()
++ * will be invoked. The psz_cancel is mandatory since this dialog is always
++ * cancellable by the user.
++ *
++ * @param p_obj the VLC object emitting the dialog
++ * @param i_type question type (severity of the question)
++ * @param psz_cancel text of the cancel button
++ * @param psz_action1 first choice/button text (optional)
++ * @param psz_action2 second choice/button text (optional)
++ * @param psz_title title of the question dialog
++ * @param psz_fmt format string for the question message
++ * @return < 0 on error, 0 if the user cancelled it, 1 on action1, 2 on action2
++ */
++VLC_API int
++vlc_dialog_wait_question(vlc_object_t *p_obj,
++                         vlc_dialog_question_type i_type,
++                         const char *psz_cancel, const char *psz_action1,
++                         const char *psz_action2, const char *psz_title,
++                         const char *psz_fmt, ...) VLC_FORMAT(7,8);
++#define vlc_dialog_wait_question(a, b, c, d, e, f, g, ...) \
++    vlc_dialog_wait_question(VLC_OBJECT(a), b, c, d, e, f, g, ##__VA_ARGS__)
++
++/**
++ * Asks a total (Yes/No/Cancel) question
++ *
++ * Equivalent to vlc_dialog_wait_question() expect that it's called with a
++ * va_list.
++ */
++VLC_API int
++vlc_dialog_wait_question_va(vlc_object_t *p_obj,
++                            vlc_dialog_question_type i_type,
++                            const char *psz_cancel, const char *psz_action1,
++                            const char *psz_action2, const char *psz_title,
++                            const char *psz_fmt, va_list ap);
++
++/**
++ * Display a progress dialog
++ *
++ * This function returns immediately
++ *
++ * @param p_obj the VLC object emitting the dialog
++ * @param b_indeterminate true if the progress dialog is indeterminate
++ * @param f_position initial position of the progress bar (between 0.0 and 1.0)
++ * @param psz_cancel text of the cancel button, if NULL the dialog is not
++ * cancellable (optional)
++ * @param psz_title title of the progress dialog
++ * @param psz_fmt format string for the progress message
++ * @return a valid vlc_dialog_id on success, must be released with
++ * vlc_dialog_id_release()
++ */
++VLC_API vlc_dialog_id *
++vlc_dialog_display_progress(vlc_object_t *p_obj, bool b_indeterminate,
++                            float f_position, const char *psz_cancel,
++                            const char *psz_title, const char *psz_fmt, ...)
++                            VLC_FORMAT(6,7);
++#define vlc_dialog_display_progress(a, b, c, d, e, f, ...) \
++    vlc_dialog_display_progress(VLC_OBJECT(a), b, c, d, e, f, ##__VA_ARGS__)
++
++/**
++ * Display a progress dialog
++ *
++ * Equivalent to vlc_dialog_display_progress() expect that it's called with a
++ * va_list.
++ */
++VLC_API vlc_dialog_id *
++vlc_dialog_display_progress_va(vlc_object_t *p_obj, bool b_indeterminate,
++                               float f_position, const char *psz_cancel,
++                               const char *psz_title, const char *psz_fmt,
++                               va_list ap);
++
++/**
++ * Update the position of the progress dialog
++ *
++ * @param p_obj the VLC object emitting the dialog
++ * @param p_id id of the dialog to update
++ * @param f_position position of the progress bar (between 0.0 and 1.0)
++ * @return VLC_SUCCESS on success, or a VLC error code on error
++ */
++VLC_API int
++vlc_dialog_update_progress(vlc_object_t *p_obj, vlc_dialog_id *p_id,
++                           float f_position);
++#define vlc_dialog_update_progress(a, b, c) \
++    vlc_dialog_update_progress(VLC_OBJECT(a), b, c)
++
++/**
++ * Update the position and the message of the progress dialog
++ *
++ * @param p_obj the VLC object emitting the dialog
++ * @param p_id id of the dialog to update
++ * @param f_position position of the progress bar (between 0.0 and 1.0)
++ * @param psz_fmt format string for the progress message
++ * @return VLC_SUCCESS on success, or a VLC error code on error
++ */
++VLC_API int
++vlc_dialog_update_progress_text(vlc_object_t *p_obj, vlc_dialog_id *p_id,
++                                float f_position, const char *psz_fmt, ...)
++                                VLC_FORMAT(4, 5);
++#define vlc_dialog_update_progress_text(a, b, c, d, ...) \
++    vlc_dialog_update_progress_text(VLC_OBJECT(a), b, c, d, ##__VA_ARGS__)
++
++/**
++ * Update the position and the message of the progress dialog
++ *
++ * Equivalent to vlc_dialog_update_progress_text() expect that it's called
++ * with a va_list.
++ */
++VLC_API int
++vlc_dialog_update_progress_text_va(vlc_object_t *p_obj, vlc_dialog_id *p_id,
++                                   float f_position, const char *psz_fmt,
++                                   va_list ap);
++
++/**
++ * Release the dialog id returned by vlc_dialog_display_progress()
++ *
++ * It causes the vlc_dialog_cbs.pf_cancel() callback to be invoked.
++ *
++ * @param p_obj the VLC object emitting the dialog
++ * @param p_id id of the dialog to release
++ */
++VLC_API void
++vlc_dialog_release(vlc_object_t *p_obj, vlc_dialog_id *p_id);
++#define vlc_dialog_release(a, b) \
++    vlc_dialog_release(VLC_OBJECT(a), b)
++
++/**
++ * Return true if the dialog id is cancelled
++ *
++ * @param p_obj the VLC object emitting the dialog
++ * @param p_id id of the dialog
++ */
++VLC_API bool
++vlc_dialog_is_cancelled(vlc_object_t *p_obj, vlc_dialog_id *p_id);
++#define vlc_dialog_is_cancelled(a, b) \
++    vlc_dialog_is_cancelled(VLC_OBJECT(a), b)
++
++/**
++ * @}
++ * @defgroup vlc_dialog_impl VLC dialog callbacks
++ * Need to be implemented by GUI modules or libvlc
++ * @{
++ */
++
++/**
++ * Dialog callbacks to be implemented
++ */
++typedef struct vlc_dialog_cbs
++{
++    /**
++     * Called when an error message needs to be displayed
++     *
++     * @param p_data opaque pointer for the callback
++     * @param psz_title title of the dialog
++     * @param psz_text text of the dialog
++     */
++    void (*pf_display_error)(void *p_data, const char *psz_title,
++                             const char *psz_text);
++
++    /**
++     * Called when a login dialog needs to be displayed
++     *
++     * You can interact with this dialog by calling vlc_dialog_id_post_login()
++     * to post an answer or vlc_dialog_id_dismiss() to cancel this dialog.
++     *
++     * @note to receive this callback, vlc_dialog_cbs.pf_cancel should not be
++     * NULL.
++     *
++     * @param p_data opaque pointer for the callback
++     * @param p_id id used to interact with the dialog
++     * @param psz_title title of the dialog
++     * @param psz_text text of the dialog
++     * @param psz_default_username user name that should be set on the user form
++     * @param b_ask_store if true, ask the user if he wants to save the
++     * credentials
++     */
++    void (*pf_display_login)(void *p_data, vlc_dialog_id *p_id,
++                             const char *psz_title, const char *psz_text,
++                             const char *psz_default_username,
++                             bool b_ask_store);
++
++    /**
++     * Called when a question dialog needs to be displayed
++     *
++     * You can interact with this dialog by calling vlc_dialog_id_post_action()
++     * to post an answer or vlc_dialog_id_dismiss() to cancel this dialog.
++     *
++     * @note to receive this callback, vlc_dialog_cbs.pf_cancel should not be
++     * NULL.
++     *
++     * @param p_data opaque pointer for the callback
++     * @param p_id id used to interact with the dialog
++     * @param psz_title title of the dialog
++     * @param psz_text text of the dialog
++     * @param i_type question type (or severity) of the dialog
++     * @param psz_cancel text of the cancel button
++     * @param psz_action1 text of the first button, if NULL, don't display this
++     * button
++     * @param psz_action2 text of the second button, if NULL, don't display
++     * this button
++     */
++    void (*pf_display_question)(void *p_data, vlc_dialog_id *p_id,
++                                const char *psz_title, const char *psz_text,
++                                vlc_dialog_question_type i_type,
++                                const char *psz_cancel, const char *psz_action1,
++                                const char *psz_action2);
++
++    /**
++     * Called when a progress dialog needs to be displayed
++     *
++     * If cancellable (psz_cancel != NULL), you can cancel this dialog by
++     * calling vlc_dialog_id_dismiss()
++     *
++     * @note to receive this callback, vlc_dialog_cbs.pf_cancel and
++     * vlc_dialog_cbs.pf_update_progress should not be NULL.
++     *
++     * @param p_data opaque pointer for the callback
++     * @param p_id id used to interact with the dialog
++     * @param psz_title title of the dialog
++     * @param psz_text text of the dialog
++     * @param b_indeterminate true if the progress dialog is indeterminate
++     * @param f_position initial position of the progress bar (between 0.0 and
++     * 1.0)
++     * @param psz_cancel text of the cancel button, if NULL the dialog is not
++     * cancellable
++     */
++    void (*pf_display_progress)(void *p_data, vlc_dialog_id *p_id,
++                                const char *psz_title, const char *psz_text,
++                                bool b_indeterminate, float f_position,
++                                const char *psz_cancel);
++
++    /**
++     * Called when a displayed dialog needs to be cancelled
++     *
++     * The implementation must call vlc_dialog_id_dismiss() to really release
++     * the dialog.
++     *
++     * @param p_data opaque pointer for the callback
++     * @param p_id id of the dialog
++     */
++    void (*pf_cancel)(void *p_data, vlc_dialog_id *p_id);
++
++    /**
++     * Called when a progress dialog needs to be updated
++     *
++     * @param p_data opaque pointer for the callback
++     * @param p_id id of the dialog
++     * @param f_position osition of the progress bar (between 0.0 and 1.0)
++     * @param psz_text new text of the progress dialog
++     */
++    void (*pf_update_progress)(void *p_data, vlc_dialog_id *p_id,
++                               float f_position, const char *psz_text);
++} vlc_dialog_cbs;
++
++/**
++ * Register callbacks to handle VLC dialogs
++ *
++ * @param p_cbs a pointer to callbacks, or NULL to unregister callbacks.
++ * @param p_data opaque pointer for the callback
++ */
++VLC_API void
++vlc_dialog_provider_set_callbacks(vlc_object_t *p_obj,
++                                  const vlc_dialog_cbs *p_cbs, void *p_data);
++#define vlc_dialog_provider_set_callbacks(a, b, c) \
++    vlc_dialog_provider_set_callbacks(VLC_OBJECT(a), b, c)
++
++/**
++ * Associate an opaque pointer with the dialog id
++ */
++VLC_API void
++vlc_dialog_id_set_context(vlc_dialog_id *p_id, void *p_context);
++
++/**
++ * Return the opaque pointer associated with the dialog id
++ */
++VLC_API void *
++vlc_dialog_id_get_context(vlc_dialog_id *p_id);
++
++/**
++ * Post a login answer
++ *
++ * After this call, p_id won't be valid anymore
++ *
++ * @see vlc_dialog_cbs.pf_display_login
++ *
++ * @param p_id id of the dialog
++ * @param psz_username valid and non empty string
++ * @param psz_password valid string (can be empty)
++ * @param b_store if true, store the credentials
++ * @return VLC_SUCCESS on success, or a VLC error code on error
++ */
++VLC_API int
++vlc_dialog_id_post_login(vlc_dialog_id *p_id, const char *psz_username,
++                         const char *psz_password, bool b_store);
++
++/**
++ * Post a question answer
++ *
++ * After this call, p_id won't be valid anymore
++ *
++ * @see vlc_dialog_cbs.pf_display_question
++ *
++ * @param p_id id of the dialog
++ * @param i_action 1 for action1, 2 for action2
++ * @return VLC_SUCCESS on success, or a VLC error code on error
++ */
++VLC_API int
++vlc_dialog_id_post_action(vlc_dialog_id *p_id, int i_action);
++
++/**
++ * Dismiss a dialog
++ *
++ * After this call, p_id won't be valid anymore
++ *
++ * @see vlc_dialog_cbs.pf_cancel
++ *
++ * @param p_id id of the dialog
++ * @return VLC_SUCCESS on success, or a VLC error code on error
++ */
++VLC_API int
++vlc_dialog_id_dismiss(vlc_dialog_id *p_id);
++
++/**
++ * @}
++ * @defgroup vlc_dialog_ext VLC extension dialog functions
++ * @{
++ */
++
++VLC_API int
++vlc_ext_dialog_update(vlc_object_t *p_obj, extension_dialog_t *dialog);
++#define vlc_ext_dialog_update(a, b) \
++    vlc_ext_dialog_update(VLC_OBJECT(a), b)
++
++/**
++ * Dialog extension callback to be implemented
++ */
++typedef void (*vlc_dialog_ext_update_cb)(extension_dialog_t *p_ext_dialog,
++                                         void *p_data);
++
++/**
++ * Register a callback for VLC extension dialog
++ *
++ * @param pf_update a pointer to the update callback, or NULL to unregister
++ * callback
++ * @param p_data opaque pointer for the callback
++ */
++VLC_API void
++vlc_dialog_provider_set_ext_callback(vlc_object_t *p_obj,
++                                     vlc_dialog_ext_update_cb pf_update,
++                                     void *p_data);
++#define vlc_dialog_provider_set_ext_callback(a, b, c) \
++    vlc_dialog_provider_set_ext_callback(VLC_OBJECT(a), b, c)
++
++/** @} @} */
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_epg.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_epg.h
+new file mode 100644
+index 0000000..7ccfedf
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_epg.h
+@@ -0,0 +1,120 @@
++/*****************************************************************************
++ * vlc_epg.h: Electronic Program Guide
++ *****************************************************************************
++ * Copyright (C) 2007 VLC authors and VideoLAN
++ * $Id: f7b9044e7c0aa1af4a44066d73f2ead943fc6a46 $
++ *
++ * Authors: Laurent Aimar <fenrir@via.ecp.fr>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_EPG_H
++#define VLC_EPG_H 1
++
++/**
++ * \file
++ * This file defines functions and structures for storing dvb epg information
++ */
++
++typedef struct
++{
++    int64_t  i_start;    /* Interpreted as a value return by time() */
++    uint32_t i_duration; /* Duration of the event in second */
++    uint16_t i_id;       /* Unique event id withing the event set */
++
++    char    *psz_name;
++    char    *psz_short_description;
++    char    *psz_description;
++    struct               /* Description items in tranmission order */
++    {
++        char *psz_key;
++        char *psz_value;
++    } * description_items;
++    int i_description_items;
++
++    uint8_t i_rating;   /* Parental control, set to 0 when undefined */
++} vlc_epg_event_t;
++
++typedef struct
++{
++    char            *psz_name;
++    uint32_t         i_id;       /* Unique identifier for this table / events (partial sets) */
++    uint16_t         i_source_id;/* Channel / Program reference id this epg relates to */
++    size_t            i_event;
++    vlc_epg_event_t **pp_event;
++    bool             b_present;  /* Contains present/following or similar, and sets below */
++    const vlc_epg_event_t *p_current; /* NULL, or equal to one of the entries in pp_event */
++} vlc_epg_t;
++
++/**
++ * Creates a new vlc_epg_event_t*
++ *
++ * You must call vlc_epg_event_Delete to release the associated resources.
++ *
++ * \p i_id is the event unique id
++ * \p i_start start in epoch time
++ * \p i_duration event duration in seconds
++ */
++VLC_API vlc_epg_event_t * vlc_epg_event_New(uint16_t i_id,
++                                            int64_t i_start, uint32_t i_duration);
++
++/**
++ * Releases a vlc_epg_event_t*.
++ */
++VLC_API void vlc_epg_event_Delete(vlc_epg_event_t *p_event);
++
++/**
++ * Returns a vlc_epg_event_t * duplicated from \p p_src.
++ *
++ */
++VLC_API vlc_epg_event_t * vlc_epg_event_Duplicate(const vlc_epg_event_t *p_src);
++
++/**
++ * It creates a new vlc_epg_t*
++ *
++ * You must call vlc_epg_Delete to release the associated resource.
++ *
++ * \p i_id is computed unique id depending on standard (table id, eit number)
++ * \p i_source_id is the associated program number
++ */
++VLC_API vlc_epg_t * vlc_epg_New(uint32_t i_id, uint16_t i_source_id);
++
++/**
++ * It releases a vlc_epg_t*.
++ */
++VLC_API void vlc_epg_Delete(vlc_epg_t *p_epg);
++
++/**
++ * It appends a new vlc_epg_event_t to a vlc_epg_t.
++ * Takes ownership of \p p_evt or returns false
++ *
++ * \p p_evt a vlc_epg_event_t * created with vlc_epg_event_New.
++ */
++VLC_API bool vlc_epg_AddEvent(vlc_epg_t *p_epg, vlc_epg_event_t *p_evt);
++
++/**
++ * It set the current event of a vlc_epg_t given a start time
++ */
++VLC_API void vlc_epg_SetCurrent(vlc_epg_t *p_epg, int64_t i_start);
++
++/**
++ * Returns a duplicated \p p_src and its associated events.
++ *
++ */
++VLC_API vlc_epg_t * vlc_epg_Duplicate(const vlc_epg_t *p_src);
++
++#endif
++
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_es.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_es.h
+new file mode 100644
+index 0000000..fa49a4f
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_es.h
+@@ -0,0 +1,668 @@
++/*****************************************************************************
++ * vlc_es.h: Elementary stream formats descriptions
++ *****************************************************************************
++ * Copyright (C) 1999-2012 VLC authors and VideoLAN
++ * $Id: c03fca394aeef77ad642defe241bd5a5ffe5d53d $
++ *
++ * Authors: Laurent Aimar <fenrir@via.ecp.fr>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_ES_H
++#define VLC_ES_H 1
++
++#include <vlc_common.h>
++#include <vlc_fourcc.h>
++#include <vlc_text_style.h>
++#include <vlc_viewpoint.h>
++
++/**
++ * \file
++ * This file defines the elementary streams format types
++ */
++
++/**
++ * video palette data
++ * \see video_format_t
++ * \see subs_format_t
++ */
++#define VIDEO_PALETTE_COLORS_MAX 256
++
++struct video_palette_t
++{
++    int i_entries;      /**< to keep the compatibility with libavcodec's palette */
++    uint8_t palette[VIDEO_PALETTE_COLORS_MAX][4];  /**< 4-byte RGBA/YUVA palette */
++};
++
++/**
++ * audio replay gain description
++ */
++#define AUDIO_REPLAY_GAIN_MAX (2)
++#define AUDIO_REPLAY_GAIN_TRACK (0)
++#define AUDIO_REPLAY_GAIN_ALBUM (1)
++typedef struct
++{
++    /* true if we have the peak value */
++    bool pb_peak[AUDIO_REPLAY_GAIN_MAX];
++    /* peak value where 1.0 means full sample value */
++    float      pf_peak[AUDIO_REPLAY_GAIN_MAX];
++
++    /* true if we have the gain value */
++    bool pb_gain[AUDIO_REPLAY_GAIN_MAX];
++    /* gain value in dB */
++    float      pf_gain[AUDIO_REPLAY_GAIN_MAX];
++} audio_replay_gain_t;
++
++
++/**
++ * Audio channel type
++ */
++typedef enum audio_channel_type_t
++{
++    AUDIO_CHANNEL_TYPE_BITMAP,
++    AUDIO_CHANNEL_TYPE_AMBISONICS,
++} audio_channel_type_t;
++
++/**
++ * audio format description
++ */
++struct audio_format_t
++{
++    vlc_fourcc_t i_format;                          /**< audio format fourcc */
++    unsigned int i_rate;                              /**< audio sample-rate */
++
++    /* Describes the channels configuration of the samples (ie. number of
++     * channels which are available in the buffer, and positions). */
++    uint16_t     i_physical_channels;
++
++    /* Describes the chan mode, either set from the input
++     * (demux/codec/packetizer) or overridden by the user, used by audio
++     * filters. */
++    uint16_t     i_chan_mode;
++
++    /* Channel type */
++    audio_channel_type_t channel_type;
++
++    /* Optional - for A/52, SPDIF and DTS types : */
++    /* Bytes used by one compressed frame, depends on bitrate. */
++    unsigned int i_bytes_per_frame;
++
++    /* Number of sampleframes contained in one compressed frame. */
++    unsigned int i_frame_length;
++    /* Please note that it may be completely arbitrary - buffers are not
++     * obliged to contain a integral number of so-called "frames". It's
++     * just here for the division :
++     * buffer_size = i_nb_samples * i_bytes_per_frame / i_frame_length
++     */
++
++    /* FIXME ? (used by the codecs) */
++    unsigned     i_bitspersample;
++    unsigned     i_blockalign;
++    uint8_t      i_channels; /* must be <=32 */
++};
++
++/* Values available for audio channels */
++#define AOUT_CHAN_CENTER            0x1
++#define AOUT_CHAN_LEFT              0x2
++#define AOUT_CHAN_RIGHT             0x4
++#define AOUT_CHAN_REARCENTER        0x10
++#define AOUT_CHAN_REARLEFT          0x20
++#define AOUT_CHAN_REARRIGHT         0x40
++#define AOUT_CHAN_MIDDLELEFT        0x100
++#define AOUT_CHAN_MIDDLERIGHT       0x200
++#define AOUT_CHAN_LFE               0x1000
++
++#define AOUT_CHANS_FRONT  (AOUT_CHAN_LEFT       | AOUT_CHAN_RIGHT)
++#define AOUT_CHANS_MIDDLE (AOUT_CHAN_MIDDLELEFT | AOUT_CHAN_MIDDLERIGHT)
++#define AOUT_CHANS_REAR   (AOUT_CHAN_REARLEFT   | AOUT_CHAN_REARRIGHT)
++#define AOUT_CHANS_CENTER (AOUT_CHAN_CENTER     | AOUT_CHAN_REARCENTER)
++
++#define AOUT_CHANS_STEREO AOUT_CHANS_2_0
++#define AOUT_CHANS_2_0    (AOUT_CHANS_FRONT)
++#define AOUT_CHANS_2_1    (AOUT_CHANS_FRONT | AOUT_CHAN_LFE)
++#define AOUT_CHANS_3_0    (AOUT_CHANS_FRONT | AOUT_CHAN_CENTER)
++#define AOUT_CHANS_3_1    (AOUT_CHANS_3_0   | AOUT_CHAN_LFE)
++#define AOUT_CHANS_4_0    (AOUT_CHANS_FRONT | AOUT_CHANS_REAR)
++#define AOUT_CHANS_4_1    (AOUT_CHANS_4_0   | AOUT_CHAN_LFE)
++#define AOUT_CHANS_5_0    (AOUT_CHANS_4_0   | AOUT_CHAN_CENTER)
++#define AOUT_CHANS_5_1    (AOUT_CHANS_5_0   | AOUT_CHAN_LFE)
++#define AOUT_CHANS_6_0    (AOUT_CHANS_4_0   | AOUT_CHANS_MIDDLE)
++#define AOUT_CHANS_7_0    (AOUT_CHANS_6_0   | AOUT_CHAN_CENTER)
++#define AOUT_CHANS_7_1    (AOUT_CHANS_5_1   | AOUT_CHANS_MIDDLE)
++#define AOUT_CHANS_8_1    (AOUT_CHANS_7_1   | AOUT_CHAN_REARCENTER)
++
++#define AOUT_CHANS_4_0_MIDDLE (AOUT_CHANS_FRONT | AOUT_CHANS_MIDDLE)
++#define AOUT_CHANS_4_CENTER_REAR (AOUT_CHANS_FRONT | AOUT_CHANS_CENTER)
++#define AOUT_CHANS_5_0_MIDDLE (AOUT_CHANS_4_0_MIDDLE | AOUT_CHAN_CENTER)
++#define AOUT_CHANS_6_1_MIDDLE (AOUT_CHANS_5_0_MIDDLE | AOUT_CHAN_REARCENTER | AOUT_CHAN_LFE)
++
++/* Maximum number of mapped channels (or the maximum of bits set in
++ * i_physical_channels) */
++#define AOUT_CHAN_MAX               9
++/* Maximum number of unmapped channels */
++#define INPUT_CHAN_MAX              64
++
++/* Values available for i_chan_mode only */
++#define AOUT_CHANMODE_DUALMONO    0x1
++#define AOUT_CHANMODE_DOLBYSTEREO 0x2
++
++/**
++ * Picture orientation.
++ */
++typedef enum video_orientation_t
++{
++    ORIENT_TOP_LEFT = 0, /**< Top line represents top, left column left. */
++    ORIENT_TOP_RIGHT, /**< Flipped horizontally */
++    ORIENT_BOTTOM_LEFT, /**< Flipped vertically */
++    ORIENT_BOTTOM_RIGHT, /**< Rotated 180 degrees */
++    ORIENT_LEFT_TOP, /**< Transposed */
++    ORIENT_LEFT_BOTTOM, /**< Rotated 90 degrees clockwise */
++    ORIENT_RIGHT_TOP, /**< Rotated 90 degrees anti-clockwise */
++    ORIENT_RIGHT_BOTTOM, /**< Anti-transposed */
++
++    ORIENT_NORMAL      = ORIENT_TOP_LEFT,
++    ORIENT_TRANSPOSED  = ORIENT_LEFT_TOP,
++    ORIENT_ANTI_TRANSPOSED = ORIENT_RIGHT_BOTTOM,
++    ORIENT_HFLIPPED    = ORIENT_TOP_RIGHT,
++    ORIENT_VFLIPPED    = ORIENT_BOTTOM_LEFT,
++    ORIENT_ROTATED_180 = ORIENT_BOTTOM_RIGHT,
++    ORIENT_ROTATED_270 = ORIENT_LEFT_BOTTOM,
++    ORIENT_ROTATED_90  = ORIENT_RIGHT_TOP,
++} video_orientation_t;
++/** Convert EXIF orientation to enum video_orientation_t */
++#define ORIENT_FROM_EXIF(exif) ((0x57642310U >> (4 * ((exif) - 1))) & 7)
++/** Convert enum video_orientation_t to EXIF */
++#define ORIENT_TO_EXIF(orient) ((0x76853421U >> (4 * (orient))) & 15)
++/** If the orientation is natural or mirrored */
++#define ORIENT_IS_MIRROR(orient) parity(orient)
++/** If the orientation swaps dimensions */
++#define ORIENT_IS_SWAP(orient) (((orient) & 4) != 0)
++/** Applies horizontal flip to an orientation */
++#define ORIENT_HFLIP(orient) ((orient) ^ 1)
++/** Applies vertical flip to an orientation */
++#define ORIENT_VFLIP(orient) ((orient) ^ 2)
++/** Applies horizontal flip to an orientation */
++#define ORIENT_ROTATE_180(orient) ((orient) ^ 3)
++
++typedef enum video_transform_t
++{
++    TRANSFORM_IDENTITY       = ORIENT_NORMAL,
++    TRANSFORM_HFLIP          = ORIENT_HFLIPPED,
++    TRANSFORM_VFLIP          = ORIENT_VFLIPPED,
++    TRANSFORM_R180           = ORIENT_ROTATED_180,
++    TRANSFORM_R270           = ORIENT_ROTATED_270,
++    TRANSFORM_R90            = ORIENT_ROTATED_90,
++    TRANSFORM_TRANSPOSE      = ORIENT_TRANSPOSED,
++    TRANSFORM_ANTI_TRANSPOSE = ORIENT_ANTI_TRANSPOSED
++} video_transform_t;
++
++typedef enum video_multiview_mode_t
++{
++    /* No stereoscopy: 2D picture. */
++    MULTIVIEW_2D = 0,
++
++    /* Side-by-side with left eye first. */
++    MULTIVIEW_STEREO_SBS,
++
++    /* Top-bottom with left eye first. */
++    MULTIVIEW_STEREO_TB,
++
++    /* Row sequential with left eye first. */
++    MULTIVIEW_STEREO_ROW,
++
++    /* Column sequential with left eye first. */
++    MULTIVIEW_STEREO_COL,
++
++    /* Frame sequential with left eye first. */
++    MULTIVIEW_STEREO_FRAME,
++
++    /* Checkerboard pattern with left eye first. */
++    MULTIVIEW_STEREO_CHECKERBOARD,
++} video_multiview_mode_t;
++
++/**
++ * Video projection mode.
++ */
++typedef enum video_projection_mode_t
++{
++    PROJECTION_MODE_RECTANGULAR = 0,
++    PROJECTION_MODE_EQUIRECTANGULAR,
++
++    PROJECTION_MODE_CUBEMAP_LAYOUT_STANDARD = 0x100,
++} video_projection_mode_t;
++
++/**
++ * Video color primaries (a.k.a. chromacities)
++ */
++typedef enum video_color_primaries_t
++{
++    COLOR_PRIMARIES_UNDEF,
++    COLOR_PRIMARIES_BT601_525,
++    COLOR_PRIMARIES_BT601_625,
++    COLOR_PRIMARIES_BT709,
++    COLOR_PRIMARIES_BT2020,
++    COLOR_PRIMARIES_DCI_P3,
++    COLOR_PRIMARIES_FCC1953,
++#define COLOR_PRIMARIES_SRGB            COLOR_PRIMARIES_BT709
++#define COLOR_PRIMARIES_SMTPE_170       COLOR_PRIMARIES_BT601_525
++#define COLOR_PRIMARIES_SMTPE_240       COLOR_PRIMARIES_BT601_525 /* Only differs from 1e10-4 in white Y */
++#define COLOR_PRIMARIES_SMTPE_RP145     COLOR_PRIMARIES_BT601_525
++#define COLOR_PRIMARIES_EBU_3213        COLOR_PRIMARIES_BT601_625
++#define COLOR_PRIMARIES_BT470_BG        COLOR_PRIMARIES_BT601_625
++#define COLOR_PRIMARIES_BT470_M         COLOR_PRIMARIES_FCC1953
++#define COLOR_PRIMARIES_MAX             COLOR_PRIMARIES_FCC1953
++} video_color_primaries_t;
++
++/**
++ * Video transfer functions
++ */
++typedef enum video_transfer_func_t
++{
++    TRANSFER_FUNC_UNDEF,
++    TRANSFER_FUNC_LINEAR,
++    TRANSFER_FUNC_SRGB /*< Gamma 2.2 */,
++    TRANSFER_FUNC_BT470_BG,
++    TRANSFER_FUNC_BT470_M,
++    TRANSFER_FUNC_BT709,
++    TRANSFER_FUNC_SMPTE_ST2084,
++    TRANSFER_FUNC_SMPTE_240,
++    TRANSFER_FUNC_HLG,
++#define TRANSFER_FUNC_BT2020            TRANSFER_FUNC_BT709
++#define TRANSFER_FUNC_SMPTE_170         TRANSFER_FUNC_BT709
++#define TRANSFER_FUNC_SMPTE_274         TRANSFER_FUNC_BT709
++#define TRANSFER_FUNC_SMPTE_293         TRANSFER_FUNC_BT709
++#define TRANSFER_FUNC_SMPTE_296         TRANSFER_FUNC_BT709
++#define TRANSFER_FUNC_ARIB_B67          TRANSFER_FUNC_HLG
++#define TRANSFER_FUNC_MAX               TRANSFER_FUNC_HLG
++} video_transfer_func_t;
++
++/**
++ * Video color space (i.e. YCbCr matrices)
++ */
++typedef enum video_color_space_t
++{
++    COLOR_SPACE_UNDEF,
++    COLOR_SPACE_BT601,
++    COLOR_SPACE_BT709,
++    COLOR_SPACE_BT2020,
++#define COLOR_SPACE_SRGB      COLOR_SPACE_BT709
++#define COLOR_SPACE_SMPTE_170 COLOR_SPACE_BT601
++#define COLOR_SPACE_SMPTE_240 COLOR_SPACE_SMPTE_170
++#define COLOR_SPACE_MAX       COLOR_SPACE_BT2020
++} video_color_space_t;
++
++/**
++ * Video chroma location
++ */
++typedef enum video_chroma_location_t
++{
++    CHROMA_LOCATION_UNDEF,
++    CHROMA_LOCATION_LEFT,   /*< Most common in MPEG-2 Video, H.264/265 */
++    CHROMA_LOCATION_CENTER, /*< Most common in MPEG-1 Video, JPEG */
++    CHROMA_LOCATION_TOP_LEFT,
++    CHROMA_LOCATION_TOP_CENTER,
++    CHROMA_LOCATION_BOTTOM_LEFT,
++    CHROMA_LOCATION_BOTTOM_CENTER,
++#define CHROMA_LOCATION_MAX CHROMA_LOCATION_BOTTOM_CENTER
++} video_chroma_location_t;
++
++/**
++ * video format description
++ */
++struct video_format_t
++{
++    vlc_fourcc_t i_chroma;                               /**< picture chroma */
++
++    unsigned int i_width;                                 /**< picture width */
++    unsigned int i_height;                               /**< picture height */
++    unsigned int i_x_offset;               /**< start offset of visible area */
++    unsigned int i_y_offset;               /**< start offset of visible area */
++    unsigned int i_visible_width;                 /**< width of visible area */
++    unsigned int i_visible_height;               /**< height of visible area */
++
++    unsigned int i_bits_per_pixel;             /**< number of bits per pixel */
++
++    unsigned int i_sar_num;                   /**< sample/pixel aspect ratio */
++    unsigned int i_sar_den;
++
++    unsigned int i_frame_rate;                     /**< frame rate numerator */
++    unsigned int i_frame_rate_base;              /**< frame rate denominator */
++
++    uint32_t i_rmask, i_gmask, i_bmask;      /**< color masks for RGB chroma */
++    int i_rrshift, i_lrshift;
++    int i_rgshift, i_lgshift;
++    int i_rbshift, i_lbshift;
++    video_palette_t *p_palette;              /**< video palette from demuxer */
++    video_orientation_t orientation;                /**< picture orientation */
++    video_color_primaries_t primaries;                  /**< color primaries */
++    video_transfer_func_t transfer;                   /**< transfer function */
++    video_color_space_t space;                        /**< YCbCr color space */
++    bool b_color_range_full;                    /**< 0-255 instead of 16-235 */
++    video_chroma_location_t chroma_location;      /**< YCbCr chroma location */
++
++    video_multiview_mode_t multiview_mode;        /** Multiview mode, 2D, 3D */
++
++    video_projection_mode_t projection_mode;            /**< projection mode */
++    vlc_viewpoint_t pose;
++    struct {
++        /* similar to SMPTE ST 2086 mastering display color volume */
++        uint16_t primaries[3*2]; /* G,B,R / x,y */
++        uint16_t white_point[2]; /* x,y */
++        uint32_t max_luminance;
++        uint32_t min_luminance;
++    } mastering;
++    struct {
++        /* similar to CTA-861.3 content light level */
++        uint16_t MaxCLL;  /* max content light level */
++        uint16_t MaxFALL; /* max frame average light level */
++    } lighting;
++    uint32_t i_cubemap_padding; /**< padding in pixels of the cube map faces */
++};
++
++/**
++ * Initialize a video_format_t structure with chroma 'i_chroma'
++ * \param p_src pointer to video_format_t structure
++ * \param i_chroma chroma value to use
++ */
++static inline void video_format_Init( video_format_t *p_src, vlc_fourcc_t i_chroma )
++{
++    memset( p_src, 0, sizeof( video_format_t ) );
++    p_src->i_chroma = i_chroma;
++    vlc_viewpoint_init( &p_src->pose );
++}
++
++/**
++ * Copy video_format_t including the palette
++ * \param p_dst video_format_t to copy to
++ * \param p_src video_format_t to copy from
++ */
++static inline int video_format_Copy( video_format_t *p_dst, const video_format_t *p_src )
++{
++    memcpy( p_dst, p_src, sizeof( *p_dst ) );
++    if( p_src->p_palette )
++    {
++        p_dst->p_palette = (video_palette_t *) malloc( sizeof( video_palette_t ) );
++        if( !p_dst->p_palette )
++            return VLC_ENOMEM;
++        memcpy( p_dst->p_palette, p_src->p_palette, sizeof( *p_dst->p_palette ) );
++    }
++    return VLC_SUCCESS;
++}
++
++static inline void video_format_AdjustColorSpace( video_format_t *p_fmt )
++{
++    if ( p_fmt->primaries == COLOR_PRIMARIES_UNDEF )
++    {
++        if ( p_fmt->i_visible_height > 576 ) // HD
++            p_fmt->primaries = COLOR_PRIMARIES_BT709;
++        else if ( p_fmt->i_visible_height > 525 ) // PAL
++            p_fmt->primaries = COLOR_PRIMARIES_BT601_625;
++        else
++            p_fmt->primaries = COLOR_PRIMARIES_BT601_525;
++    }
++
++    if ( p_fmt->transfer == TRANSFER_FUNC_UNDEF )
++    {
++        if ( p_fmt->i_visible_height > 576 ) // HD
++            p_fmt->transfer = TRANSFER_FUNC_BT709;
++        else
++            p_fmt->transfer = TRANSFER_FUNC_SRGB;
++    }
++
++    if ( p_fmt->space == COLOR_SPACE_UNDEF )
++    {
++        if ( p_fmt->i_visible_height > 576 ) // HD
++            p_fmt->space = COLOR_SPACE_BT709;
++        else
++            p_fmt->space = COLOR_SPACE_BT601;
++    }
++}
++
++/**
++ * Cleanup and free palette of this video_format_t
++ * \param p_src video_format_t structure to clean
++ */
++static inline void video_format_Clean( video_format_t *p_src )
++{
++    free( p_src->p_palette );
++    memset( p_src, 0, sizeof( video_format_t ) );
++}
++
++/**
++ * It will fill up a video_format_t using the given arguments.
++ * Note that the video_format_t must already be initialized.
++ */
++VLC_API void video_format_Setup( video_format_t *, vlc_fourcc_t i_chroma,
++    int i_width, int i_height, int i_visible_width, int i_visible_height,
++    int i_sar_num, int i_sar_den );
++
++/**
++ * It will copy the crop properties from a video_format_t to another.
++ */
++VLC_API void video_format_CopyCrop( video_format_t *, const video_format_t * );
++
++/**
++ * It will compute the crop/ar properties when scaling.
++ */
++VLC_API void video_format_ScaleCropAr( video_format_t *, const video_format_t * );
++
++/**
++ * This function "normalizes" the formats orientation, by switching the a/r according to the orientation,
++ * producing a format whose orientation is ORIENT_NORMAL. It makes a shallow copy (pallette is not alloc'ed).
++ */
++VLC_API void video_format_ApplyRotation(video_format_t * /*restrict*/ out,
++                                        const video_format_t *in);
++
++/**
++ * This function applies the transform operation to fmt.
++ */
++VLC_API void video_format_TransformBy(video_format_t *fmt, video_transform_t transform);
++
++/**
++ * This function applies the transforms necessary to fmt so that the resulting fmt
++ * has the dst_orientation.
++ */
++VLC_API void video_format_TransformTo(video_format_t *fmt, video_orientation_t dst_orientation);
++
++/**
++ * Returns the operation required to transform src into dst.
++ */
++VLC_API video_transform_t video_format_GetTransform(video_orientation_t src, video_orientation_t dst);
++
++/**
++ * This function will check if the first video format is similar
++ * to the second one.
++ */
++VLC_API bool video_format_IsSimilar( const video_format_t *, const video_format_t * );
++
++/**
++ * It prints details about the given video_format_t
++ */
++VLC_API void video_format_Print( vlc_object_t *, const char *, const video_format_t * );
++
++
++static inline video_transform_t transform_Inverse( video_transform_t transform )
++{
++    switch ( transform ) {
++        case TRANSFORM_R90:
++            return TRANSFORM_R270;
++        case TRANSFORM_R270:
++            return TRANSFORM_R90;
++        default:
++            return transform;
++    }
++}
++/**
++ * subtitles format description
++ */
++struct subs_format_t
++{
++    /* the character encoding of the text of the subtitle.
++     * all gettext recognized shorts can be used */
++    char *psz_encoding;
++
++
++    int  i_x_origin; /**< x coordinate of the subtitle. 0 = left */
++    int  i_y_origin; /**< y coordinate of the subtitle. 0 = top */
++
++    struct
++    {
++        /*  */
++        uint32_t palette[16+1];
++
++        /* the width of the original movie the spu was extracted from */
++        int i_original_frame_width;
++        /* the height of the original movie the spu was extracted from */
++        int i_original_frame_height;
++    } spu;
++
++    struct
++    {
++        int i_id;
++    } dvb;
++    struct
++    {
++        int i_magazine;
++        int i_page;
++    } teletext;
++    struct
++    {
++        uint8_t i_channel;
++        /* Reorder depth of transport video, -1 for no reordering */
++        int i_reorder_depth;
++    } cc;
++
++    text_style_t *p_style; /* Default styles to use */
++};
++
++#define SPU_PALETTE_DEFINED  0xbeefbeef
++
++/**
++ * ES language definition
++ */
++typedef struct extra_languages_t
++{
++        char *psz_language;
++        char *psz_description;
++} extra_languages_t;
++
++/** ES Categories */
++enum es_format_category_e
++{
++    UNKNOWN_ES = 0x00,
++    VIDEO_ES,
++    AUDIO_ES,
++    SPU_ES,
++    DATA_ES,
++};
++#define ES_CATEGORY_COUNT (DATA_ES + 1)
++
++/**
++ * ES format definition
++ */
++#define ES_PRIORITY_NOT_SELECTABLE  -2
++#define ES_PRIORITY_NOT_DEFAULTABLE -1
++#define ES_PRIORITY_SELECTABLE_MIN   0
++#define ES_PRIORITY_MIN ES_PRIORITY_NOT_SELECTABLE
++struct es_format_t
++{
++    enum es_format_category_e i_cat;    /**< ES category */
++    vlc_fourcc_t    i_codec;            /**< FOURCC value as used in vlc */
++    vlc_fourcc_t    i_original_fourcc;  /**< original FOURCC from the container */
++
++    int             i_id;       /**< es identifier, where means
++                                    -1: let the core mark the right id
++                                    >=0: valid id */
++    int             i_group;    /**< group identifier, where means:
++                                    -1 : standalone
++                                    >= 0 then a "group" (program) is created
++                                        for each value */
++    int             i_priority; /**< priority, where means:
++                                    -2 : mean not selectable by the users
++                                    -1 : mean not selected by default even
++                                         when no other stream
++                                    >=0: priority */
++
++    char            *psz_language;        /**< human-readable language name */
++    char            *psz_description;     /**< human-readable description of language */
++    unsigned        i_extra_languages;    /**< length in bytes of extra language data pointer */
++    extra_languages_t *p_extra_languages; /**< extra language data needed by some decoders */
++
++    union {
++        struct {
++            audio_format_t  audio;    /**< description of audio format */
++            audio_replay_gain_t audio_replay_gain; /*< audio replay gain information */
++        };
++        video_format_t video;     /**< description of video format */
++        subs_format_t  subs;      /**< description of subtitle format */
++    };
++
++    unsigned int   i_bitrate; /**< bitrate of this ES */
++    int      i_profile;       /**< codec specific information (like real audio flavor, mpeg audio layer, h264 profile ...) */
++    int      i_level;         /**< codec specific information: indicates maximum restrictions on the stream (resolution, bitrate, codec features ...) */
++
++    bool     b_packetized;  /**< whether the data is packetized (ie. not truncated) */
++    int     i_extra;        /**< length in bytes of extra data pointer */
++    void    *p_extra;       /**< extra data needed by some decoders or muxers */
++
++};
++
++/**
++ * This function will fill all RGB shift from RGB masks.
++ */
++VLC_API void video_format_FixRgb( video_format_t * );
++
++/**
++ * This function will initialize a es_format_t structure.
++ */
++VLC_API void es_format_Init( es_format_t *, int i_cat, vlc_fourcc_t i_codec );
++
++/**
++ * This function will initialize a es_format_t structure from a video_format_t.
++ */
++VLC_API void es_format_InitFromVideo( es_format_t *, const video_format_t * );
++
++/**
++ * This functions will copy a es_format_t.
++ */
++VLC_API int es_format_Copy( es_format_t *p_dst, const es_format_t *p_src );
++
++/**
++ * This function will clean up a es_format_t and release all associated
++ * resources.
++ * You can call it multiple times on the same structure.
++ */
++VLC_API void es_format_Clean( es_format_t *fmt );
++
++/**
++ * This function will check if the first ES format is similar
++ * to the second one.
++ *
++ * All descriptive fields are ignored.
++ */
++VLC_API bool es_format_IsSimilar( const es_format_t *, const es_format_t * );
++
++/**
++ * Changes ES format to another category
++ * Format must have been properly initialized
++ */
++static inline void es_format_Change( es_format_t *fmt, int i_cat, vlc_fourcc_t i_codec )
++{
++    es_format_Clean( fmt );
++    es_format_Init( fmt, i_cat, i_codec );
++}
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_es_out.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_es_out.h
+new file mode 100644
+index 0000000..d79ab4f
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_es_out.h
+@@ -0,0 +1,183 @@
++/*****************************************************************************
++ * vlc_es_out.h: es_out (demuxer output) descriptor, queries and methods
++ *****************************************************************************
++ * Copyright (C) 1999-2004 VLC authors and VideoLAN
++ * $Id: fe53c2a3d34f76eec76d83032cd0d3111be915aa $
++ *
++ * Authors: Laurent Aimar <fenrir@via.ecp.fr>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_ES_OUT_H
++#define VLC_ES_OUT_H 1
++
++/**
++ * \defgroup es_out ES output
++ * \ingroup input
++ * Elementary streams output
++ * @{
++ * \file
++ * Elementary streams output interface
++ */
++
++enum es_out_query_e
++{
++    /* set or change the selected ES in its category (audio/video/spu) */
++    ES_OUT_SET_ES,      /* arg1= es_out_id_t*                   */
++    ES_OUT_RESTART_ES,  /* arg1= es_out_id_t*                   */
++    ES_OUT_RESTART_ALL_ES, /* Deprecated, no effect */
++
++    /* set 'default' tag on ES (copied across from container) */
++    ES_OUT_SET_ES_DEFAULT, /* arg1= es_out_id_t*                */
++
++    /* force (un)selection of the ES (bypass current mode)
++       XXX: this will not change the state of any other ES ! (see SET_ES) */
++    ES_OUT_SET_ES_STATE,/* arg1= es_out_id_t* arg2=bool   */
++    ES_OUT_GET_ES_STATE,/* arg1= es_out_id_t* arg2=bool*  */
++
++    /* sets es selection policy when in auto mode */
++    ES_OUT_SET_ES_CAT_POLICY, /* arg1=es_format_category_e arg2=es_out_policy_e */
++
++    /* */
++    ES_OUT_SET_GROUP,   /* arg1= int                            */
++
++    /* PCR handling, DTS/PTS will be automatically computed using thoses PCR
++     * XXX: SET_PCR(_GROUP) are in charge of the pace control. They will wait
++     * to slow down the demuxer so that it reads at the right speed.
++     * XXX: if you want PREROLL just call ES_OUT_SET_NEXT_DISPLAY_TIME and send
++     * as you would normally do.
++     */
++    ES_OUT_SET_PCR,             /* arg1=int64_t i_pcr(microsecond!) (using default group 0)*/
++    ES_OUT_SET_GROUP_PCR,       /* arg1= int i_group, arg2=int64_t i_pcr(microsecond!)*/
++    ES_OUT_RESET_PCR,           /* no arg */
++
++    /* Try not to use this one as it is a bit hacky */
++    ES_OUT_SET_ES_FMT,         /* arg1= es_out_id_t* arg2=es_format_t* */
++
++    /* Allow preroll of data (data with dts/pts < i_pts for all ES will be decoded but not displayed */
++    ES_OUT_SET_NEXT_DISPLAY_TIME,       /* arg1=int64_t i_pts(microsecond) */
++    /* Set meta data for group (dynamic) (The vlc_meta_t is not modified nor released) */
++    ES_OUT_SET_GROUP_META,  /* arg1=int i_group arg2=const vlc_meta_t */
++    /* Set epg for group (dynamic) (The vlc_epg_t is not modified nor released) */
++    ES_OUT_SET_GROUP_EPG,       /* arg1=int i_group arg2=const vlc_epg_t * */
++    ES_OUT_SET_GROUP_EPG_EVENT, /* arg1=int i_group arg2=const vlc_epg_event_t * */
++    ES_OUT_SET_EPG_TIME,        /* arg1=int int64_t */
++
++    /* */
++    ES_OUT_DEL_GROUP,       /* arg1=int i_group */
++
++    /* Set scrambled state for one es */
++    ES_OUT_SET_ES_SCRAMBLED_STATE,  /* arg1=int i_group arg2=es_out_id_t* */
++
++    /* Stop any buffering being done, and ask if es_out has no more data to
++     * play.
++     * It will not block and so MUST be used carrefully. The only good reason
++     * is for interactive playback (like for DVD menu).
++     * XXX You SHALL call ES_OUT_RESET_PCR before any other es_out_Control/Send calls. */
++    ES_OUT_GET_EMPTY,       /* arg1=bool*   res=cannot fail */
++
++    /* Set global meta data (The vlc_meta_t is not modified nor released) */
++    ES_OUT_SET_META, /* arg1=const vlc_meta_t * */
++
++    /* PCR system clock manipulation for external clock synchronization */
++    ES_OUT_GET_PCR_SYSTEM, /* arg1=mtime_t *, arg2=mtime_t * res=can fail */
++    ES_OUT_MODIFY_PCR_SYSTEM, /* arg1=int is_absolute, arg2=mtime_t, res=can fail */
++
++    ES_OUT_POST_SUBNODE, /* arg1=input_item_node_t *, res=can fail */
++
++    /* First value usable for private control */
++    ES_OUT_PRIVATE_START = 0x10000,
++};
++
++enum es_out_policy_e
++{
++    ES_OUT_ES_POLICY_EXCLUSIVE = 0,/* Enforces single ES selection only */
++    ES_OUT_ES_POLICY_SIMULTANEOUS, /* Allows multiple ES per cat */
++};
++
++struct es_out_t
++{
++    es_out_id_t *(*pf_add)    ( es_out_t *, const es_format_t * );
++    int          (*pf_send)   ( es_out_t *, es_out_id_t *, block_t * );
++    void         (*pf_del)    ( es_out_t *, es_out_id_t * );
++    int          (*pf_control)( es_out_t *, int i_query, va_list );
++    void         (*pf_destroy)( es_out_t * );
++
++    es_out_sys_t    *p_sys;
++};
++
++VLC_USED
++static inline es_out_id_t * es_out_Add( es_out_t *out, const es_format_t *fmt )
++{
++    return out->pf_add( out, fmt );
++}
++
++static inline void es_out_Del( es_out_t *out, es_out_id_t *id )
++{
++    out->pf_del( out, id );
++}
++
++static inline int es_out_Send( es_out_t *out, es_out_id_t *id,
++                               block_t *p_block )
++{
++    return out->pf_send( out, id, p_block );
++}
++
++static inline int es_out_vaControl( es_out_t *out, int i_query, va_list args )
++{
++    return out->pf_control( out, i_query, args );
++}
++
++static inline int es_out_Control( es_out_t *out, int i_query, ... )
++{
++    va_list args;
++    int     i_result;
++
++    va_start( args, i_query );
++    i_result = es_out_vaControl( out, i_query, args );
++    va_end( args );
++    return i_result;
++}
++
++static inline void es_out_Delete( es_out_t *p_out )
++{
++    p_out->pf_destroy( p_out );
++}
++
++static inline int es_out_SetPCR( es_out_t *out, int64_t pcr )
++{
++    return es_out_Control( out, ES_OUT_SET_PCR, pcr );
++}
++
++static inline int es_out_ControlSetMeta( es_out_t *out, const vlc_meta_t *p_meta )
++{
++    return es_out_Control( out, ES_OUT_SET_META, p_meta );
++}
++
++static inline int es_out_ControlGetPcrSystem( es_out_t *out, mtime_t *pi_system, mtime_t *pi_delay )
++{
++    return es_out_Control( out, ES_OUT_GET_PCR_SYSTEM, pi_system, pi_delay );
++}
++static inline int es_out_ControlModifyPcrSystem( es_out_t *out, bool b_absolute, mtime_t i_system )
++{
++    return es_out_Control( out, ES_OUT_MODIFY_PCR_SYSTEM, b_absolute, i_system );
++}
++
++/**
++ * @}
++ */
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_events.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_events.h
+new file mode 100644
+index 0000000..ac4a225
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_events.h
+@@ -0,0 +1,209 @@
++/*****************************************************************************
++ * vlc_events.h: events definitions
++ * Interface used to send events.
++ *****************************************************************************
++ * Copyright (C) 2007 VLC authors and VideoLAN
++ * $Id: 229f4f677029763a837558932dad3e47b283e61c $
++ *
++ * Authors: Pierre d'Herbemont
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_EVENTS_H
++# define VLC_EVENTS_H
++
++#include <vlc_arrays.h>
++#include <vlc_meta.h>
++
++/**
++ * \file
++ * This file is the interface definition for events
++ * (implementation in src/misc/events.c)
++ */
++
++/*****************************************************************************
++ * Documentation
++ *****************************************************************************/
++/*
++ **** Background
++ *
++ * This implements a way to send and receive event for an object (which can be
++ * a simple C struct or less).
++ *
++ * This is in direct concurrency with the Variable based Callback
++ * (see src/misc/variables.c).
++ *
++ * It has the following advantages over Variable based Callback:
++ * - No need to implement the whole VLC_COMMON_MEMBERS in the object,
++ * thus it reduce it size. This is especially true for input_item_t which
++ * doesn't have VLC_COMMON_MEMBERS. This is the first reason of existence of
++ * this implementation.
++ * - Libvlc can easily be based upon that.
++ * - Existing event are clearly declared (in include/vlc_events.h)
++ *
++ *
++ **** Example usage
++ *
++ * (vlc_cool_object_t doesn't need to have the VLC_COMMON_MEMBERS.)
++ *
++ * struct vlc_cool_object_t
++ * {
++ *        ...
++ *        vlc_event_manager_t p_event_manager;
++ *        ...
++ * }
++ *
++ * vlc_my_cool_object_new()
++ * {
++ *        ...
++ *        vlc_event_manager_init( &p_self->p_event_manager, p_self, p_a_libvlc_object );
++ *        ...
++ * }
++ *
++ * vlc_my_cool_object_release()
++ * {
++ *         ...
++ *         vlc_event_manager_fini( &p_self->p_event_manager );
++ *         ...
++ * }
++ *
++ * vlc_my_cool_object_do_something()
++ * {
++ *        ...
++ *        vlc_event_t event;
++ *        event.type = vlc_MyCoolObjectDidSomething;
++ *        event.u.my_cool_object_did_something.what_it_did = kSomething;
++ *        vlc_event_send( &p_self->p_event_manager, &event );
++ * }
++ * */
++
++  /*****************************************************************************
++ * Event Type
++ *****************************************************************************/
++
++/* List of event */
++typedef enum vlc_event_type_t {
++    /* Input item events */
++    vlc_InputItemMetaChanged,
++    vlc_InputItemSubItemTreeAdded,
++    vlc_InputItemDurationChanged,
++    vlc_InputItemPreparsedChanged,
++    vlc_InputItemNameChanged,
++    vlc_InputItemInfoChanged,
++    vlc_InputItemErrorWhenReadingChanged,
++    vlc_InputItemPreparseEnded,
++} vlc_event_type_t;
++
++typedef struct vlc_event_listeners_group_t
++{
++    DECL_ARRAY(struct vlc_event_listener_t *) listeners;
++} vlc_event_listeners_group_t;
++
++/* Event manager type */
++typedef struct vlc_event_manager_t
++{
++    void * p_obj;
++    vlc_mutex_t lock;
++    vlc_event_listeners_group_t events[vlc_InputItemPreparseEnded + 1];
++} vlc_event_manager_t;
++
++/* Event definition */
++typedef struct vlc_event_t
++{
++    vlc_event_type_t type;
++    void * p_obj; /* Sender object, automatically filled by vlc_event_send() */
++    union vlc_event_type_specific
++    {
++        /* Input item events */
++        struct vlc_input_item_meta_changed
++        {
++            vlc_meta_type_t meta_type;
++        } input_item_meta_changed;
++        struct vlc_input_item_subitem_added
++        {
++            input_item_t * p_new_child;
++        } input_item_subitem_added;
++        struct vlc_input_item_subitem_tree_added
++        {
++            input_item_node_t * p_root;
++        } input_item_subitem_tree_added;
++        struct vlc_input_item_duration_changed
++        {
++            mtime_t new_duration;
++        } input_item_duration_changed;
++        struct vlc_input_item_preparsed_changed
++        {
++            int new_status;
++        } input_item_preparsed_changed;
++        struct vlc_input_item_name_changed
++        {
++            const char * new_name;
++        } input_item_name_changed;
++        struct vlc_input_item_info_changed
++        {
++            void * unused;
++        } input_item_info_changed;
++        struct input_item_error_when_reading_changed
++        {
++            bool new_value;
++        } input_item_error_when_reading_changed;
++        struct input_item_preparse_ended
++        {
++            int new_status;
++        } input_item_preparse_ended;
++    } u;
++} vlc_event_t;
++
++/* Event callback type */
++typedef void ( *vlc_event_callback_t )( const vlc_event_t *, void * );
++
++ /*****************************************************************************
++ * Event manager
++ *****************************************************************************/
++
++/*
++ * p_obj points to the object that owns the event manager, and from
++ * which events are sent
++ */
++void vlc_event_manager_init( vlc_event_manager_t * p_em, void * p_obj );
++
++/*
++ * Destroy
++ */
++void vlc_event_manager_fini( vlc_event_manager_t * p_em );
++
++/*
++ * Send an event to the listener attached to this p_em.
++ */
++void vlc_event_send( vlc_event_manager_t * p_em, vlc_event_t * );
++
++/*
++ * Add a callback for an event.
++ */
++VLC_API int vlc_event_attach( vlc_event_manager_t * p_event_manager,
++                              vlc_event_type_t event_type,
++                              vlc_event_callback_t pf_callback,
++                              void *p_user_data );
++
++/*
++ * Remove a callback for an event.
++ */
++VLC_API void vlc_event_detach( vlc_event_manager_t *p_event_manager,
++                               vlc_event_type_t event_type,
++                               vlc_event_callback_t pf_callback,
++                               void *p_user_data );
++
++#endif /* VLC_EVENTS_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_filter.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_filter.h
+new file mode 100644
+index 0000000..3b30dbb
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_filter.h
+@@ -0,0 +1,470 @@
++/*****************************************************************************
++ * vlc_filter.h: filter related structures and functions
++ *****************************************************************************
++ * Copyright (C) 1999-2014 VLC authors and VideoLAN
++ *
++ * Authors: Gildas Bazin <gbazin@videolan.org>
++ *          Antoine Cellerier <dionoea at videolan dot org>
++ *          Rémi Denis-Courmont
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_FILTER_H
++#define VLC_FILTER_H 1
++
++#include <vlc_es.h>
++
++/**
++ * \defgroup filter Filters
++ * \ingroup output
++ * Audio, video, text filters
++ * @{
++ * \file
++ * Filter modules interface
++ */
++
++typedef struct filter_owner_sys_t filter_owner_sys_t;
++
++typedef struct filter_owner_t
++{
++    void *sys;
++
++    union
++    {
++        struct
++        {
++            picture_t * (*buffer_new)( filter_t * );
++        } video;
++        struct
++        {
++            subpicture_t * (*buffer_new)( filter_t * );
++        } sub;
++    };
++} filter_owner_t;
++
++struct vlc_mouse_t;
++
++/** Structure describing a filter
++ * @warning BIG FAT WARNING : the code relies on the first 4 members of
++ * filter_t and decoder_t to be the same, so if you have anything to add,
++ * do it at the end of the structure.
++ */
++struct filter_t
++{
++    VLC_COMMON_MEMBERS
++
++    /* Module properties */
++    module_t *          p_module;
++    filter_sys_t *      p_sys;
++
++    /* Input format */
++    es_format_t         fmt_in;
++
++    /* Output format of filter */
++    es_format_t         fmt_out;
++    bool                b_allow_fmt_out_change;
++
++    /* Name of the "video filter" shortcut that is requested, can be NULL */
++    const char *        psz_name;
++    /* Filter configuration */
++    config_chain_t *    p_cfg;
++
++    union
++    {
++        /** Filter a picture (video filter) */
++        picture_t * (*pf_video_filter)( filter_t *, picture_t * );
++
++        /** Filter an audio block (audio filter) */
++        block_t * (*pf_audio_filter)( filter_t *, block_t * );
++
++        /** Blend a subpicture onto a picture (blend) */
++        void (*pf_video_blend)( filter_t *,  picture_t *, const picture_t *,
++                                 int, int, int );
++
++        /** Generate a subpicture (sub source) */
++        subpicture_t *(*pf_sub_source)( filter_t *, mtime_t );
++
++        /** Filter a subpicture (sub filter) */
++        subpicture_t *(*pf_sub_filter)( filter_t *, subpicture_t * );
++
++        /** Render text (text render) */
++        int (*pf_render)( filter_t *, subpicture_region_t *,
++                          subpicture_region_t *, const vlc_fourcc_t * );
++    };
++
++    union
++    {
++        /* TODO: video filter drain */
++        /** Drain (audio filter) */
++        block_t *(*pf_audio_drain) ( filter_t * );
++    };
++
++    /** Flush
++     *
++     * Flush (i.e. discard) any internal buffer in a video or audio filter.
++     */
++    void (*pf_flush)( filter_t * );
++
++    /** Change viewpoint
++     *
++     * Pass a new viewpoint to audio filters. Filters like the spatialaudio one
++     * used for Ambisonics rendering will change its output according to this
++     * viewpoint.
++     */
++    void (*pf_change_viewpoint)( filter_t *, const vlc_viewpoint_t * );
++
++    union
++    {
++        /** Filter mouse state (video filter).
++         *
++         * If non-NULL, you must convert from output to input formats:
++         * - If VLC_SUCCESS is returned, the mouse state is propagated.
++         * - Otherwise, the mouse change is not propagated.
++         * If NULL, the mouse state is considered unchanged and will be
++         * propagated. */
++        int (*pf_video_mouse)( filter_t *, struct vlc_mouse_t *,
++                               const struct vlc_mouse_t *p_old,
++                               const struct vlc_mouse_t *p_new );
++        int (*pf_sub_mouse)( filter_t *, const struct vlc_mouse_t *p_old,
++                             const struct vlc_mouse_t *p_new,
++                             const video_format_t * );
++    };
++
++    /* Input attachments
++     * XXX use filter_GetInputAttachments */
++    int (*pf_get_attachments)( filter_t *, input_attachment_t ***, int * );
++
++    /* Private structure for the owner of the decoder */
++    filter_owner_t      owner;
++};
++
++/**
++ * This function will return a new picture usable by p_filter as an output
++ * buffer. You have to release it using picture_Release or by returning
++ * it to the caller as a pf_video_filter return value.
++ * Provided for convenience.
++ *
++ * \param p_filter filter_t object
++ * \return new picture on success or NULL on failure
++ */
++static inline picture_t *filter_NewPicture( filter_t *p_filter )
++{
++    picture_t *pic = p_filter->owner.video.buffer_new( p_filter );
++    if( pic == NULL )
++        msg_Warn( p_filter, "can't get output picture" );
++    return pic;
++}
++
++/**
++ * Flush a filter
++ *
++ * This function will flush the state of a filter (audio or video).
++ */
++static inline void filter_Flush( filter_t *p_filter )
++{
++    if( p_filter->pf_flush != NULL )
++        p_filter->pf_flush( p_filter );
++}
++
++static inline void filter_ChangeViewpoint( filter_t *p_filter,
++                                           const vlc_viewpoint_t *vp)
++{
++    if( p_filter->pf_change_viewpoint != NULL )
++        p_filter->pf_change_viewpoint( p_filter, vp );
++}
++
++/**
++ * This function will drain, then flush an audio filter.
++ */
++static inline block_t *filter_DrainAudio( filter_t *p_filter )
++{
++    if( p_filter->pf_audio_drain )
++        return p_filter->pf_audio_drain( p_filter );
++    else
++        return NULL;
++}
++
++/**
++ * This function will return a new subpicture usable by p_filter as an output
++ * buffer. You have to release it using subpicture_Delete or by returning it to
++ * the caller as a pf_sub_source return value.
++ * Provided for convenience.
++ *
++ * \param p_filter filter_t object
++ * \return new subpicture
++ */
++static inline subpicture_t *filter_NewSubpicture( filter_t *p_filter )
++{
++    subpicture_t *subpic = p_filter->owner.sub.buffer_new( p_filter );
++    if( subpic == NULL )
++        msg_Warn( p_filter, "can't get output subpicture" );
++    return subpic;
++}
++
++/**
++ * This function gives all input attachments at once.
++ *
++ * You MUST release the returned values
++ */
++static inline int filter_GetInputAttachments( filter_t *p_filter,
++                                              input_attachment_t ***ppp_attachment,
++                                              int *pi_attachment )
++{
++    if( !p_filter->pf_get_attachments )
++        return VLC_EGENERIC;
++    return p_filter->pf_get_attachments( p_filter,
++                                         ppp_attachment, pi_attachment );
++}
++
++/**
++ * This function duplicates every variables from the filter, and adds a proxy
++ * callback to trigger filter events from obj.
++ *
++ * \param restart_cb a vlc_callback_t to call if the event means restarting the
++ * filter (i.e. an event on a non-command variable)
++ */
++VLC_API void filter_AddProxyCallbacks( vlc_object_t *obj, filter_t *filter,
++                                       vlc_callback_t restart_cb );
++# define filter_AddProxyCallbacks(a, b, c) \
++    filter_AddProxyCallbacks(VLC_OBJECT(a), b, c)
++
++/**
++ * This function removes the callbacks previously added to every duplicated
++ * variables, and removes them afterward.
++ *
++ * \param restart_cb the same vlc_callback_t passed to filter_AddProxyCallbacks
++ */
++VLC_API void filter_DelProxyCallbacks( vlc_object_t *obj, filter_t *filter,
++                                       vlc_callback_t restart_cb);
++# define filter_DelProxyCallbacks(a, b, c) \
++    filter_DelProxyCallbacks(VLC_OBJECT(a), b, c)
++
++/**
++ * It creates a blend filter.
++ *
++ * Only the chroma properties of the dest format is used (chroma
++ * type, rgb masks and shifts)
++ */
++VLC_API filter_t * filter_NewBlend( vlc_object_t *, const video_format_t *p_dst_chroma ) VLC_USED;
++
++/**
++ * It configures blend filter parameters that are allowed to changed
++ * after the creation.
++ */
++VLC_API int filter_ConfigureBlend( filter_t *, int i_dst_width, int i_dst_height, const video_format_t *p_src );
++
++/**
++ * It blends a picture into another one.
++ *
++ * The input picture is not modified and not released.
++ */
++VLC_API int filter_Blend( filter_t *, picture_t *p_dst, int i_dst_x, int i_dst_y, const picture_t *p_src, int i_alpha );
++
++/**
++ * It destroys a blend filter created by filter_NewBlend.
++ */
++VLC_API void filter_DeleteBlend( filter_t * );
++
++/**
++ * Create a picture_t *(*)( filter_t *, picture_t * ) compatible wrapper
++ * using a void (*)( filter_t *, picture_t *, picture_t * ) function
++ *
++ * Currently used by the chroma video filters
++ */
++#define VIDEO_FILTER_WRAPPER( name )                                    \
++    static picture_t *name ## _Filter ( filter_t *p_filter,             \
++                                        picture_t *p_pic )              \
++    {                                                                   \
++        picture_t *p_outpic = filter_NewPicture( p_filter );            \
++        if( p_outpic )                                                  \
++        {                                                               \
++            name( p_filter, p_pic, p_outpic );                          \
++            picture_CopyProperties( p_outpic, p_pic );                  \
++        }                                                               \
++        picture_Release( p_pic );                                       \
++        return p_outpic;                                                \
++    }
++
++/**
++ * Filter chain management API
++ * The filter chain management API is used to dynamically construct filters
++ * and add them in a chain.
++ */
++
++typedef struct filter_chain_t filter_chain_t;
++
++/**
++ * Create new filter chain
++ *
++ * \param p_object pointer to a vlc object
++ * \param psz_capability vlc capability of filters in filter chain
++ * \return pointer to a filter chain
++ */
++filter_chain_t * filter_chain_New( vlc_object_t *, const char *, enum es_format_category_e )
++VLC_USED;
++#define filter_chain_New( a, b, c ) filter_chain_New( VLC_OBJECT( a ), b, c )
++
++/**
++ * Creates a new video filter chain.
++ *
++ * \param obj pointer to parent VLC object
++ * \param change whether to allow changing the output format
++ * \param owner owner video buffer callbacks
++ * \return new filter chain, or NULL on error
++ */
++VLC_API filter_chain_t * filter_chain_NewVideo( vlc_object_t *obj, bool change,
++                                                const filter_owner_t *owner )
++VLC_USED;
++#define filter_chain_NewVideo( a, b, c ) \
++        filter_chain_NewVideo( VLC_OBJECT( a ), b, c )
++
++/**
++ * Delete filter chain will delete all filters in the chain and free all
++ * allocated data. The pointer to the filter chain is then no longer valid.
++ *
++ * \param p_chain pointer to filter chain
++ */
++VLC_API void filter_chain_Delete( filter_chain_t * );
++
++/**
++ * Reset filter chain will delete all filters in the chain and
++ * reset p_fmt_in and p_fmt_out to the new values.
++ *
++ * \param p_chain pointer to filter chain
++ * \param p_fmt_in new fmt_in params, may be NULL to leave input fmt unchanged
++ * \param p_fmt_out new fmt_out params, may be NULL to leave output fmt unchanged
++ */
++VLC_API void filter_chain_Reset( filter_chain_t *, const es_format_t *, const es_format_t * );
++
++/**
++ * Append a filter to the chain.
++ *
++ * \param chain filter chain to append a filter to
++ * \param name filter name
++ * \param fmt_in filter input format
++ * \param fmt_out filter output format
++ * \return a pointer to the filter or NULL on error
++ */
++VLC_API filter_t *filter_chain_AppendFilter(filter_chain_t *chain,
++    const char *name, config_chain_t *cfg, const es_format_t *fmt_in,
++    const es_format_t *fmt_out);
++
++/**
++ * Append a conversion to the chain.
++ *
++ * \param chain filter chain to append a filter to
++ * \param fmt_in filter input format
++ * \param fmt_out filter output format
++ * \retval 0 on success
++ * \retval -1 on failure
++ */
++VLC_API int filter_chain_AppendConverter(filter_chain_t *chain,
++    const es_format_t *fmt_in, const es_format_t *fmt_out);
++
++/**
++ * Append new filter to filter chain from string.
++ *
++ * \param chain filter chain to append a filter to
++ * \param str filters chain nul-terminated string
++ */
++VLC_API int filter_chain_AppendFromString(filter_chain_t *chain,
++                                          const char *str);
++
++/**
++ * Delete filter from filter chain. This function also releases the filter
++ * object and unloads the filter modules. The pointer to p_filter is no
++ * longer valid after this function successfully returns.
++ *
++ * \param chain filter chain to remove the filter from
++ * \param filter filter to remove from the chain and delete
++ */
++VLC_API void filter_chain_DeleteFilter(filter_chain_t *chain,
++                                       filter_t *filter);
++
++/**
++ * Checks if the filter chain is empty.
++ *
++ * \param chain pointer to filter chain
++ * \return true if and only if there are no filters in this filter chain
++ */
++VLC_API bool filter_chain_IsEmpty(const filter_chain_t *chain);
++
++/**
++ * Get last output format of the last element in the filter chain.
++ *
++ * \param chain filter chain
++ */
++VLC_API const es_format_t *filter_chain_GetFmtOut(filter_chain_t *chain);
++
++/**
++ * Apply the filter chain to a video picture.
++ *
++ * \param chain pointer to filter chain
++ * \param pic picture to apply filters to
++ * \return modified picture after applying all video filters
++ */
++VLC_API picture_t *filter_chain_VideoFilter(filter_chain_t *chain,
++                                            picture_t *pic);
++
++/**
++ * Flush a video filter chain.
++ */
++VLC_API void filter_chain_VideoFlush( filter_chain_t * );
++
++/**
++ * Generate subpictures from a chain of subpicture source "filters".
++ *
++ * \param chain filter chain
++ * \param display_date of subpictures
++ */
++void filter_chain_SubSource(filter_chain_t *chain, spu_t *,
++                            mtime_t display_date);
++
++/**
++ * Apply filter chain to subpictures.
++ *
++ * \param chain filter chain
++ * \param subpic subpicture to apply filters on
++ * \return modified subpicture after applying all subpicture filters
++ */
++VLC_API subpicture_t *filter_chain_SubFilter(filter_chain_t *chain,
++                                             subpicture_t *subpic);
++
++/**
++ * Apply the filter chain to a mouse state.
++ *
++ * It will be applied from the output to the input. It makes sense only
++ * for a video filter chain.
++ *
++ * The vlc_mouse_t* pointers may be the same.
++ */
++VLC_API int filter_chain_MouseFilter( filter_chain_t *, struct vlc_mouse_t *,
++                                      const struct vlc_mouse_t * );
++
++/**
++ * Inform the filter chain of mouse state.
++ *
++ * It makes sense only for a sub source chain.
++ */
++VLC_API int filter_chain_MouseEvent( filter_chain_t *,
++                                     const struct vlc_mouse_t *,
++                                     const video_format_t * );
++
++int filter_chain_ForEach( filter_chain_t *chain,
++                          int (*cb)( filter_t *, void * ), void *opaque );
++
++/** @} */
++#endif /* _VLC_FILTER_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_fingerprinter.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_fingerprinter.h
+new file mode 100644
+index 0000000..dc10644
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_fingerprinter.h
+@@ -0,0 +1,91 @@
++/*****************************************************************************
++ * vlc_fingerprinter.h: Fingerprinter abstraction layer
++ *****************************************************************************
++ * Copyright (C) 2012 VLC authors and VideoLAN
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_FINGERPRINTER_H
++# define VLC_FINGERPRINTER_H
++
++#include <vlc_common.h>
++#include <vlc_meta.h>
++#include <vlc_input_item.h>
++#include <vlc_arrays.h>
++
++# ifdef __cplusplus
++extern "C" {
++# endif
++
++typedef struct fingerprinter_sys_t fingerprinter_sys_t;
++
++struct fingerprint_request_t
++{
++    input_item_t *p_item;
++    unsigned int i_duration; /* track length hint in seconds, 0 if unknown */
++    struct
++    {
++        char *psz_fingerprint;
++        vlc_array_t metas_array;
++    } results ;
++};
++typedef struct fingerprint_request_t fingerprint_request_t;
++
++static inline fingerprint_request_t *fingerprint_request_New( input_item_t *p_item )
++{
++    fingerprint_request_t *p_r =
++            ( fingerprint_request_t * ) calloc( 1, sizeof( fingerprint_request_t ) );
++    if ( !p_r ) return NULL;
++    p_r->results.psz_fingerprint = NULL;
++    p_r->i_duration = 0;
++    input_item_Hold( p_item );
++    p_r->p_item = p_item;
++    vlc_array_init( & p_r->results.metas_array ); /* shouldn't be needed */
++    return p_r;
++}
++
++static inline void fingerprint_request_Delete( fingerprint_request_t *p_f )
++{
++    input_item_Release( p_f->p_item );
++    free( p_f->results.psz_fingerprint );
++    for( size_t i = 0; i < vlc_array_count( & p_f->results.metas_array ); i++ )
++        vlc_meta_Delete( (vlc_meta_t *) vlc_array_item_at_index( & p_f->results.metas_array, i ) );
++    free( p_f );
++}
++
++struct fingerprinter_thread_t
++{
++    VLC_COMMON_MEMBERS
++
++    /* Specific interfaces */
++    fingerprinter_sys_t * p_sys;
++
++    module_t *   p_module;
++
++    int ( *pf_enqueue ) ( struct fingerprinter_thread_t *f, fingerprint_request_t *r );
++    fingerprint_request_t * ( *pf_getresults ) ( struct fingerprinter_thread_t *f );
++    void ( *pf_apply ) ( fingerprint_request_t *, size_t i_resultid );
++};
++typedef struct fingerprinter_thread_t fingerprinter_thread_t;
++
++VLC_API fingerprinter_thread_t *fingerprinter_Create( vlc_object_t *p_this );
++VLC_API void fingerprinter_Destroy( fingerprinter_thread_t *p_fingerprint );
++
++# ifdef __cplusplus
++}
++# endif
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_fourcc.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_fourcc.h
+new file mode 100644
+index 0000000..0dc9f52
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_fourcc.h
+@@ -0,0 +1,692 @@
++/*****************************************************************************
++ * vlc_fourcc.h: Definition of various FOURCC and helpers
++ *****************************************************************************
++ * Copyright (C) 2009 Laurent Aimar
++ * $Id: 9042a48a9bd206c8fb6228bbb04dbde136c25499 $
++ *
++ * Authors: Laurent Aimar <fenrir _AT_ videolan _DOT_ com>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_FOURCC_H
++#define VLC_FOURCC_H 1
++
++#define VLC_CODEC_UNKNOWN         VLC_FOURCC('u','n','d','f')
++
++/* Video codec */
++#define VLC_CODEC_MPGV            VLC_FOURCC('m','p','g','v')
++#define VLC_CODEC_MP4V            VLC_FOURCC('m','p','4','v')
++#define VLC_CODEC_DIV1            VLC_FOURCC('D','I','V','1')
++#define VLC_CODEC_DIV2            VLC_FOURCC('D','I','V','2')
++#define VLC_CODEC_DIV3            VLC_FOURCC('D','I','V','3')
++#define VLC_CODEC_SVQ1            VLC_FOURCC('S','V','Q','1')
++#define VLC_CODEC_SVQ3            VLC_FOURCC('S','V','Q','3')
++#define VLC_CODEC_H264            VLC_FOURCC('h','2','6','4')
++#define VLC_CODEC_H263            VLC_FOURCC('h','2','6','3')
++#define VLC_CODEC_H263I           VLC_FOURCC('I','2','6','3')
++#define VLC_CODEC_H263P           VLC_FOURCC('I','L','V','R')
++#define VLC_CODEC_FLV1            VLC_FOURCC('F','L','V','1')
++#define VLC_CODEC_H261            VLC_FOURCC('h','2','6','1')
++#define VLC_CODEC_MJPG            VLC_FOURCC('M','J','P','G')
++#define VLC_CODEC_MJPGB           VLC_FOURCC('m','j','p','b')
++#define VLC_CODEC_LJPG            VLC_FOURCC('L','J','P','G')
++#define VLC_CODEC_WMV1            VLC_FOURCC('W','M','V','1')
++#define VLC_CODEC_WMV2            VLC_FOURCC('W','M','V','2')
++#define VLC_CODEC_WMV3            VLC_FOURCC('W','M','V','3')
++#define VLC_CODEC_WMVA            VLC_FOURCC('W','M','V','A')
++#define VLC_CODEC_WMVP            VLC_FOURCC('W','M','V','P')
++#define VLC_CODEC_WMVP2           VLC_FOURCC('W','V','P','2')
++#define VLC_CODEC_VC1             VLC_FOURCC('V','C','-','1')
++#define VLC_CODEC_DAALA           VLC_FOURCC('d','a','a','l')
++#define VLC_CODEC_THEORA          VLC_FOURCC('t','h','e','o')
++#define VLC_CODEC_TARKIN          VLC_FOURCC('t','a','r','k')
++#define VLC_CODEC_DIRAC           VLC_FOURCC('d','r','a','c')
++#define VLC_CODEC_OGGSPOTS        VLC_FOURCC('S','P','O','T')
++#define VLC_CODEC_CAVS            VLC_FOURCC('C','A','V','S')
++#define VLC_CODEC_NUV             VLC_FOURCC('N','J','P','G')
++#define VLC_CODEC_RV10            VLC_FOURCC('R','V','1','0')
++#define VLC_CODEC_RV13            VLC_FOURCC('R','V','1','3')
++#define VLC_CODEC_RV20            VLC_FOURCC('R','V','2','0')
++#define VLC_CODEC_RV30            VLC_FOURCC('R','V','3','0')
++#define VLC_CODEC_RV40            VLC_FOURCC('R','V','4','0')
++#define VLC_CODEC_VP3             VLC_FOURCC('V','P','3',' ')
++#define VLC_CODEC_VP5             VLC_FOURCC('V','P','5',' ')
++#define VLC_CODEC_VP6             VLC_FOURCC('V','P','6','2')
++#define VLC_CODEC_VP6F            VLC_FOURCC('V','P','6','F')
++#define VLC_CODEC_VP6A            VLC_FOURCC('V','P','6','A')
++#define VLC_CODEC_MSVIDEO1        VLC_FOURCC('M','S','V','C')
++#define VLC_CODEC_FLIC            VLC_FOURCC('F','L','I','C')
++#define VLC_CODEC_SP5X            VLC_FOURCC('S','P','5','X')
++#define VLC_CODEC_DV              VLC_FOURCC('d','v',' ',' ')
++#define VLC_CODEC_MSRLE           VLC_FOURCC('m','r','l','e')
++#define VLC_CODEC_HUFFYUV         VLC_FOURCC('H','F','Y','U')
++#define VLC_CODEC_FFVHUFF         VLC_FOURCC('F','F','V','H')
++#define VLC_CODEC_ASV1            VLC_FOURCC('A','S','V','1')
++#define VLC_CODEC_ASV2            VLC_FOURCC('A','S','V','2')
++#define VLC_CODEC_FFV1            VLC_FOURCC('F','F','V','1')
++#define VLC_CODEC_VCR1            VLC_FOURCC('V','C','R','1')
++#define VLC_CODEC_CLJR            VLC_FOURCC('C','L','J','R')
++#define VLC_CODEC_RPZA            VLC_FOURCC('r','p','z','a')
++#define VLC_CODEC_SMC             VLC_FOURCC('s','m','c',' ')
++#define VLC_CODEC_CINEPAK         VLC_FOURCC('C','V','I','D')
++#define VLC_CODEC_TSCC            VLC_FOURCC('T','S','C','C')
++#define VLC_CODEC_CSCD            VLC_FOURCC('C','S','C','D')
++#define VLC_CODEC_ZMBV            VLC_FOURCC('Z','M','B','V')
++#define VLC_CODEC_VMNC            VLC_FOURCC('V','M','n','c')
++#define VLC_CODEC_FMVC            VLC_FOURCC('F','M','V','C')
++#define VLC_CODEC_FRAPS           VLC_FOURCC('F','P','S','1')
++#define VLC_CODEC_TRUEMOTION1     VLC_FOURCC('D','U','C','K')
++#define VLC_CODEC_TRUEMOTION2     VLC_FOURCC('T','M','2','0')
++#define VLC_CODEC_QTRLE           VLC_FOURCC('r','l','e',' ')
++#define VLC_CODEC_QDRAW           VLC_FOURCC('q','d','r','w')
++#define VLC_CODEC_QPEG            VLC_FOURCC('Q','P','E','G')
++#define VLC_CODEC_ULTI            VLC_FOURCC('U','L','T','I')
++#define VLC_CODEC_VIXL            VLC_FOURCC('V','I','X','L')
++#define VLC_CODEC_LOCO            VLC_FOURCC('L','O','C','O')
++#define VLC_CODEC_WNV1            VLC_FOURCC('W','N','V','1')
++#define VLC_CODEC_AASC            VLC_FOURCC('A','A','S','C')
++#define VLC_CODEC_INDEO2          VLC_FOURCC('I','V','2','0')
++#define VLC_CODEC_INDEO3          VLC_FOURCC('I','V','3','1')
++#define VLC_CODEC_INDEO4          VLC_FOURCC('I','V','4','1')
++#define VLC_CODEC_INDEO5          VLC_FOURCC('I','V','5','0')
++#define VLC_CODEC_FLASHSV         VLC_FOURCC('F','S','V','1')
++#define VLC_CODEC_KMVC            VLC_FOURCC('K','M','V','C')
++#define VLC_CODEC_SMACKVIDEO      VLC_FOURCC('S','M','K','2')
++#define VLC_CODEC_DNXHD           VLC_FOURCC('A','V','d','n')
++#define VLC_CODEC_8BPS            VLC_FOURCC('8','B','P','S')
++#define VLC_CODEC_MIMIC           VLC_FOURCC('M','L','2','O')
++#define VLC_CODEC_INTERPLAY       VLC_FOURCC('i','m','v','e')
++#define VLC_CODEC_IDCIN           VLC_FOURCC('I','D','C','I')
++#define VLC_CODEC_4XM             VLC_FOURCC('4','X','M','V')
++#define VLC_CODEC_ROQ             VLC_FOURCC('R','o','Q','v')
++#define VLC_CODEC_MDEC            VLC_FOURCC('M','D','E','C')
++#define VLC_CODEC_VMDVIDEO        VLC_FOURCC('V','M','D','V')
++#define VLC_CODEC_CDG             VLC_FOURCC('C','D','G',' ')
++#define VLC_CODEC_FRWU            VLC_FOURCC('F','R','W','U')
++#define VLC_CODEC_AMV             VLC_FOURCC('A','M','V',' ')
++#define VLC_CODEC_VP7             VLC_FOURCC('V','P','7','0')
++#define VLC_CODEC_VP8             VLC_FOURCC('V','P','8','0')
++#define VLC_CODEC_VP9             VLC_FOURCC('V','P','9','0')
++#define VLC_CODEC_VP10            VLC_FOURCC('V','P',':','0')
++#define VLC_CODEC_AV1             VLC_FOURCC('a','v','0','1')
++#define VLC_CODEC_JPEG2000        VLC_FOURCC('J','P','2','K')
++#define VLC_CODEC_LAGARITH        VLC_FOURCC('L','A','G','S')
++#define VLC_CODEC_FLASHSV2        VLC_FOURCC('F','S','V','2')
++#define VLC_CODEC_PRORES          VLC_FOURCC('a','p','c','n')
++#define VLC_CODEC_MXPEG           VLC_FOURCC('M','X','P','G')
++#define VLC_CODEC_CDXL            VLC_FOURCC('C','D','X','L')
++#define VLC_CODEC_BMVVIDEO        VLC_FOURCC('B','M','V','V')
++#define VLC_CODEC_UTVIDEO         VLC_FOURCC('U','L','R','A')
++#define VLC_CODEC_VBLE            VLC_FOURCC('V','B','L','E')
++#define VLC_CODEC_DXTORY          VLC_FOURCC('x','t','o','r')
++#define VLC_CODEC_MSS1            VLC_FOURCC('M','S','S','1')
++#define VLC_CODEC_MSS2            VLC_FOURCC('M','S','S','2')
++#define VLC_CODEC_MSA1            VLC_FOURCC('M','S','A','1')
++#define VLC_CODEC_TSC2            VLC_FOURCC('T','S','C','2')
++#define VLC_CODEC_MTS2            VLC_FOURCC('M','T','S','2')
++#define VLC_CODEC_HEVC            VLC_FOURCC('h','e','v','c')
++#define VLC_CODEC_ICOD            VLC_FOURCC('i','c','o','d')
++#define VLC_CODEC_G2M2            VLC_FOURCC('G','2','M','2')
++#define VLC_CODEC_G2M3            VLC_FOURCC('G','2','M','3')
++#define VLC_CODEC_G2M4            VLC_FOURCC('G','2','M','4')
++#define VLC_CODEC_BINKVIDEO       VLC_FOURCC('B','I','K','f')
++#define VLC_CODEC_BINKAUDIO_DCT   VLC_FOURCC('B','A','U','1')
++#define VLC_CODEC_BINKAUDIO_RDFT  VLC_FOURCC('B','A','U','2')
++#define VLC_CODEC_XAN_WC4         VLC_FOURCC('X','x','a','n')
++#define VLC_CODEC_LCL_MSZH        VLC_FOURCC('M','S','Z','H')
++#define VLC_CODEC_LCL_ZLIB        VLC_FOURCC('Z','L','I','B')
++#define VLC_CODEC_THP             VLC_FOURCC('T','H','P','0')
++#define VLC_CODEC_ESCAPE124       VLC_FOURCC('E','1','2','4')
++#define VLC_CODEC_KGV1            VLC_FOURCC('K','G','V','1')
++#define VLC_CODEC_CLLC            VLC_FOURCC('C','L','L','C')
++#define VLC_CODEC_AURA            VLC_FOURCC('A','U','R','A')
++#define VLC_CODEC_FIC             VLC_FOURCC('F','I','C','V')
++#define VLC_CODEC_TMV             VLC_FOURCC('T','M','A','V')
++#define VLC_CODEC_XAN_WC3         VLC_FOURCC('X','A','N','3')
++#define VLC_CODEC_WS_VQA          VLC_FOURCC('W','V','Q','A')
++#define VLC_CODEC_MMVIDEO         VLC_FOURCC('M','M','V','I')
++#define VLC_CODEC_AVS             VLC_FOURCC('A','V','S','V')
++#define VLC_CODEC_DSICINVIDEO     VLC_FOURCC('D','C','I','V')
++#define VLC_CODEC_TIERTEXSEQVIDEO VLC_FOURCC('T','S','E','Q')
++#define VLC_CODEC_DXA             VLC_FOURCC('D','E','X','A')
++#define VLC_CODEC_C93             VLC_FOURCC('I','C','9','3')
++#define VLC_CODEC_BETHSOFTVID     VLC_FOURCC('B','V','I','D')
++#define VLC_CODEC_VB              VLC_FOURCC('V','B','V','1')
++#define VLC_CODEC_RL2             VLC_FOURCC('R','L','V','2')
++#define VLC_CODEC_BFI             VLC_FOURCC('B','F','&','I')
++#define VLC_CODEC_CMV             VLC_FOURCC('E','C','M','V')
++#define VLC_CODEC_MOTIONPIXELS    VLC_FOURCC('M','P','I','X')
++#define VLC_CODEC_TGV             VLC_FOURCC('T','G','V','V')
++#define VLC_CODEC_TGQ             VLC_FOURCC('T','G','Q','V')
++#define VLC_CODEC_TQI             VLC_FOURCC('T','Q','I','V')
++#define VLC_CODEC_MAD             VLC_FOURCC('M','A','D','V')
++#define VLC_CODEC_ANM             VLC_FOURCC('A','N','I','M')
++#define VLC_CODEC_YOP             VLC_FOURCC('Y','O','P','V')
++#define VLC_CODEC_JV              VLC_FOURCC('J','V','0','0')
++#define VLC_CODEC_DFA             VLC_FOURCC('D','F','I','A')
++#define VLC_CODEC_HNM4_VIDEO      VLC_FOURCC('H','N','M','4')
++#define VLC_CODEC_TDSC            VLC_FOURCC('T','D','S','C')
++#define VLC_CODEC_HQX             VLC_FOURCC('C','H','Q','X')
++#define VLC_CODEC_HQ_HQA          VLC_FOURCC('C','U','V','C')
++#define VLC_CODEC_HAP             VLC_FOURCC('H','A','P','1')
++#define VLC_CODEC_DXV             VLC_FOURCC('D','X','D','3')
++#define VLC_CODEC_CINEFORM        VLC_FOURCC('C','F','H','D')
++#define VLC_CODEC_SPEEDHQ         VLC_FOURCC('S','H','Q','2')
++#define VLC_CODEC_PIXLET          VLC_FOURCC('p','x','l','t')
++
++/***********
++ * Chromas
++ ***********/
++
++/* Planar YUV */
++
++/* Planar YUV 4:1:0 Y:V:U */
++#define VLC_CODEC_YV9             VLC_FOURCC('Y','V','U','9')
++/* Planar YUV 4:1:0 Y:U:V */
++#define VLC_CODEC_I410            VLC_FOURCC('I','4','1','0')
++/* Planar YUV 4:1:1 Y:U:V */
++#define VLC_CODEC_I411            VLC_FOURCC('I','4','1','1')
++
++/* Planar YUV 4:2:0 Y:V:U */
++#define VLC_CODEC_YV12            VLC_FOURCC('Y','V','1','2')
++/* Planar YUV 4:2:0 Y:U:V 8-bit */
++#define VLC_CODEC_I420            VLC_FOURCC('I','4','2','0')
++/* Planar YUV 4:2:0 Y:U:V  9-bit stored on 16 bits */
++#define VLC_CODEC_I420_9L         VLC_FOURCC('I','0','9','L')
++#define VLC_CODEC_I420_9B         VLC_FOURCC('I','0','9','B')
++/* Planar YUV 4:2:0 Y:U:V 10-bit stored on 16 bits LSB */
++#define VLC_CODEC_I420_10L        VLC_FOURCC('I','0','A','L')
++#define VLC_CODEC_I420_10B        VLC_FOURCC('I','0','A','B')
++/* Planar YUV 4:2:0 Y:U:V 12-bit stored on 16 bits */
++#define VLC_CODEC_I420_12L        VLC_FOURCC('I','0','C','L')
++#define VLC_CODEC_I420_12B        VLC_FOURCC('I','0','C','B')
++
++/* Planar YUV 4:2:0 Y:U:V 16-bit stored on 16 bits */
++#define VLC_CODEC_I420_16L        VLC_FOURCC('I','0','F','L')
++#define VLC_CODEC_I420_16B        VLC_FOURCC('I','0','F','B')
++
++/* Planar YUV 4:2:2 Y:U:V 8-bit */
++#define VLC_CODEC_I422            VLC_FOURCC('I','4','2','2')
++/* Planar YUV 4:2:2 Y:U:V  9-bit stored on 16 bits */
++#define VLC_CODEC_I422_9L         VLC_FOURCC('I','2','9','L')
++#define VLC_CODEC_I422_9B         VLC_FOURCC('I','2','9','B')
++/* Planar YUV 4:2:2 Y:U:V 10-bit stored on 16 bits */
++#define VLC_CODEC_I422_10L        VLC_FOURCC('I','2','A','L')
++#define VLC_CODEC_I422_10B        VLC_FOURCC('I','2','A','B')
++/* Planar YUV 4:2:2 Y:U:V 12-bit stored on 16 bits */
++#define VLC_CODEC_I422_12L        VLC_FOURCC('I','2','C','L')
++#define VLC_CODEC_I422_12B        VLC_FOURCC('I','2','C','B')
++
++/* Planar YUV 4:4:0 Y:U:V */
++#define VLC_CODEC_I440            VLC_FOURCC('I','4','4','0')
++/* Planar YUV 4:4:4 Y:U:V 8-bit */
++#define VLC_CODEC_I444            VLC_FOURCC('I','4','4','4')
++/* Planar YUV 4:4:4 Y:U:V  9-bit stored on 16 bits */
++#define VLC_CODEC_I444_9L         VLC_FOURCC('I','4','9','L')
++#define VLC_CODEC_I444_9B         VLC_FOURCC('I','4','9','B')
++/* Planar YUV 4:4:4 Y:U:V 10-bit stored on 16 bits */
++#define VLC_CODEC_I444_10L        VLC_FOURCC('I','4','A','L')
++#define VLC_CODEC_I444_10B        VLC_FOURCC('I','4','A','B')
++/* Planar YUV 4:4:4 Y:U:V 12-bit stored on 16 bits */
++#define VLC_CODEC_I444_12L        VLC_FOURCC('I','4','C','L')
++#define VLC_CODEC_I444_12B        VLC_FOURCC('I','4','C','B')
++/* Planar YUV 4:4:4 Y:U:V 16-bit */
++#define VLC_CODEC_I444_16L        VLC_FOURCC('I','4','F','L')
++#define VLC_CODEC_I444_16B        VLC_FOURCC('I','4','F','B')
++
++/* Planar YUV 4:2:0 Y:U:V full scale */
++#define VLC_CODEC_J420            VLC_FOURCC('J','4','2','0')
++/* Planar YUV 4:2:2 Y:U:V full scale */
++#define VLC_CODEC_J422            VLC_FOURCC('J','4','2','2')
++/* Planar YUV 4:4:0 Y:U:V full scale */
++#define VLC_CODEC_J440            VLC_FOURCC('J','4','4','0')
++/* Planar YUV 4:4:4 Y:U:V full scale */
++#define VLC_CODEC_J444            VLC_FOURCC('J','4','4','4')
++/* Palettized YUV with palette element Y:U:V:A */
++#define VLC_CODEC_YUVP            VLC_FOURCC('Y','U','V','P')
++
++/* Planar YUV 4:4:4 Y:U:V:A */
++#define VLC_CODEC_YUVA            VLC_FOURCC('Y','U','V','A')
++/* Planar YUV 4:2:2 Y:U:V:A */
++#define VLC_CODEC_YUV422A         VLC_FOURCC('I','4','2','A')
++/* Planar YUV 4:2:0 Y:U:V:A */
++#define VLC_CODEC_YUV420A         VLC_FOURCC('I','4','0','A')
++
++/* Planar Y:U:V:A 4:4:4 10bits */
++#define VLC_CODEC_YUVA_444_10L    VLC_FOURCC('Y','A','0','L')
++#define VLC_CODEC_YUVA_444_10B    VLC_FOURCC('Y','A','0','B')
++
++/* Semi-planar Y/UV */
++
++/* 2 planes Y/UV 4:2:0 */
++#define VLC_CODEC_NV12            VLC_FOURCC('N','V','1','2')
++/* 2 planes Y/VU 4:2:0 */
++#define VLC_CODEC_NV21            VLC_FOURCC('N','V','2','1')
++/* 2 planes Y/UV 4:2:2 */
++#define VLC_CODEC_NV16            VLC_FOURCC('N','V','1','6')
++/* 2 planes Y/VU 4:2:2 */
++#define VLC_CODEC_NV61            VLC_FOURCC('N','V','6','1')
++/* 2 planes Y/UV 4:4:4 */
++#define VLC_CODEC_NV24            VLC_FOURCC('N','V','2','4')
++/* 2 planes Y/VU 4:4:4 */
++#define VLC_CODEC_NV42            VLC_FOURCC('N','V','4','2')
++/* 2 planes Y/UV 4:2:0 10-bit */
++#define VLC_CODEC_P010            VLC_FOURCC('P','0','1','0')
++
++/* Packed YUV */
++
++/* Packed YUV 4:2:2, U:Y:V:Y */
++#define VLC_CODEC_UYVY            VLC_FOURCC('U','Y','V','Y')
++/* Packed YUV 4:2:2, V:Y:U:Y */
++#define VLC_CODEC_VYUY            VLC_FOURCC('V','Y','U','Y')
++/* Packed YUV 4:2:2, Y:U:Y:V */
++#define VLC_CODEC_YUYV            VLC_FOURCC('Y','U','Y','2')
++/* Packed YUV 4:2:2, Y:V:Y:U */
++#define VLC_CODEC_YVYU            VLC_FOURCC('Y','V','Y','U')
++/* Packed YUV 2:1:1, Y:U:Y:V */
++#define VLC_CODEC_Y211            VLC_FOURCC('Y','2','1','1')
++/* Packed YUV 4:2:2, U:Y:V:Y, reverted */
++#define VLC_CODEC_CYUV            VLC_FOURCC('c','y','u','v')
++/* 10-bit 4:2:2 Component YCbCr */
++#define VLC_CODEC_V210            VLC_FOURCC('v','2','1','0')
++/* I420 packed for RTP (RFC 4175) */
++#define VLC_CODEC_R420            VLC_FOURCC('r','4','2','0')
++/* Packed YUV 4:4:4 V:U:Y:A */
++#define VLC_CODEC_VUYA            VLC_FOURCC('V','U','Y','A')
++
++
++/* RGB */
++
++/* Palettized RGB with palette element R:G:B */
++#define VLC_CODEC_RGBP            VLC_FOURCC('R','G','B','P')
++/* 8 bits RGB */
++#define VLC_CODEC_RGB8            VLC_FOURCC('R','G','B','8')
++/* 12 bits RGB padded to 16 bits */
++#define VLC_CODEC_RGB12           VLC_FOURCC('R','V','1','2')
++/* 15 bits RGB padded to 16 bits */
++#define VLC_CODEC_RGB15           VLC_FOURCC('R','V','1','5')
++/* 16 bits RGB */
++#define VLC_CODEC_RGB16           VLC_FOURCC('R','V','1','6')
++/* 24 bits RGB */
++#define VLC_CODEC_RGB24           VLC_FOURCC('R','V','2','4')
++/* 24 bits RGB padded to 32 bits */
++#define VLC_CODEC_RGB32           VLC_FOURCC('R','V','3','2')
++/* 32 bits RGBA */
++#define VLC_CODEC_RGBA            VLC_FOURCC('R','G','B','A')
++/* 32 bits ARGB */
++#define VLC_CODEC_ARGB            VLC_FOURCC('A','R','G','B')
++/* 32 bits BGRA */
++#define VLC_CODEC_BGRA            VLC_FOURCC('B','G','R','A')
++/* 32 bits BGRA 10:10:10:2 */
++#define VLC_CODEC_RGBA10          VLC_FOURCC('R','G','A','0')
++/* 64 bits RGBA */
++#define VLC_CODEC_RGBA64          VLC_FOURCC('R','G','A','4')
++
++/* Planar GBR 4:4:4 8 bits */
++#define VLC_CODEC_GBR_PLANAR      VLC_FOURCC('G','B','R','8')
++#define VLC_CODEC_GBR_PLANAR_9B   VLC_FOURCC('G','B','9','B')
++#define VLC_CODEC_GBR_PLANAR_9L   VLC_FOURCC('G','B','9','L')
++#define VLC_CODEC_GBR_PLANAR_10B  VLC_FOURCC('G','B','A','B')
++#define VLC_CODEC_GBR_PLANAR_10L  VLC_FOURCC('G','B','A','L')
++#define VLC_CODEC_GBR_PLANAR_16L  VLC_FOURCC('G','B','F','L')
++#define VLC_CODEC_GBR_PLANAR_16B  VLC_FOURCC('G','B','F','B')
++
++/* 8 bits grey */
++#define VLC_CODEC_GREY            VLC_FOURCC('G','R','E','Y')
++
++/* VDPAU video surface YCbCr 4:2:0 */
++#define VLC_CODEC_VDPAU_VIDEO_420 VLC_FOURCC('V','D','V','0')
++/* VDPAU video surface YCbCr 4:2:2 */
++#define VLC_CODEC_VDPAU_VIDEO_422 VLC_FOURCC('V','D','V','2')
++/* VDPAU video surface YCbCr 4:4:4 */
++#define VLC_CODEC_VDPAU_VIDEO_444 VLC_FOURCC('V','D','V','4')
++/* VDPAU output surface RGBA */
++#define VLC_CODEC_VDPAU_OUTPUT    VLC_FOURCC('V','D','O','R')
++
++/* VAAPI opaque surface */
++#define VLC_CODEC_VAAPI_420 VLC_FOURCC('V','A','O','P') /* 4:2:0  8 bpc */
++#define VLC_CODEC_VAAPI_420_10BPP VLC_FOURCC('V','A','O','0') /* 4:2:0 10 bpc */
++
++/* MediaCodec/IOMX opaque buffer type */
++#define VLC_CODEC_ANDROID_OPAQUE  VLC_FOURCC('A','N','O','P')
++
++/* Broadcom MMAL opaque buffer type */
++#define VLC_CODEC_MMAL_OPAQUE     VLC_FOURCC('M','M','A','L')
++
++/* DXVA2 opaque video surface for use with D3D9 */
++#define VLC_CODEC_D3D9_OPAQUE     VLC_FOURCC('D','X','A','9') /* 4:2:0  8 bpc */
++#define VLC_CODEC_D3D9_OPAQUE_10B VLC_FOURCC('D','X','A','0') /* 4:2:0 10 bpc */
++
++/* D3D11VA opaque video surface for use with D3D11 */
++#define VLC_CODEC_D3D11_OPAQUE          VLC_FOURCC('D','X','1','1') /* 4:2:0  8 bpc */
++#define VLC_CODEC_D3D11_OPAQUE_10B      VLC_FOURCC('D','X','1','0') /* 4:2:0 10 bpc */
++
++/* CVPixelBuffer opaque buffer type */
++#define VLC_CODEC_CVPX_NV12       VLC_FOURCC('C','V','P','N')
++#define VLC_CODEC_CVPX_UYVY       VLC_FOURCC('C','V','P','Y')
++#define VLC_CODEC_CVPX_I420       VLC_FOURCC('C','V','P','I')
++#define VLC_CODEC_CVPX_BGRA       VLC_FOURCC('C','V','P','B')
++#define VLC_CODEC_CVPX_P010       VLC_FOURCC('C','V','P','P')
++
++/* Image codec (video) */
++#define VLC_CODEC_PNG             VLC_FOURCC('p','n','g',' ')
++#define VLC_CODEC_PPM             VLC_FOURCC('p','p','m',' ')
++#define VLC_CODEC_PGM             VLC_FOURCC('p','g','m',' ')
++#define VLC_CODEC_PGMYUV          VLC_FOURCC('p','g','m','y')
++#define VLC_CODEC_PAM             VLC_FOURCC('p','a','m',' ')
++#define VLC_CODEC_JPEG            VLC_FOURCC('j','p','e','g')
++#define VLC_CODEC_BPG             VLC_FOURCC('B','P','G',0xFB)
++#define VLC_CODEC_JPEGLS          VLC_FOURCC('M','J','L','S')
++#define VLC_CODEC_BMP             VLC_FOURCC('b','m','p',' ')
++#define VLC_CODEC_TIFF            VLC_FOURCC('t','i','f','f')
++#define VLC_CODEC_GIF             VLC_FOURCC('g','i','f',' ')
++#define VLC_CODEC_TARGA           VLC_FOURCC('t','g','a',' ')
++#define VLC_CODEC_SVG             VLC_FOURCC('s','v','g',' ')
++#define VLC_CODEC_SGI             VLC_FOURCC('s','g','i',' ')
++#define VLC_CODEC_PNM             VLC_FOURCC('p','n','m',' ')
++#define VLC_CODEC_PCX             VLC_FOURCC('p','c','x',' ')
++#define VLC_CODEC_XWD             VLC_FOURCC('X','W','D',' ')
++#define VLC_CODEC_TXD             VLC_FOURCC('T','X','D',' ')
++
++
++/* Audio codec */
++#define VLC_CODEC_MPGA                       VLC_FOURCC('m','p','g','a')
++#define VLC_CODEC_MP4A                       VLC_FOURCC('m','p','4','a')
++#define VLC_CODEC_ALS                        VLC_FOURCC('a','l','s',' ')
++#define VLC_CODEC_A52                        VLC_FOURCC('a','5','2',' ')
++#define VLC_CODEC_EAC3                       VLC_FOURCC('e','a','c','3')
++#define VLC_CODEC_DTS                        VLC_FOURCC('d','t','s',' ')
++#define VLC_CODEC_WMA1                       VLC_FOURCC('W','M','A','1')
++#define VLC_CODEC_WMA2                       VLC_FOURCC('W','M','A','2')
++#define VLC_CODEC_WMAP                       VLC_FOURCC('W','M','A','P')
++#define VLC_CODEC_WMAL                       VLC_FOURCC('W','M','A','L')
++#define VLC_CODEC_WMAS                       VLC_FOURCC('W','M','A','S')
++#define VLC_CODEC_FLAC                       VLC_FOURCC('f','l','a','c')
++#define VLC_CODEC_MLP                        VLC_FOURCC('m','l','p',' ')
++#define VLC_CODEC_TRUEHD                     VLC_FOURCC('t','r','h','d')
++#define VLC_CODEC_DVAUDIO                    VLC_FOURCC('d','v','a','u')
++#define VLC_CODEC_SPEEX                      VLC_FOURCC('s','p','x',' ')
++#define VLC_CODEC_OPUS                       VLC_FOURCC('O','p','u','s')
++#define VLC_CODEC_VORBIS                     VLC_FOURCC('v','o','r','b')
++#define VLC_CODEC_MACE3                      VLC_FOURCC('M','A','C','3')
++#define VLC_CODEC_MACE6                      VLC_FOURCC('M','A','C','6')
++#define VLC_CODEC_MUSEPACK7                  VLC_FOURCC('M','P','C',' ')
++#define VLC_CODEC_MUSEPACK8                  VLC_FOURCC('M','P','C','K')
++#define VLC_CODEC_RA_144                     VLC_FOURCC('1','4','_','4')
++#define VLC_CODEC_RA_288                     VLC_FOURCC('2','8','_','8')
++#define VLC_CODEC_INTERPLAY_DPCM             VLC_FOURCC('i','d','p','c')
++#define VLC_CODEC_ROQ_DPCM                   VLC_FOURCC('R','o','Q','a')
++#define VLC_CODEC_DSICINAUDIO                VLC_FOURCC('D','C','I','A')
++#define VLC_CODEC_ADPCM_4XM                  VLC_FOURCC('4','x','m','a')
++#define VLC_CODEC_ADPCM_EA                   VLC_FOURCC('A','D','E','A')
++#define VLC_CODEC_ADPCM_XA                   VLC_FOURCC('x','a',' ',' ')
++#define VLC_CODEC_ADPCM_ADX                  VLC_FOURCC('a','d','x',' ')
++#define VLC_CODEC_ADPCM_IMA_WS               VLC_FOURCC('A','I','W','S')
++#define VLC_CODEC_ADPCM_G722                 VLC_FOURCC('g','7','2','2')
++#define VLC_CODEC_ADPCM_G726                 VLC_FOURCC('g','7','2','6')
++#define VLC_CODEC_ADPCM_SWF                  VLC_FOURCC('S','W','F','a')
++#define VLC_CODEC_ADPCM_MS                   VLC_FOURCC('m','s',0x00,0x02)
++#define VLC_CODEC_ADPCM_IMA_WAV              VLC_FOURCC('m','s',0x00,0x11)
++#define VLC_CODEC_ADPCM_IMA_AMV              VLC_FOURCC('i','m','a','v')
++#define VLC_CODEC_ADPCM_IMA_QT               VLC_FOURCC('i','m','a','4')
++#define VLC_CODEC_ADPCM_YAMAHA               VLC_FOURCC('m','s',0x00,0x20)
++#define VLC_CODEC_ADPCM_DK3                  VLC_FOURCC('m','s',0x00,0x62)
++#define VLC_CODEC_ADPCM_DK4                  VLC_FOURCC('m','s',0x00,0x61)
++#define VLC_CODEC_ADPCM_CREATIVE             VLC_FOURCC('m','s',0x00,0xC0)
++#define VLC_CODEC_ADPCM_SBPRO_2              VLC_FOURCC('m','s',0x00,0xC2)
++#define VLC_CODEC_ADPCM_SBPRO_3              VLC_FOURCC('m','s',0x00,0xC3)
++#define VLC_CODEC_ADPCM_SBPRO_4              VLC_FOURCC('m','s',0x00,0xC4)
++#define VLC_CODEC_ADPCM_THP                  VLC_FOURCC('T','H','P','A')
++#define VLC_CODEC_ADPCM_XA_EA                VLC_FOURCC('X','A','J', 0)
++#define VLC_CODEC_G723_1                     VLC_FOURCC('g','7','2', 0x31)
++#define VLC_CODEC_G729                       VLC_FOURCC('g','7','2','9')
++#define VLC_CODEC_VMDAUDIO                   VLC_FOURCC('v','m','d','a')
++#define VLC_CODEC_AMR_NB                     VLC_FOURCC('s','a','m','r')
++#define VLC_CODEC_AMR_WB                     VLC_FOURCC('s','a','w','b')
++#define VLC_CODEC_ALAC                       VLC_FOURCC('a','l','a','c')
++#define VLC_CODEC_QDM2                       VLC_FOURCC('Q','D','M','2')
++#define VLC_CODEC_QDMC                       VLC_FOURCC('Q','D','M','C')
++#define VLC_CODEC_COOK                       VLC_FOURCC('c','o','o','k')
++#define VLC_CODEC_SIPR                       VLC_FOURCC('s','i','p','r')
++#define VLC_CODEC_TTA                        VLC_FOURCC('T','T','A','1')
++#define VLC_CODEC_SHORTEN                    VLC_FOURCC('s','h','n',' ')
++#define VLC_CODEC_WAVPACK                    VLC_FOURCC('W','V','P','K')
++#define VLC_CODEC_GSM                        VLC_FOURCC('g','s','m',' ')
++#define VLC_CODEC_GSM_MS                     VLC_FOURCC('a','g','s','m')
++#define VLC_CODEC_ATRAC1                     VLC_FOURCC('a','t','r','1')
++#define VLC_CODEC_ATRAC3                     VLC_FOURCC('a','t','r','c')
++#define VLC_CODEC_ATRAC3P                    VLC_FOURCC('a','t','r','p')
++#define VLC_CODEC_IMC                        VLC_FOURCC(0x1,0x4,0x0,0x0)
++#define VLC_CODEC_TRUESPEECH                 VLC_FOURCC(0x22,0x0,0x0,0x0)
++#define VLC_CODEC_NELLYMOSER                 VLC_FOURCC('N','E','L','L')
++#define VLC_CODEC_APE                        VLC_FOURCC('A','P','E',' ')
++#define VLC_CODEC_QCELP                      VLC_FOURCC('Q','c','l','p')
++#define VLC_CODEC_302M                       VLC_FOURCC('3','0','2','m')
++#define VLC_CODEC_DVD_LPCM                   VLC_FOURCC('l','p','c','m')
++#define VLC_CODEC_DVDA_LPCM                  VLC_FOURCC('a','p','c','m')
++#define VLC_CODEC_BD_LPCM                    VLC_FOURCC('b','p','c','m')
++#define VLC_CODEC_WIDI_LPCM                  VLC_FOURCC('w','p','c','m')
++#define VLC_CODEC_SDDS                       VLC_FOURCC('s','d','d','s')
++#define VLC_CODEC_MIDI                       VLC_FOURCC('M','I','D','I')
++#define VLC_CODEC_RALF                       VLC_FOURCC('R','A','L','F')
++
++#define VLC_CODEC_S8                         VLC_FOURCC('s','8',' ',' ')
++#define VLC_CODEC_U8                         VLC_FOURCC('u','8',' ',' ')
++#define VLC_CODEC_S16L                       VLC_FOURCC('s','1','6','l')
++#define VLC_CODEC_S16L_PLANAR                VLC_FOURCC('s','1','l','p')
++#define VLC_CODEC_S16B                       VLC_FOURCC('s','1','6','b')
++#define VLC_CODEC_U16L                       VLC_FOURCC('u','1','6','l')
++#define VLC_CODEC_U16B                       VLC_FOURCC('u','1','6','b')
++#define VLC_CODEC_S20B                       VLC_FOURCC('s','2','0','b')
++#define VLC_CODEC_S24L                       VLC_FOURCC('s','2','4','l')
++#define VLC_CODEC_S24B                       VLC_FOURCC('s','2','4','b')
++#define VLC_CODEC_U24L                       VLC_FOURCC('u','2','4','l')
++#define VLC_CODEC_U24B                       VLC_FOURCC('u','2','4','b')
++#define VLC_CODEC_S24L32                     VLC_FOURCC('s','2','4','4')
++#define VLC_CODEC_S24B32                     VLC_FOURCC('S','2','4','4')
++#define VLC_CODEC_S32L                       VLC_FOURCC('s','3','2','l')
++#define VLC_CODEC_S32B                       VLC_FOURCC('s','3','2','b')
++#define VLC_CODEC_U32L                       VLC_FOURCC('u','3','2','l')
++#define VLC_CODEC_U32B                       VLC_FOURCC('u','3','2','b')
++#define VLC_CODEC_F32L                       VLC_FOURCC('f','3','2','l')
++#define VLC_CODEC_F32B                       VLC_FOURCC('f','3','2','b')
++#define VLC_CODEC_F64L                       VLC_FOURCC('f','6','4','l')
++#define VLC_CODEC_F64B                       VLC_FOURCC('f','6','4','b')
++
++#define VLC_CODEC_ALAW                       VLC_FOURCC('a','l','a','w')
++#define VLC_CODEC_MULAW                      VLC_FOURCC('m','l','a','w')
++#define VLC_CODEC_DAT12                      VLC_FOURCC('L','P','1','2')
++#define VLC_CODEC_S24DAUD                    VLC_FOURCC('d','a','u','d')
++#define VLC_CODEC_TWINVQ                     VLC_FOURCC('T','W','I','N')
++#define VLC_CODEC_BMVAUDIO                   VLC_FOURCC('B','M','V','A')
++#define VLC_CODEC_ULEAD_DV_AUDIO_NTSC        VLC_FOURCC('m','s',0x02,0x15)
++#define VLC_CODEC_ULEAD_DV_AUDIO_PAL         VLC_FOURCC('m','s',0x02,0x16)
++#define VLC_CODEC_INDEO_AUDIO                VLC_FOURCC('m','s',0x04,0x02)
++#define VLC_CODEC_METASOUND                  VLC_FOURCC('m','s',0x00,0x75)
++#define VLC_CODEC_ON2AVC                     VLC_FOURCC('m','s',0x05,0x00)
++#define VLC_CODEC_TAK                        VLC_FOURCC('t','a','k',' ')
++#define VLC_CODEC_SMACKAUDIO                 VLC_FOURCC('S','M','K','A')
++#define VLC_CODEC_ADPCM_IMA_EA_SEAD          VLC_FOURCC('S','E','A','D')
++#define VLC_CODEC_ADPCM_EA_R1                VLC_FOURCC('E','A','R','1')
++#define VLC_CODEC_ADPCM_IMA_APC              VLC_FOURCC('A','I','P','C')
++
++/* Subtitle */
++#define VLC_CODEC_SPU       VLC_FOURCC('s','p','u',' ')
++#define VLC_CODEC_DVBS      VLC_FOURCC('d','v','b','s')
++#define VLC_CODEC_SUBT      VLC_FOURCC('s','u','b','t')
++#define VLC_CODEC_XSUB      VLC_FOURCC('X','S','U','B')
++#define VLC_CODEC_SSA       VLC_FOURCC('s','s','a',' ')
++#define VLC_CODEC_TEXT      VLC_FOURCC('T','E','X','T')
++#define VLC_CODEC_TELETEXT  VLC_FOURCC('t','e','l','x')
++#define VLC_CODEC_KATE      VLC_FOURCC('k','a','t','e')
++#define VLC_CODEC_CMML      VLC_FOURCC('c','m','m','l')
++#define VLC_CODEC_ITU_T140  VLC_FOURCC('t','1','4','0')
++#define VLC_CODEC_USF       VLC_FOURCC('u','s','f',' ')
++#define VLC_CODEC_OGT       VLC_FOURCC('o','g','t',' ')
++#define VLC_CODEC_CVD       VLC_FOURCC('c','v','d',' ')
++#define VLC_CODEC_TX3G      VLC_FOURCC('t','x','3','g')
++#define VLC_CODEC_ARIB_A    VLC_FOURCC('a','r','b','a')
++#define VLC_CODEC_ARIB_C    VLC_FOURCC('a','r','b','c')
++/* Blu-ray Presentation Graphics */
++#define VLC_CODEC_BD_PG     VLC_FOURCC('b','d','p','g')
++#define VLC_CODEC_BD_TEXT   VLC_FOURCC('b','d','t','x')
++/* EBU STL (TECH. 3264-E) */
++#define VLC_CODEC_EBU_STL   VLC_FOURCC('S','T','L',' ')
++#define VLC_CODEC_SCTE_18   VLC_FOURCC('S','C','1','8')
++#define VLC_CODEC_SCTE_27   VLC_FOURCC('S','C','2','7')
++/* EIA/CEA-608/708 */
++#define VLC_CODEC_CEA608    VLC_FOURCC('c','6','0','8')
++#define VLC_CODEC_CEA708    VLC_FOURCC('c','7','0','8')
++#define VLC_CODEC_TTML      VLC_FOURCC('T','T','M','L')
++#define VLC_CODEC_WEBVTT    VLC_FOURCC('w','v','t','t')
++
++/* XYZ colorspace 12 bits packed in 16 bits, organisation |XXX0|YYY0|ZZZ0| */
++#define VLC_CODEC_XYZ12     VLC_FOURCC('X','Y','1','2')
++
++
++/* Special endian dependent values
++ * The suffic N means Native
++ * The suffix I means Inverted (ie non native) */
++#ifdef WORDS_BIGENDIAN
++#   define VLC_CODEC_S16N VLC_CODEC_S16B
++#   define VLC_CODEC_U16N VLC_CODEC_U16B
++#   define VLC_CODEC_S24N VLC_CODEC_S24B
++#   define VLC_CODEC_U24N VLC_CODEC_U24B
++#   define VLC_CODEC_S32N VLC_CODEC_S32B
++#   define VLC_CODEC_U32N VLC_CODEC_U32B
++#   define VLC_CODEC_FL32 VLC_CODEC_F32B
++#   define VLC_CODEC_FL64 VLC_CODEC_F64B
++
++#   define VLC_CODEC_S16I VLC_CODEC_S16L
++#   define VLC_CODEC_U16I VLC_CODEC_U16L
++#   define VLC_CODEC_S24I VLC_CODEC_S24L
++#   define VLC_CODEC_U24I VLC_CODEC_U24L
++#   define VLC_CODEC_S32I VLC_CODEC_S32L
++#   define VLC_CODEC_U32I VLC_CODEC_U32L
++
++#else
++#   define VLC_CODEC_S16N VLC_CODEC_S16L
++#   define VLC_CODEC_U16N VLC_CODEC_U16L
++#   define VLC_CODEC_S24N VLC_CODEC_S24L
++#   define VLC_CODEC_U24N VLC_CODEC_U24L
++#   define VLC_CODEC_S32N VLC_CODEC_S32L
++#   define VLC_CODEC_U32N VLC_CODEC_U32L
++#   define VLC_CODEC_FL32 VLC_CODEC_F32L
++#   define VLC_CODEC_FL64 VLC_CODEC_F64L
++
++#   define VLC_CODEC_S16I VLC_CODEC_S16B
++#   define VLC_CODEC_U16I VLC_CODEC_U16B
++#   define VLC_CODEC_S24I VLC_CODEC_S24B
++#   define VLC_CODEC_U24I VLC_CODEC_U24B
++#   define VLC_CODEC_S32I VLC_CODEC_S32B
++#   define VLC_CODEC_U32I VLC_CODEC_U32B
++#endif
++
++/* Non official codecs, used to force a profile in an encoder */
++/* MPEG-1 video */
++#define VLC_CODEC_MP1V      VLC_FOURCC('m','p','1','v')
++/* MPEG-2 video */
++#define VLC_CODEC_MP2V      VLC_FOURCC('m','p','2','v')
++/* MPEG-I/II layer 2 audio */
++#define VLC_CODEC_MP2       VLC_FOURCC('m','p','2',' ')
++/* MPEG-I/II layer 3 audio */
++#define VLC_CODEC_MP3       VLC_FOURCC('m','p','3',' ')
++
++/**
++ * It returns the codec associated to a fourcc within an ES category.
++ *
++ * If not found, it will return the given fourcc.
++ * If found, it will always be one of the VLC_CODEC_ defined above.
++ *
++ * You may use UNKNOWN_ES for the ES category if you don't have the information.
++ */
++VLC_API vlc_fourcc_t vlc_fourcc_GetCodec( int i_cat, vlc_fourcc_t i_fourcc );
++
++/**
++ * It returns the codec associated to a fourcc stored in a zero terminated
++ * string.
++ *
++ * If the string is NULL or does not have exactly 4 characters, it will
++ * return 0, otherwise it behaves like vlc_fourcc_GetCodec.
++ *
++ * Provided for convenience.
++ */
++VLC_API vlc_fourcc_t vlc_fourcc_GetCodecFromString( int i_cat, const char * );
++
++/**
++ * It converts the given fourcc to an audio codec when possible.
++ *
++ * The fourccs converted are aflt, araw/pcm , twos, sowt. When an incompatible i_bits
++ * is detected, 0 is returned.
++ * The other fourccs go through vlc_fourcc_GetCodec and i_bits is not checked.
++ */
++VLC_API vlc_fourcc_t vlc_fourcc_GetCodecAudio( vlc_fourcc_t i_fourcc, int i_bits );
++
++/**
++ * It returns the description of the given fourcc or NULL if not found.
++ *
++ * You may use UNKNOWN_ES for the ES category if you don't have the information.
++ */
++VLC_API const char * vlc_fourcc_GetDescription( int i_cat, vlc_fourcc_t i_fourcc );
++
++/**
++ * It returns a list (terminated with the value 0) of YUV fourccs in
++ * decreasing priority order for the given chroma.
++ *
++ * It will always return a non NULL pointer that must not be freed.
++ */
++VLC_API const vlc_fourcc_t * vlc_fourcc_GetYUVFallback( vlc_fourcc_t );
++
++/**
++ * It returns a list (terminated with the value 0) of RGB fourccs in
++ * decreasing priority order for the given chroma.
++ *
++ * It will always return a non NULL pointer that must not be freed.
++ */
++VLC_API const vlc_fourcc_t * vlc_fourcc_GetRGBFallback( vlc_fourcc_t );
++
++/**
++ * It returns true if the given fourcc is YUV and false otherwise.
++ */
++VLC_API bool vlc_fourcc_IsYUV( vlc_fourcc_t );
++
++/**
++ * It returns true if the two fourccs are equivalent if their U&V planes are
++ * swapped.
++ */
++VLC_API bool vlc_fourcc_AreUVPlanesSwapped(vlc_fourcc_t , vlc_fourcc_t );
++
++/**
++ * Chroma related information.
++ */
++typedef struct {
++    unsigned plane_count;
++    struct {
++        vlc_rational_t w;
++        vlc_rational_t h;
++    } p[4];
++    unsigned pixel_size;        /* Number of bytes per pixel for a plane */
++    unsigned pixel_bits;        /* Number of bits actually used bits per pixel for a plane */
++} vlc_chroma_description_t;
++
++/**
++ * It returns a vlc_chroma_description_t describing the requested fourcc or NULL
++ * if not found.
++ */
++VLC_API const vlc_chroma_description_t * vlc_fourcc_GetChromaDescription( vlc_fourcc_t fourcc ) VLC_USED;
++
++#endif /* _VLC_FOURCC_H */
++
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_fs.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_fs.h
+new file mode 100644
+index 0000000..8fda513
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_fs.h
+@@ -0,0 +1,294 @@
++/*****************************************************************************
++ * vlc_fs.h: File system helpers
++ *****************************************************************************
++ * Copyright © 2006-2010 Rémi Denis-Courmont
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_FS_H
++#define VLC_FS_H 1
++
++#include <sys/types.h>
++#include <dirent.h>
++
++struct stat;
++struct iovec;
++
++#ifdef _WIN32
++# include <sys/stat.h>
++# ifndef stat
++#  define stat _stati64
++# endif
++# ifndef fstat
++#  define fstat _fstati64
++# endif
++# ifndef _MSC_VER
++#  undef lseek
++#  define lseek _lseeki64
++# endif
++#endif
++
++#ifdef __ANDROID__
++# define lseek lseek64
++#endif
++
++
++/**
++ * \defgroup os Operating system
++ * @{
++ * \defgroup file File system
++ * @{
++ *
++ * \file
++ * The functions in this file help with using low-level Unix-style file
++ * descriptors, BSD sockets and directories. In general, they retain the
++ * prototype and most semantics from their respective standard equivalents.
++ * However, there are a few differences:
++ *  - On Windows, file path arguments are expected in UTF-8 format.
++ *    They are converted to UTF-16 internally, thus enabling access to paths
++ *    outside of the local Windows ANSI code page.
++ *  - On POSIX systems, file descriptors are created with the close-on-exec
++ *    flag set (atomically where possible), so that they do not leak to
++ *    child process after fork-and-exec.
++ *  - vlc_scandir(), inspired by GNU scandir(), passes file names rather than
++ *    dirent structure pointers to its callbacks.
++ *  - vlc_accept() takes an extra boolean for nonblocking mode (compare with
++ *    the flags parameter in POSIX.next accept4()).
++ *  - Writing functions do not emit a SIGPIPE signal in case of broken pipe.
++ *
++ * \defgroup fd File descriptors
++ * @{
++ */
++
++/**
++ * Opens a system file handle.
++ *
++ * @param filename file path to open (with UTF-8 encoding)
++ * @param flags open() flags, see the C library open() documentation
++ * @return a file handle on success, -1 on error (see errno).
++ * @note Contrary to standard open(), this function returns a file handle
++ * with the close-on-exec flag preset.
++ */
++VLC_API int vlc_open(const char *filename, int flags, ...) VLC_USED;
++
++/**
++ * Opens a system file handle relative to an existing directory handle.
++ *
++ * @param dir directory file descriptor
++ * @param filename file path to open (with UTF-8 encoding)
++ * @param flags open() flags, see the C library open() documentation
++ * @return a file handle on success, -1 on error (see errno).
++ * @note Contrary to standard open(), this function returns a file handle
++ * with the close-on-exec flag preset.
++ */
++VLC_API int vlc_openat(int fd, const char *filename, int flags, ...) VLC_USED;
++
++VLC_API int vlc_mkstemp( char * );
++
++/**
++ * Duplicates a file descriptor. The new file descriptor has the close-on-exec
++ * descriptor flag preset.
++ * @return a new file descriptor, -1 (see errno)
++ */
++VLC_API int vlc_dup(int) VLC_USED;
++
++/**
++ * Creates a pipe (see "man pipe" for further reference). The new file
++ * descriptors have the close-on-exec flag preset.
++ * @return 0 on success, -1 on error (see errno)
++ */
++VLC_API int vlc_pipe(int [2]) VLC_USED;
++
++/**
++ * Creates an anonymous regular file descriptor, i.e. a descriptor for a
++ * temporary file.
++ *
++ * The file is initially empty. The storage space is automatically reclaimed
++ * when all file descriptors referencing it are closed.
++ *
++ * The new file descriptor has the close-on-exec flag preset.
++ *
++ * @return a file descriptor on success, -1 on error (see errno)
++ */
++VLC_API int vlc_memfd(void) VLC_USED;
++
++/**
++ * Writes data to a file descriptor. Unlike write(), if EPIPE error occurs,
++ * this function does not generate a SIGPIPE signal.
++ * @note If the file descriptor is known to be neither a pipe/FIFO nor a
++ * connection-oriented socket, the normal write() should be used.
++ */
++VLC_API ssize_t vlc_write(int, const void *, size_t);
++
++/**
++ * Writes data from an iovec structure to a file descriptor. Unlike writev(),
++ * if EPIPE error occurs, this function does not generate a SIGPIPE signal.
++ */
++VLC_API ssize_t vlc_writev(int, const struct iovec *, int);
++
++/**
++ * Closes a file descriptor.
++ *
++ * This closes a file descriptor. If this is a last file descriptor for the
++ * underlying open file, the file is closed too; the exact semantics depend
++ * on the type of file.
++ *
++ * @note The file descriptor is always closed when the function returns, even
++ * if the function returns an error. The sole exception is if the file
++ * descriptor was not currently valid, and thus cannot be closed (errno will
++ * then be set to EBADF).
++ *
++ * @param fd file descriptor
++ * @return Normally, zero is returned.
++ * If an I/O error is detected before or while closing, the function may return
++ * -1. Such an error is unrecoverable since the descriptor is closed.
++ *
++ * A nul return value does not necessarily imply that all pending I/O
++ * succeeded, since I/O might still occur asynchronously afterwards.
++ */
++VLC_API int vlc_close(int fd);
++
++/**
++ * @}
++ */
++
++/**
++ * Finds file/inode information - like stat().
++ * @note As far as possible, fstat() should be used instead.
++ *
++ * @param filename UTF-8 file path
++ */
++VLC_API int vlc_stat(const char *filename, struct stat *) VLC_USED;
++
++/**
++ * Finds file/inode information, as lstat().
++ * Consider using fstat() instead, if possible.
++ *
++ * @param filename UTF-8 file path
++ */
++VLC_API int vlc_lstat(const char *filename, struct stat *) VLC_USED;
++
++/**
++ * Removes a file.
++ *
++ * @param filename a UTF-8 string with the name of the file you want to delete.
++ * @return A 0 return value indicates success. A -1 return value indicates an
++ *        error, and an error code is stored in errno
++ */
++VLC_API int vlc_unlink(const char *filename);
++
++/**
++ * Moves a file atomically. This only works within a single file system.
++ *
++ * @param oldpath path to the file before the move
++ * @param newpath intended path to the file after the move
++ * @return A 0 return value indicates success. A -1 return value indicates an
++ *        error, and an error code is stored in errno
++ */
++VLC_API int vlc_rename(const char *oldpath, const char *newpath);
++
++VLC_API FILE * vlc_fopen( const char *filename, const char *mode ) VLC_USED;
++
++/**
++ * \defgroup dir Directories
++ * @{
++ */
++
++/**
++ * Opens a DIR pointer.
++ *
++ * @param dirname UTF-8 representation of the directory name
++ * @return a pointer to the DIR struct, or NULL in case of error.
++ * Release with standard closedir().
++ */
++VLC_API DIR *vlc_opendir(const char *dirname) VLC_USED;
++
++/**
++ * Reads the next file name from an open directory.
++ *
++ * @param dir directory handle as returned by vlc_opendir()
++ *            (must not be used by another thread concurrently)
++ *
++ * @return a UTF-8 string of the directory entry. The string is valid until
++ * the next call to vlc_readdir() or closedir() on the handle.
++ * If there are no more entries in the directory, NULL is returned.
++ * If an error occurs, errno is set and NULL is returned.
++ */
++VLC_API const char *vlc_readdir(DIR *dir) VLC_USED;
++
++VLC_API int vlc_loaddir( DIR *dir, char ***namelist, int (*select)( const char * ), int (*compar)( const char **, const char ** ) );
++VLC_API int vlc_scandir( const char *dirname, char ***namelist, int (*select)( const char * ), int (*compar)( const char **, const char ** ) );
++
++/**
++ * Creates a directory.
++ *
++ * @param dirname a UTF-8 string with the name of the directory that you
++ *        want to create.
++ * @param mode directory permissions
++ * @return 0 on success, -1 on error (see errno).
++ */
++VLC_API int vlc_mkdir(const char *dirname, mode_t mode);
++
++/**
++ * Determines the current working directory.
++ *
++ * @return the current working directory (must be free()'d)
++ *         or NULL on error
++ */
++VLC_API char *vlc_getcwd(void) VLC_USED;
++
++/** @} */
++/** @} */
++
++#if defined( _WIN32 )
++typedef struct vlc_DIR
++{
++    _WDIR *wdir; /* MUST be first, see <vlc_fs.h> */
++    char *entry;
++    union
++    {
++        DWORD drives;
++        bool insert_dot_dot;
++    } u;
++} vlc_DIR;
++
++static inline int vlc_closedir( DIR *dir )
++{
++    vlc_DIR *vdir = (vlc_DIR *)dir;
++    _WDIR *wdir = vdir->wdir;
++
++    free( vdir->entry );
++    free( vdir );
++    return (wdir != NULL) ? _wclosedir( wdir ) : 0;
++}
++# undef closedir
++# define closedir vlc_closedir
++
++static inline void vlc_rewinddir( DIR *dir )
++{
++    _WDIR *wdir = *(_WDIR **)dir;
++
++    _wrewinddir( wdir );
++}
++# undef rewinddir
++# define rewinddir vlc_rewinddir
++#endif
++
++#ifdef __ANDROID__
++# define lseek lseek64
++#endif
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_gcrypt.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_gcrypt.h
+new file mode 100644
+index 0000000..a04e1b1
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_gcrypt.h
+@@ -0,0 +1,47 @@
++/*****************************************************************************
++ * vlc_gcrypt.h: VLC thread support for gcrypt
++ *****************************************************************************
++ * Copyright (C) 2004-2010 Rémi Denis-Courmont
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++/**
++ * \file
++ * This file implements gcrypt support functions in vlc
++ */
++
++#include <errno.h>
++
++static inline void vlc_gcrypt_init (void)
++{
++    /* This would need a process-wide static mutex with all libraries linking
++     * to a given instance of libgcrypt. We cannot do this as we have different
++     * plugins linking with gcrypt, and some underlying libraries may use it
++     * behind our back. Only way is to always link gcrypt statically (ouch!) or
++     * have upstream gcrypt provide one shared object per threading system. */
++    static bool done = false;
++
++    vlc_global_lock (VLC_GCRYPT_MUTEX);
++    if (!done)
++    {
++        /* The suggested way for an application to make sure that global_init
++         * has been called is by using gcry_check_version. (see global_init
++         * comments in gcrypt sources) */
++        gcry_check_version(NULL);
++        done = true;
++    }
++    vlc_global_unlock (VLC_GCRYPT_MUTEX);
++}
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_http.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_http.h
+new file mode 100644
+index 0000000..6811e5d
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_http.h
+@@ -0,0 +1,97 @@
++/*****************************************************************************
++ * vlc_http.h: Shared code for HTTP clients
++ *****************************************************************************
++ * Copyright (C) 2001-2008 VLC authors and VideoLAN
++ * $Id: ed7e1613da0bc45b680f3887846f80cf118f36a4 $
++ *
++ * Authors: Laurent Aimar <fenrir@via.ecp.fr>
++ *          Christophe Massiot <massiot@via.ecp.fr>
++ *          Rémi Denis-Courmont <rem # videolan.org>
++ *          Antoine Cellerier <dionoea at videolan dot org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_HTTP_H
++#define VLC_HTTP_H 1
++
++/**
++ * \file
++ * This file defines functions, structures, enums and macros shared between
++ * HTTP clients.
++ */
++
++#include <vlc_url.h>
++#include <vlc_arrays.h>
++
++/* RFC 2617: Basic and Digest Access Authentication */
++typedef struct vlc_http_auth_t
++{
++    char *psz_realm;
++    char *psz_domain;
++    char *psz_nonce;
++    char *psz_opaque;
++    char *psz_stale;
++    char *psz_algorithm;
++    char *psz_qop;
++    int i_nonce;
++    char *psz_cnonce;
++    char *psz_HA1; /* stored H(A1) value if algorithm = "MD5-sess" */
++} vlc_http_auth_t;
++
++
++VLC_API void vlc_http_auth_Init( vlc_http_auth_t * );
++VLC_API void vlc_http_auth_Deinit( vlc_http_auth_t * );
++VLC_API void vlc_http_auth_ParseWwwAuthenticateHeader
++            ( vlc_object_t *, vlc_http_auth_t * , const char * );
++VLC_API int vlc_http_auth_ParseAuthenticationInfoHeader
++            ( vlc_object_t *, vlc_http_auth_t *,
++              const char *, const char *,
++              const char *, const char *,
++              const char * );
++VLC_API char *vlc_http_auth_FormatAuthorizationHeader
++            ( vlc_object_t *, vlc_http_auth_t *,
++              const char *, const char *,
++              const char *, const char * ) VLC_USED;
++
++/* RFC 6265: cookies */
++
++typedef struct vlc_http_cookie_jar_t vlc_http_cookie_jar_t;
++
++VLC_API vlc_http_cookie_jar_t * vlc_http_cookies_new( void ) VLC_USED;
++VLC_API void vlc_http_cookies_destroy( vlc_http_cookie_jar_t * p_jar );
++
++/**
++ * Parse a value of an incoming Set-Cookie header and append the
++ * cookie to the cookie jar if appropriate.
++ *
++ * @param jar cookie jar object
++ * @param cookie header field value of Set-Cookie
++ * @return true, if the cookie was added, false otherwise
++ */
++VLC_API bool vlc_http_cookies_store( vlc_http_cookie_jar_t *jar,
++    const char *cookie, const char *host, const char *path );
++
++/**
++ * Returns a cookie value that match the given URL.
++ *
++ * @param p_jar a cookie jar
++ * @param p_url the URL for which the cookies are returned
++ * @return A string consisting of semicolon-separated cookie NAME=VALUE pairs.
++ */
++VLC_API char *vlc_http_cookies_fetch( vlc_http_cookie_jar_t *jar, bool secure,
++                                      const char *host, const char *path );
++
++#endif /* VLC_HTTP_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_httpd.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_httpd.h
+new file mode 100644
+index 0000000..2cbf035
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_httpd.h
+@@ -0,0 +1,152 @@
++/*****************************************************************************
++ * vlc_httpd.h: builtin HTTP/RTSP server.
++ *****************************************************************************
++ * Copyright (C) 2004-2006 VLC authors and VideoLAN
++ * $Id: 29b8229e7b6baa7a8eedf37f6fdb1e97bf6a9ca7 $
++ *
++ * Authors: Laurent Aimar <fenrir@via.ecp.fr>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_HTTPD_H
++#define VLC_HTTPD_H 1
++
++/**
++ * \file
++ * HTTP/RTSP server API.
++ */
++
++enum
++{
++    HTTPD_MSG_NONE,
++
++    /* answer */
++    HTTPD_MSG_ANSWER,
++
++    /* http request */
++    HTTPD_MSG_GET,
++    HTTPD_MSG_HEAD,
++    HTTPD_MSG_POST,
++
++    /* rtsp request */
++    HTTPD_MSG_OPTIONS,
++    HTTPD_MSG_DESCRIBE,
++    HTTPD_MSG_SETUP,
++    HTTPD_MSG_PLAY,
++    HTTPD_MSG_PAUSE,
++    HTTPD_MSG_GETPARAMETER,
++    HTTPD_MSG_TEARDOWN,
++
++    /* just to track the count of MSG */
++    HTTPD_MSG_MAX
++};
++
++enum
++{
++    HTTPD_PROTO_NONE,
++    HTTPD_PROTO_HTTP,  /* HTTP/1.x */
++    HTTPD_PROTO_RTSP,  /* RTSP/1.x */
++    HTTPD_PROTO_HTTP0, /* HTTP/0.x */
++};
++
++typedef struct httpd_host_t   httpd_host_t;
++typedef struct httpd_client_t httpd_client_t;
++/* create a new host */
++VLC_API httpd_host_t *vlc_http_HostNew( vlc_object_t * ) VLC_USED;
++VLC_API httpd_host_t *vlc_https_HostNew( vlc_object_t * ) VLC_USED;
++VLC_API httpd_host_t *vlc_rtsp_HostNew( vlc_object_t * ) VLC_USED;
++/* delete a host */
++VLC_API void httpd_HostDelete( httpd_host_t * );
++
++typedef struct
++{
++    char * name;
++    char * value;
++} httpd_header;
++
++typedef struct httpd_message_t
++{
++    httpd_client_t *cl; /* NULL if not throught a connection e vlc internal */
++
++    uint8_t i_type;
++    uint8_t i_proto;
++    uint8_t i_version;
++
++    /* for an answer */
++    int     i_status;
++
++    /* for a query */
++    char    *psz_url;
++    /* FIXME find a clean way to handle GET(psz_args)
++       and POST(body) through the same code */
++    uint8_t *psz_args;
++
++    /* options */
++    size_t       i_headers;
++    httpd_header *p_headers;
++
++    /* body */
++    int64_t i_body_offset;
++    int     i_body;
++    uint8_t *p_body;
++
++} httpd_message_t;
++
++typedef struct httpd_url_t      httpd_url_t;
++typedef struct httpd_callback_sys_t httpd_callback_sys_t;
++typedef int    (*httpd_callback_t)( httpd_callback_sys_t *, httpd_client_t *, httpd_message_t *answer, const httpd_message_t *query );
++/* register a new url */
++VLC_API httpd_url_t * httpd_UrlNew( httpd_host_t *, const char *psz_url, const char *psz_user, const char *psz_password ) VLC_USED;
++/* register callback on a url */
++VLC_API int httpd_UrlCatch( httpd_url_t *, int i_msg, httpd_callback_t, httpd_callback_sys_t * );
++/* delete a url */
++VLC_API void httpd_UrlDelete( httpd_url_t * );
++
++VLC_API char* httpd_ClientIP( const httpd_client_t *cl, char *, int * );
++VLC_API char* httpd_ServerIP( const httpd_client_t *cl, char *, int * );
++
++/* High level */
++
++typedef struct httpd_file_t     httpd_file_t;
++typedef struct httpd_file_sys_t httpd_file_sys_t;
++typedef int (*httpd_file_callback_t)( httpd_file_sys_t *, httpd_file_t *, uint8_t *psz_request, uint8_t **pp_data, int *pi_data );
++VLC_API httpd_file_t * httpd_FileNew( httpd_host_t *, const char *psz_url, const char *psz_mime, const char *psz_user, const char *psz_password, httpd_file_callback_t pf_fill, httpd_file_sys_t * ) VLC_USED;
++VLC_API httpd_file_sys_t * httpd_FileDelete( httpd_file_t * );
++
++
++typedef struct httpd_handler_t  httpd_handler_t;
++typedef int (*httpd_handler_callback_t)( void *, httpd_handler_t *, char *psz_url, uint8_t *psz_request, int i_type, uint8_t *p_in, int i_in, char *psz_remote_addr, char *psz_remote_host, uint8_t **pp_data, int *pi_data );
++VLC_API httpd_handler_t * httpd_HandlerNew( httpd_host_t *, const char *psz_url, const char *psz_user, const char *psz_password, httpd_handler_callback_t pf_fill, void * ) VLC_USED;
++VLC_API void * httpd_HandlerDelete( httpd_handler_t * );
++
++typedef struct httpd_redirect_t httpd_redirect_t;
++VLC_API httpd_redirect_t * httpd_RedirectNew( httpd_host_t *, const char *psz_url_dst, const char *psz_url_src ) VLC_USED;
++VLC_API void httpd_RedirectDelete( httpd_redirect_t * );
++
++
++typedef struct httpd_stream_t httpd_stream_t;
++VLC_API httpd_stream_t * httpd_StreamNew( httpd_host_t *, const char *psz_url, const char *psz_mime, const char *psz_user, const char *psz_password ) VLC_USED;
++VLC_API void httpd_StreamDelete( httpd_stream_t * );
++VLC_API int httpd_StreamHeader( httpd_stream_t *, uint8_t *p_data, int i_data );
++VLC_API int httpd_StreamSend( httpd_stream_t *, const block_t *p_block );
++VLC_API int httpd_StreamSetHTTPHeaders(httpd_stream_t *, const httpd_header *, size_t);
++
++/* Msg functions facilities */
++VLC_API void httpd_MsgAdd( httpd_message_t *, const char *psz_name, const char *psz_value, ... ) VLC_FORMAT( 3, 4 );
++/* return "" if not found. The string is not allocated */
++VLC_API const char * httpd_MsgGet( const httpd_message_t *, const char *psz_name );
++
++#endif /* _VLC_HTTPD_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_image.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_image.h
+new file mode 100644
+index 0000000..2c5896f
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_image.h
+@@ -0,0 +1,81 @@
++/*****************************************************************************
++ * vlc_image.h : wrapper for image reading/writing facilities
++ *****************************************************************************
++ * Copyright (C) 2004 VLC authors and VideoLAN
++ * $Id: 2b308fd0e52f4d4d6e20f95d08e0d63c53822eef $
++ *
++ * Authors: Gildas Bazin <gbazin@videolan.org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_IMAGE_H
++#define VLC_IMAGE_H 1
++
++# include <vlc_picture.h>
++# include <vlc_picture_fifo.h>
++
++/**
++ * \file
++ * This file defines functions and structures for image conversions in vlc
++ */
++
++# ifdef __cplusplus
++extern "C" {
++# endif
++
++struct image_handler_t
++{
++    picture_t * (*pf_read)      ( image_handler_t *, block_t *,
++                                  const video_format_t *, video_format_t * );
++    picture_t * (*pf_read_url)  ( image_handler_t *, const char *,
++                                  video_format_t *, video_format_t * );
++    block_t * (*pf_write)       ( image_handler_t *, picture_t *,
++                                  const video_format_t *, const video_format_t * );
++    int (*pf_write_url)         ( image_handler_t *, picture_t *,
++                                  const video_format_t *, video_format_t *,
++                                  const char * );
++
++    picture_t * (*pf_convert)   ( image_handler_t *, picture_t *,
++                                  const video_format_t *, video_format_t * );
++
++    /* Private properties */
++    vlc_object_t *p_parent;
++    decoder_t *p_dec;
++    encoder_t *p_enc;
++    filter_t  *p_filter;
++
++    picture_fifo_t *outfifo;
++};
++
++VLC_API image_handler_t * image_HandlerCreate( vlc_object_t * ) VLC_USED;
++#define image_HandlerCreate( a ) image_HandlerCreate( VLC_OBJECT(a) )
++VLC_API void image_HandlerDelete( image_handler_t * );
++
++#define image_Read( a, b, c, d ) a->pf_read( a, b, c, d )
++#define image_ReadUrl( a, b, c, d ) a->pf_read_url( a, b, c, d )
++#define image_Write( a, b, c, d ) a->pf_write( a, b, c, d )
++#define image_WriteUrl( a, b, c, d, e ) a->pf_write_url( a, b, c, d, e )
++#define image_Convert( a, b, c, d ) a->pf_convert( a, b, c, d )
++
++VLC_API vlc_fourcc_t image_Type2Fourcc( const char *psz_name );
++VLC_API vlc_fourcc_t image_Ext2Fourcc( const char *psz_name );
++VLC_API vlc_fourcc_t image_Mime2Fourcc( const char *psz_mime );
++
++# ifdef __cplusplus
++}
++# endif
++
++#endif /* _VLC_IMAGE_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_inhibit.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_inhibit.h
+new file mode 100644
+index 0000000..b1f7330
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_inhibit.h
+@@ -0,0 +1,54 @@
++/*****************************************************************************
++ * vlc_inhibit.h: VLC screen saver inhibition
++ *****************************************************************************
++ * Copyright (C) 2009 Rémi Denis-Courmont
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++/**
++ * \file
++ * This file defines the interface for screen-saver inhibition modules
++ */
++
++#ifndef VLC_INHIBIT_H
++# define VLC_INHIBIT_H 1
++
++typedef struct vlc_inhibit vlc_inhibit_t;
++typedef struct vlc_inhibit_sys vlc_inhibit_sys_t;
++
++enum vlc_inhibit_flags
++{
++    VLC_INHIBIT_NONE=0 /*< No inhibition */,
++    VLC_INHIBIT_SUSPEND=0x1 /*< Processor is in use - do not suspend */,
++    VLC_INHIBIT_DISPLAY=0x2 /*< Display is in use - do not blank/lock */,
++#define VLC_INHIBIT_AUDIO (VLC_INHIBIT_SUSPEND)
++#define VLC_INHIBIT_VIDEO (VLC_INHIBIT_SUSPEND|VLC_INHIBIT_DISPLAY)
++};
++
++struct vlc_inhibit
++{
++    VLC_COMMON_MEMBERS
++
++    vlc_inhibit_sys_t *p_sys;
++    void (*inhibit) (vlc_inhibit_t *, unsigned flags);
++};
++
++static inline void vlc_inhibit_Set (vlc_inhibit_t *ih, unsigned flags)
++{
++    ih->inhibit (ih, flags);
++}
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_input.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_input.h
+new file mode 100644
+index 0000000..85b4d3d
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_input.h
+@@ -0,0 +1,703 @@
++/*****************************************************************************
++ * vlc_input.h: Core input structures
++ *****************************************************************************
++ * Copyright (C) 1999-2015 VLC authors and VideoLAN
++ * $Id: d20585ba33030980fa496cd042227b543f10827a $
++ *
++ * Authors: Christophe Massiot <massiot@via.ecp.fr>
++ *          Laurent Aimar <fenrir@via.ecp.fr>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_INPUT_H
++#define VLC_INPUT_H 1
++
++/**
++ * \defgroup input Input
++ * Input thread
++ * @{
++ * \file
++ * Input thread interface
++ */
++
++#include <vlc_es.h>
++#include <vlc_meta.h>
++#include <vlc_epg.h>
++#include <vlc_events.h>
++#include <vlc_input_item.h>
++#include <vlc_vout.h>
++#include <vlc_vout_osd.h>
++
++#include <string.h>
++
++/*****************************************************************************
++ * Seek point: (generalisation of chapters)
++ *****************************************************************************/
++struct seekpoint_t
++{
++    int64_t i_time_offset;
++    char    *psz_name;
++};
++
++static inline seekpoint_t *vlc_seekpoint_New( void )
++{
++    seekpoint_t *point = (seekpoint_t*)malloc( sizeof( seekpoint_t ) );
++    if( !point )
++        return NULL;
++    point->i_time_offset = -1;
++    point->psz_name = NULL;
++    return point;
++}
++
++static inline void vlc_seekpoint_Delete( seekpoint_t *point )
++{
++    if( !point ) return;
++    free( point->psz_name );
++    free( point );
++}
++
++static inline seekpoint_t *vlc_seekpoint_Duplicate( const seekpoint_t *src )
++{
++    seekpoint_t *point = vlc_seekpoint_New();
++    if( likely(point) )
++    {
++        if( src->psz_name ) point->psz_name = strdup( src->psz_name );
++        point->i_time_offset = src->i_time_offset;
++    }
++    return point;
++}
++
++/*****************************************************************************
++ * Title:
++ *****************************************************************************/
++
++/* input_title_t.i_flags field */
++#define INPUT_TITLE_MENU         0x01   /* Menu title */
++#define INPUT_TITLE_INTERACTIVE  0x02   /* Interactive title. Playback position has no meaning. */
++
++typedef struct input_title_t
++{
++    char        *psz_name;
++
++    int64_t     i_length;   /* Length(microsecond) if known, else 0 */
++
++    unsigned    i_flags;    /* Is it a menu or a normal entry */
++
++    /* Title seekpoint */
++    int         i_seekpoint;
++    seekpoint_t **seekpoint;
++} input_title_t;
++
++static inline input_title_t *vlc_input_title_New(void)
++{
++    input_title_t *t = (input_title_t*)malloc( sizeof( input_title_t ) );
++    if( !t )
++        return NULL;
++
++    t->psz_name = NULL;
++    t->i_flags = 0;
++    t->i_length = 0;
++    t->i_seekpoint = 0;
++    t->seekpoint = NULL;
++
++    return t;
++}
++
++static inline void vlc_input_title_Delete( input_title_t *t )
++{
++    int i;
++    if( t == NULL )
++        return;
++
++    free( t->psz_name );
++    for( i = 0; i < t->i_seekpoint; i++ )
++        vlc_seekpoint_Delete( t->seekpoint[i] );
++    free( t->seekpoint );
++    free( t );
++}
++
++static inline input_title_t *vlc_input_title_Duplicate( const input_title_t *t )
++{
++    input_title_t *dup = vlc_input_title_New( );
++    if( dup == NULL) return NULL;
++
++    if( t->psz_name ) dup->psz_name = strdup( t->psz_name );
++    dup->i_flags     = t->i_flags;
++    dup->i_length    = t->i_length;
++    if( t->i_seekpoint > 0 )
++    {
++        dup->seekpoint = (seekpoint_t**)vlc_alloc( t->i_seekpoint, sizeof(seekpoint_t*) );
++        if( likely(dup->seekpoint) )
++        {
++            for( int i = 0; i < t->i_seekpoint; i++ )
++                dup->seekpoint[i] = vlc_seekpoint_Duplicate( t->seekpoint[i] );
++            dup->i_seekpoint = t->i_seekpoint;
++        }
++    }
++
++    return dup;
++}
++
++/*****************************************************************************
++ * Attachments
++ *****************************************************************************/
++struct input_attachment_t
++{
++    char *psz_name;
++    char *psz_mime;
++    char *psz_description;
++
++    size_t i_data;
++    void *p_data;
++};
++
++static inline void vlc_input_attachment_Delete( input_attachment_t *a )
++{
++    if( !a )
++        return;
++
++    free( a->p_data );
++    free( a->psz_description );
++    free( a->psz_mime );
++    free( a->psz_name );
++    free( a );
++}
++
++static inline input_attachment_t *vlc_input_attachment_New( const char *psz_name,
++                                                            const char *psz_mime,
++                                                            const char *psz_description,
++                                                            const void *p_data,
++                                                            size_t i_data )
++{
++    input_attachment_t *a = (input_attachment_t *)malloc( sizeof (*a) );
++    if( unlikely(a == NULL) )
++        return NULL;
++
++    a->psz_name = strdup( psz_name ? psz_name : "" );
++    a->psz_mime = strdup( psz_mime ? psz_mime : "" );
++    a->psz_description = strdup( psz_description ? psz_description : "" );
++    a->i_data = i_data;
++    a->p_data = malloc( i_data );
++    if( i_data > 0 && likely(a->p_data != NULL) )
++        memcpy( a->p_data, p_data, i_data );
++
++    if( unlikely(a->psz_name == NULL || a->psz_mime == NULL
++              || a->psz_description == NULL || (i_data > 0 && a->p_data == NULL)) )
++    {
++        vlc_input_attachment_Delete( a );
++        a = NULL;
++    }
++    return a;
++}
++
++static inline input_attachment_t *vlc_input_attachment_Duplicate( const input_attachment_t *a )
++{
++    return vlc_input_attachment_New( a->psz_name, a->psz_mime, a->psz_description,
++                                     a->p_data, a->i_data );
++}
++
++/*****************************************************************************
++ * input defines/constants.
++ *****************************************************************************/
++
++/**
++ * This defines an opaque input resource handler.
++ */
++typedef struct input_resource_t input_resource_t;
++
++/**
++ * Main structure representing an input thread. This structure is mostly
++ * private. The only public fields are read-only and constant.
++ */
++struct input_thread_t
++{
++    VLC_COMMON_MEMBERS
++};
++
++/**
++ * Record prefix string.
++ * TODO make it configurable.
++ */
++#define INPUT_RECORD_PREFIX "vlc-record-%Y-%m-%d-%Hh%Mm%Ss-$ N-$ p"
++
++/*****************************************************************************
++ * Input events and variables
++ *****************************************************************************/
++
++/**
++ * \defgroup inputvariable Input variables
++ *
++ * The input provides multiples variable you can write to and/or read from.
++ *
++ * TODO complete the documentation.
++ * The read only variables are:
++ *  - "length"
++ *  - "can-seek" (if you can seek, it doesn't say if 'bar display' has be shown
++ *    or not, for that check position != 0.0)
++ *  - "can-pause"
++ *  - "can-rate"
++ *  - "can-rewind"
++ *  - "can-record" (if a stream can be recorded while playing)
++ *  - "teletext-es" (list of id from the spu tracks (spu-es) that are teletext, the
++ *                   variable value being the one currently selected, -1 if no teletext)
++ *  - "signal-quality"
++ *  - "signal-strength"
++ *  - "program-scrambled" (if the current program is scrambled)
++ *  - "cache" (level of data cached [0 .. 1])
++ *
++ * The read-write variables are:
++ *  - state (\see input_state_e)
++ *  - rate
++ *  - position
++ *  - time, time-offset
++ *  - title, next-title, prev-title
++ *  - chapter, next-chapter, next-chapter-prev
++ *  - program, audio-es, video-es, spu-es
++ *  - audio-delay, spu-delay
++ *  - bookmark (bookmark list)
++ *  - record
++ *  - frame-next
++ *  - navigation (list of "title %2i")
++ *  - "title %2i"
++ *
++ * The variable used for event is
++ *  - intf-event (\see input_event_type_e)
++ */
++
++/**
++ * Input state
++ *
++ * This enum is used by the variable "state"
++ */
++typedef enum input_state_e
++{
++    INIT_S = 0,
++    OPENING_S,
++    PLAYING_S,
++    PAUSE_S,
++    END_S,
++    ERROR_S,
++} input_state_e;
++
++/**
++ * Input rate.
++ *
++ * It is an float used by the variable "rate" in the
++ * range [INPUT_RATE_DEFAULT/INPUT_RATE_MAX, INPUT_RATE_DEFAULT/INPUT_RATE_MIN]
++ * the default value being 1. It represents the ratio of playback speed to
++ * nominal speed (bigger is faster).
++ *
++ * Internally, the rate is stored as a value in the range
++ * [INPUT_RATE_MIN, INPUT_RATE_MAX].
++ * internal rate = INPUT_RATE_DEFAULT / rate variable
++ */
++
++/**
++ * Default rate value
++ */
++#define INPUT_RATE_DEFAULT  1000
++/**
++ * Minimal rate value
++ */
++#define INPUT_RATE_MIN        32            /* Up to 32/1 */
++/**
++ * Maximal rate value
++ */
++#define INPUT_RATE_MAX     32000            /* Up to 1/32 */
++
++/**
++ * Input events
++ *
++ * You can catch input event by adding a callback on the variable "intf-event".
++ * This variable is an integer that will hold a input_event_type_e value.
++ */
++typedef enum input_event_type_e
++{
++    /* "state" has changed */
++    INPUT_EVENT_STATE,
++    /* b_dead is true */
++    INPUT_EVENT_DEAD,
++
++    /* "rate" has changed */
++    INPUT_EVENT_RATE,
++
++    /* At least one of "position" or "time" */
++    INPUT_EVENT_POSITION,
++
++    /* "length" has changed */
++    INPUT_EVENT_LENGTH,
++
++    /* A title has been added or removed or selected.
++     * It implies that the chapter has changed (no chapter event is sent) */
++    INPUT_EVENT_TITLE,
++    /* A chapter has been added or removed or selected. */
++    INPUT_EVENT_CHAPTER,
++
++    /* A program ("program") has been added or removed or selected,
++     * or "program-scrambled" has changed.*/
++    INPUT_EVENT_PROGRAM,
++    /* A ES has been added or removed or selected */
++    INPUT_EVENT_ES,
++    /* "teletext-es" has changed */
++    INPUT_EVENT_TELETEXT,
++
++    /* "record" has changed */
++    INPUT_EVENT_RECORD,
++
++    /* input_item_t media has changed */
++    INPUT_EVENT_ITEM_META,
++    /* input_item_t info has changed */
++    INPUT_EVENT_ITEM_INFO,
++    /* input_item_t epg has changed */
++    INPUT_EVENT_ITEM_EPG,
++
++    /* Input statistics have been updated */
++    INPUT_EVENT_STATISTICS,
++    /* At least one of "signal-quality" or "signal-strength" has changed */
++    INPUT_EVENT_SIGNAL,
++
++    /* "audio-delay" has changed */
++    INPUT_EVENT_AUDIO_DELAY,
++    /* "spu-delay" has changed */
++    INPUT_EVENT_SUBTITLE_DELAY,
++
++    /* "bookmark" has changed */
++    INPUT_EVENT_BOOKMARK,
++
++    /* cache" has changed */
++    INPUT_EVENT_CACHE,
++
++    /* A audio_output_t object has been created/deleted by *the input* */
++    INPUT_EVENT_AOUT,
++    /* A vout_thread_t object has been created/deleted by *the input* */
++    INPUT_EVENT_VOUT,
++
++} input_event_type_e;
++
++/**
++ * Input queries
++ */
++enum input_query_e
++{
++    /* input variable "position" */
++    INPUT_GET_POSITION,         /* arg1= double *       res=    */
++    INPUT_SET_POSITION,         /* arg1= double         res=can fail    */
++
++    /* input variable "length" */
++    INPUT_GET_LENGTH,           /* arg1= int64_t *      res=can fail    */
++
++    /* input variable "time" */
++    INPUT_GET_TIME,             /* arg1= int64_t *      res=    */
++    INPUT_SET_TIME,             /* arg1= int64_t        res=can fail    */
++
++    /* input variable "rate" (nominal is INPUT_RATE_DEFAULT) */
++    INPUT_GET_RATE,             /* arg1= int *          res=    */
++    INPUT_SET_RATE,             /* arg1= int            res=can fail    */
++
++    /* input variable "state" */
++    INPUT_GET_STATE,            /* arg1= int *          res=    */
++    INPUT_SET_STATE,            /* arg1= int            res=can fail    */
++
++    /* input variable "audio-delay" and "sub-delay" */
++    INPUT_GET_AUDIO_DELAY,      /* arg1 = int* res=can fail */
++    INPUT_SET_AUDIO_DELAY,      /* arg1 = int  res=can fail */
++    INPUT_GET_SPU_DELAY,        /* arg1 = int* res=can fail */
++    INPUT_SET_SPU_DELAY,        /* arg1 = int  res=can fail */
++
++    /* Menu (VCD/DVD/BD) Navigation */
++    /** Activate the navigation item selected. res=can fail */
++    INPUT_NAV_ACTIVATE,
++    /** Use the up arrow to select a navigation item above. res=can fail */
++    INPUT_NAV_UP,
++    /** Use the down arrow to select a navigation item under. res=can fail */
++    INPUT_NAV_DOWN,
++    /** Use the left arrow to select a navigation item on the left. res=can fail */
++    INPUT_NAV_LEFT,
++    /** Use the right arrow to select a navigation item on the right. res=can fail */
++    INPUT_NAV_RIGHT,
++    /** Activate the popup Menu (for BD). res=can fail */
++    INPUT_NAV_POPUP,
++    /** Activate disc Root Menu. res=can fail */
++    INPUT_NAV_MENU,
++
++    /* Meta datas */
++    INPUT_ADD_INFO,   /* arg1= char* arg2= char* arg3=...     res=can fail */
++    INPUT_REPLACE_INFOS,/* arg1= info_category_t *            res=cannot fail */
++    INPUT_MERGE_INFOS,/* arg1= info_category_t *              res=cannot fail */
++    INPUT_DEL_INFO,   /* arg1= char* arg2= char*              res=can fail */
++
++    /* bookmarks */
++    INPUT_GET_BOOKMARK,    /* arg1= seekpoint_t *               res=can fail */
++    INPUT_GET_BOOKMARKS,   /* arg1= seekpoint_t *** arg2= int * res=can fail */
++    INPUT_CLEAR_BOOKMARKS, /* res=can fail */
++    INPUT_ADD_BOOKMARK,    /* arg1= seekpoint_t *  res=can fail   */
++    INPUT_CHANGE_BOOKMARK, /* arg1= seekpoint_t * arg2= int * res=can fail   */
++    INPUT_DEL_BOOKMARK,    /* arg1= seekpoint_t *  res=can fail   */
++    INPUT_SET_BOOKMARK,    /* arg1= int  res=can fail    */
++
++    /* titles */
++    INPUT_GET_TITLE_INFO,     /* arg1=input_title_t** arg2= int * res=can fail */
++    INPUT_GET_FULL_TITLE_INFO,     /* arg1=input_title_t*** arg2= int * res=can fail */
++
++    /* seekpoints */
++    INPUT_GET_SEEKPOINTS,  /* arg1=seekpoint_t*** arg2= int * res=can fail */
++
++    /* Attachments */
++    INPUT_GET_ATTACHMENTS, /* arg1=input_attachment_t***, arg2=int*  res=can fail */
++    INPUT_GET_ATTACHMENT,  /* arg1=input_attachment_t**, arg2=char*  res=can fail */
++
++    /* On the fly input slave */
++    INPUT_ADD_SLAVE,       /* arg1= enum slave_type, arg2= const char *,
++                            * arg3= bool forced, arg4= bool notify,
++                            * arg5= bool check_extension */
++
++    /* On the fly record while playing */
++    INPUT_SET_RECORD_STATE, /* arg1=bool    res=can fail */
++    INPUT_GET_RECORD_STATE, /* arg1=bool*   res=can fail */
++
++    /* ES */
++    INPUT_RESTART_ES,       /* arg1=int (-AUDIO/VIDEO/SPU_ES for the whole category) */
++
++    /* Viewpoint */
++    INPUT_UPDATE_VIEWPOINT, /* arg1=(const vlc_viewpoint_t*), arg2=bool b_absolute */
++    INPUT_SET_INITIAL_VIEWPOINT, /* arg1=(const vlc_viewpoint_t*) */
++
++    /* Input ressources
++     * XXX You must call vlc_object_release as soon as possible */
++    INPUT_GET_AOUT,         /* arg1=audio_output_t **              res=can fail */
++    INPUT_GET_VOUTS,        /* arg1=vout_thread_t ***, size_t *        res=can fail */
++    INPUT_GET_ES_OBJECTS,   /* arg1=int id, vlc_object_t **dec, vout_thread_t **, audio_output_t ** */
++
++    /* Renderers */
++    INPUT_SET_RENDERER,     /* arg1=vlc_renderer_item_t* */
++
++    /* External clock managments */
++    INPUT_GET_PCR_SYSTEM,   /* arg1=mtime_t *, arg2=mtime_t *       res=can fail */
++    INPUT_MODIFY_PCR_SYSTEM,/* arg1=int absolute, arg2=mtime_t      res=can fail */
++};
++
++/** @}*/
++
++/*****************************************************************************
++ * Prototypes
++ *****************************************************************************/
++
++VLC_API input_thread_t * input_Create( vlc_object_t *p_parent, input_item_t *,
++                                       const char *psz_log, input_resource_t *,
++                                       vlc_renderer_item_t* p_renderer ) VLC_USED;
++#define input_Create(a,b,c,d,e) input_Create(VLC_OBJECT(a),b,c,d,e)
++
++VLC_API int input_Start( input_thread_t * );
++
++VLC_API void input_Stop( input_thread_t * );
++
++VLC_API int input_Read( vlc_object_t *, input_item_t * );
++#define input_Read(a,b) input_Read(VLC_OBJECT(a),b)
++
++VLC_API int input_vaControl( input_thread_t *, int i_query, va_list  );
++
++VLC_API int input_Control( input_thread_t *, int i_query, ...  );
++
++VLC_API void input_Close( input_thread_t * );
++
++/**
++ * Create a new input_thread_t and start it.
++ *
++ * Provided for convenience.
++ *
++ * \see input_Create
++ */
++static inline
++input_thread_t *input_CreateAndStart( vlc_object_t *parent,
++                                      input_item_t *item, const char *log )
++{
++    input_thread_t *input = input_Create( parent, item, log, NULL, NULL );
++    if( input != NULL && input_Start( input ) )
++    {
++        vlc_object_release( input );
++        input = NULL;
++    }
++    return input;
++}
++#define input_CreateAndStart(a,b,c) input_CreateAndStart(VLC_OBJECT(a),b,c)
++
++/**
++ * Get the input item for an input thread
++ *
++ * You have to keep a reference to the input or to the input_item_t until
++ * you do not need it anymore.
++ */
++VLC_API input_item_t* input_GetItem( input_thread_t * ) VLC_USED;
++
++/**
++ * It will return the current state of the input.
++ * Provided for convenience.
++ */
++static inline input_state_e input_GetState( input_thread_t * p_input )
++{
++    input_state_e state = INIT_S;
++    input_Control( p_input, INPUT_GET_STATE, &state );
++    return state;
++}
++
++/**
++ * Return one of the video output (if any). If possible, you should use
++ * INPUT_GET_VOUTS directly and process _all_ video outputs instead.
++ * @param p_input an input thread from which to get a video output
++ * @return NULL on error, or a video output thread pointer (which needs to be
++ * released with vlc_object_release()).
++ */
++static inline vout_thread_t *input_GetVout( input_thread_t *p_input )
++{
++     vout_thread_t **pp_vout, *p_vout;
++     size_t i_vout;
++
++     if( input_Control( p_input, INPUT_GET_VOUTS, &pp_vout, &i_vout ) )
++         return NULL;
++
++     for( size_t i = 1; i < i_vout; i++ )
++         vlc_object_release( (vlc_object_t *)(pp_vout[i]) );
++
++     p_vout = (i_vout >= 1) ? pp_vout[0] : NULL;
++     free( pp_vout );
++     return p_vout;
++}
++
++static inline int input_AddSlave( input_thread_t *p_input, enum slave_type type,
++                                  const char *psz_uri, bool b_forced,
++                                  bool b_notify, bool b_check_ext )
++{
++    return input_Control( p_input, INPUT_ADD_SLAVE, type, psz_uri, b_forced,
++                          b_notify, b_check_ext );
++}
++
++/**
++ * Update the viewpoint of the input thread. The viewpoint will be applied to
++ * all vouts and aouts.
++ *
++ * @param p_input an input thread
++ * @param p_viewpoint the viewpoint value
++ * @param b_absolute if true replace the old viewpoint with the new one. If
++ * false, increase/decrease it.
++ * @return VLC_SUCCESS or a VLC error code
++ */
++static inline int input_UpdateViewpoint( input_thread_t *p_input,
++                                         const vlc_viewpoint_t *p_viewpoint,
++                                         bool b_absolute )
++{
++    return input_Control( p_input, INPUT_UPDATE_VIEWPOINT, p_viewpoint,
++                          b_absolute );
++}
++
++/**
++ * Return the audio output (if any) associated with an input.
++ * @param p_input an input thread
++ * @return NULL on error, or the audio output (which needs to be
++ * released with vlc_object_release()).
++ */
++static inline audio_output_t *input_GetAout( input_thread_t *p_input )
++{
++     audio_output_t *p_aout;
++     return input_Control( p_input, INPUT_GET_AOUT, &p_aout ) ? NULL : p_aout;
++}
++
++/**
++ * Returns the objects associated to an ES.
++ *
++ * You must release all non NULL object using vlc_object_release.
++ * You may set pointer of pointer to NULL to avoid retreiving it.
++ */
++static inline int input_GetEsObjects( input_thread_t *p_input, int i_id,
++                                      vlc_object_t **pp_decoder,
++                                      vout_thread_t **pp_vout, audio_output_t **pp_aout )
++{
++    return input_Control( p_input, INPUT_GET_ES_OBJECTS, i_id,
++                          pp_decoder, pp_vout, pp_aout );
++}
++
++/**
++ * \see input_clock_GetSystemOrigin
++ */
++static inline int input_GetPcrSystem( input_thread_t *p_input, mtime_t *pi_system, mtime_t *pi_delay )
++{
++    return input_Control( p_input, INPUT_GET_PCR_SYSTEM, pi_system, pi_delay );
++}
++/**
++ * \see input_clock_ChangeSystemOrigin
++ */
++static inline int input_ModifyPcrSystem( input_thread_t *p_input, bool b_absolute, mtime_t i_system )
++{
++    return input_Control( p_input, INPUT_MODIFY_PCR_SYSTEM, b_absolute, i_system );
++}
++
++/* */
++VLC_API decoder_t * input_DecoderCreate( vlc_object_t *, const es_format_t *, input_resource_t * ) VLC_USED;
++VLC_API void input_DecoderDelete( decoder_t * );
++VLC_API void input_DecoderDecode( decoder_t *, block_t *, bool b_do_pace );
++VLC_API void input_DecoderDrain( decoder_t * );
++VLC_API void input_DecoderFlush( decoder_t * );
++
++/**
++ * This function creates a sane filename path.
++ */
++VLC_API char * input_CreateFilename( input_thread_t *, const char *psz_path, const char *psz_prefix, const char *psz_extension ) VLC_USED;
++
++/**
++ * It creates an empty input resource handler.
++ *
++ * The given object MUST stay alive as long as the input_resource_t is
++ * not deleted.
++ */
++VLC_API input_resource_t * input_resource_New( vlc_object_t * ) VLC_USED;
++
++/**
++ * It releases an input resource.
++ */
++VLC_API void input_resource_Release( input_resource_t * );
++
++/**
++ * Forcefully destroys the video output (e.g. when the playlist is stopped).
++ */
++VLC_API void input_resource_TerminateVout( input_resource_t * );
++
++/**
++ * This function releases all resources (object).
++ */
++VLC_API void input_resource_Terminate( input_resource_t * );
++
++/**
++ * \return the current audio output if any.
++ * Use vlc_object_release() to drop the reference.
++ */
++VLC_API audio_output_t *input_resource_HoldAout( input_resource_t * );
++
++/**
++ * This function creates or recycles an audio output.
++ */
++VLC_API audio_output_t *input_resource_GetAout( input_resource_t * );
++
++/**
++ * This function retains or destroys an audio output.
++ */
++VLC_API void input_resource_PutAout( input_resource_t *, audio_output_t * );
++
++/**
++ * Prevents the existing audio output (if any) from being recycled.
++ */
++VLC_API void input_resource_ResetAout( input_resource_t * );
++
++/** @} */
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_input_item.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_input_item.h
+new file mode 100644
+index 0000000..82f9b59
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_input_item.h
+@@ -0,0 +1,483 @@
++/*****************************************************************************
++ * vlc_input_item.h: Core input item
++ *****************************************************************************
++ * Copyright (C) 1999-2009 VLC authors and VideoLAN
++ * $Id: f22c3d9330af98a15992ef08e362424313774d6f $
++ *
++ * Authors: Christophe Massiot <massiot@via.ecp.fr>
++ *          Laurent Aimar <fenrir@via.ecp.fr>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_INPUT_ITEM_H
++#define VLC_INPUT_ITEM_H 1
++
++/**
++ * \file
++ * This file defines functions, structures and enums for input items in vlc
++ */
++
++#include <vlc_meta.h>
++#include <vlc_epg.h>
++#include <vlc_events.h>
++
++#include <string.h>
++
++typedef struct input_item_opaque input_item_opaque_t;
++typedef struct input_item_slave input_item_slave_t;
++
++struct info_t
++{
++    char *psz_name;            /**< Name of this info */
++    char *psz_value;           /**< Value of the info */
++};
++
++struct info_category_t
++{
++    char   *psz_name;      /**< Name of this category */
++    int    i_infos;        /**< Number of infos in the category */
++    struct info_t **pp_infos;     /**< Pointer to an array of infos */
++};
++
++/**
++ * Describes an input and is used to spawn input_thread_t objects.
++ */
++struct input_item_t
++{
++    char       *psz_name;            /**< text describing this item */
++    char       *psz_uri;             /**< mrl of this item */
++
++    int        i_options;            /**< Number of input options */
++    char       **ppsz_options;       /**< Array of input options */
++    uint8_t    *optflagv;            /**< Some flags of input options */
++    unsigned   optflagc;
++    input_item_opaque_t *opaques;    /**< List of opaque pointer values */
++
++    mtime_t    i_duration;           /**< Duration in microseconds */
++
++
++    int        i_categories;         /**< Number of info categories */
++    info_category_t **pp_categories; /**< Pointer to the first info category */
++
++    int         i_es;                /**< Number of es format descriptions */
++    es_format_t **es;                /**< Es formats */
++
++    input_stats_t *p_stats;          /**< Statistics */
++
++    vlc_meta_t *p_meta;
++
++    int         i_epg;               /**< Number of EPG entries */
++    vlc_epg_t   **pp_epg;            /**< EPG entries */
++    int64_t     i_epg_time;          /** EPG timedate as epoch time */
++    const vlc_epg_t *p_epg_table;    /** running/selected program cur/next EPG table */
++
++    int         i_slaves;            /**< Number of slaves */
++    input_item_slave_t **pp_slaves;  /**< Slave entries that will be loaded by
++                                          the input_thread */
++
++    vlc_event_manager_t event_manager;
++
++    vlc_mutex_t lock;                 /**< Lock for the item */
++
++    uint8_t     i_type;              /**< Type (file, disc, ... see input_item_type_e) */
++    bool        b_net;               /**< Net: always true for TYPE_STREAM, it
++                                          depends for others types */
++    bool        b_error_when_reading;/**< Error When Reading */
++
++    int         i_preparse_depth;    /**< How many level of sub items can be preparsed:
++                                          -1: recursive, 0: none, >0: n levels */
++
++    bool        b_preparse_interact; /**< Force interaction with the user when
++                                          preparsing.*/
++};
++
++enum input_item_type_e
++{
++    ITEM_TYPE_UNKNOWN,
++    ITEM_TYPE_FILE,
++    ITEM_TYPE_DIRECTORY,
++    ITEM_TYPE_DISC,
++    ITEM_TYPE_CARD,
++    ITEM_TYPE_STREAM,
++    ITEM_TYPE_PLAYLIST,
++    ITEM_TYPE_NODE,
++
++    /* This one is not a real type but the number of input_item types. */
++    ITEM_TYPE_NUMBER
++};
++
++enum input_item_net_type
++{
++    ITEM_NET_UNKNOWN,
++    ITEM_NET,
++    ITEM_LOCAL
++};
++
++enum slave_type
++{
++    SLAVE_TYPE_SPU,
++    SLAVE_TYPE_AUDIO,
++};
++
++enum slave_priority
++{
++    SLAVE_PRIORITY_MATCH_NONE = 1,
++    SLAVE_PRIORITY_MATCH_RIGHT,
++    SLAVE_PRIORITY_MATCH_LEFT,
++    SLAVE_PRIORITY_MATCH_ALL,
++    SLAVE_PRIORITY_USER
++};
++
++/* Extensions must be in alphabetical order */
++#define MASTER_EXTENSIONS \
++    "asf", "avi", "divx", \
++    "f4v", "flv", "m1v", \
++    "m2v", "m4v", "mkv", \
++    "mov", "mp2", "mp2v", \
++    "mp4", "mp4v", "mpe", \
++    "mpeg", "mpeg1", "mpeg2", \
++    "mpeg4", "mpg", "mpv2", \
++    "mxf", "ogv", "ogx", \
++    "ps", "vro","webm", \
++    "wmv", "wtv"
++
++#define SLAVE_SPU_EXTENSIONS \
++    "aqt", "ass",  "cdg", \
++    "dks", "idx", "jss", \
++    "mpl2", "mpsub", "pjs", \
++    "psb", "rt", "sami", "sbv", \
++    "scc", "smi", "srt", \
++    "ssa",  "stl", "sub", \
++    "ttml", "tt", "usf", \
++    "vtt", "webvtt"
++
++#define SLAVE_AUDIO_EXTENSIONS \
++    "aac", "ac3", "dts", \
++    "dtshd", "eac3", "flac", \
++    "m4a", "mp3", "pcm" \
++
++struct input_item_slave
++{
++    enum slave_type     i_type;     /**< Slave type (spu, audio) */
++    enum slave_priority i_priority; /**< Slave priority */
++    bool                b_forced;   /**< Slave should be selected */
++    char                psz_uri[];  /**< Slave mrl */
++};
++
++struct input_item_node_t
++{
++    input_item_t *         p_item;
++    int                    i_children;
++    input_item_node_t      **pp_children;
++};
++
++VLC_API void input_item_CopyOptions( input_item_t *p_child, input_item_t *p_parent );
++VLC_API void input_item_SetName( input_item_t *p_item, const char *psz_name );
++
++/**
++ * Start adding multiple subitems.
++ *
++ * Create a root node to hold a tree of subitems for given item
++ */
++VLC_API input_item_node_t * input_item_node_Create( input_item_t *p_input ) VLC_USED;
++
++/**
++ * Add a new child node to this parent node that will point to this subitem.
++ */
++VLC_API input_item_node_t * input_item_node_AppendItem( input_item_node_t *p_node, input_item_t *p_item );
++
++/**
++ * Add an already created node to children of this parent node.
++ */
++VLC_API void input_item_node_AppendNode( input_item_node_t *p_parent, input_item_node_t *p_child );
++
++/**
++ * Remove a node from its parent.
++ */
++void input_item_node_RemoveNode( input_item_node_t *parent,
++                                 input_item_node_t *child );
++
++/**
++ * Delete a node created with input_item_node_Create() and all its children.
++ */
++VLC_API void input_item_node_Delete( input_item_node_t *p_node );
++
++/**
++ * Option flags
++ */
++enum input_item_option_e
++{
++    /* Allow VLC to trust the given option.
++     * By default options are untrusted */
++    VLC_INPUT_OPTION_TRUSTED = 0x2,
++
++    /* Add the option, unless the same option
++     * is already present. */
++    VLC_INPUT_OPTION_UNIQUE  = 0x100,
++};
++
++/**
++ * This function allows to add an option to an existing input_item_t.
++ */
++VLC_API int input_item_AddOption(input_item_t *, const char *, unsigned i_flags );
++/**
++ * This function add several options to an existing input_item_t.
++ */
++VLC_API int input_item_AddOptions(input_item_t *, int i_options,
++                                  const char *const *ppsz_options,
++                                  unsigned i_flags );
++VLC_API int input_item_AddOpaque(input_item_t *, const char *, void *);
++
++void input_item_ApplyOptions(vlc_object_t *, input_item_t *);
++
++VLC_API bool input_item_slave_GetType(const char *, enum slave_type *);
++
++VLC_API input_item_slave_t *input_item_slave_New(const char *, enum slave_type,
++                                               enum slave_priority);
++#define input_item_slave_Delete(p_slave) free(p_slave)
++
++/**
++ * This function allows adding a slave to an existing input item.
++ * The slave is owned by the input item after this call.
++ */
++VLC_API int input_item_AddSlave(input_item_t *, input_item_slave_t *);
++
++/* */
++VLC_API bool input_item_HasErrorWhenReading( input_item_t * );
++VLC_API void input_item_SetMeta( input_item_t *, vlc_meta_type_t meta_type, const char *psz_val );
++VLC_API bool input_item_MetaMatch( input_item_t *p_i, vlc_meta_type_t meta_type, const char *psz );
++VLC_API char * input_item_GetMeta( input_item_t *p_i, vlc_meta_type_t meta_type ) VLC_USED;
++VLC_API char * input_item_GetName( input_item_t * p_i ) VLC_USED;
++VLC_API char * input_item_GetTitleFbName( input_item_t * p_i ) VLC_USED;
++VLC_API char * input_item_GetURI( input_item_t * p_i ) VLC_USED;
++VLC_API char * input_item_GetNowPlayingFb( input_item_t *p_item ) VLC_USED;
++VLC_API void input_item_SetURI( input_item_t * p_i, const char *psz_uri );
++VLC_API mtime_t input_item_GetDuration( input_item_t * p_i );
++VLC_API void input_item_SetDuration( input_item_t * p_i, mtime_t i_duration );
++VLC_API bool input_item_IsPreparsed( input_item_t *p_i );
++VLC_API bool input_item_IsArtFetched( input_item_t *p_i );
++
++#define INPUT_META( name ) \
++static inline \
++void input_item_Set ## name (input_item_t *p_input, const char *val) \
++{ \
++    input_item_SetMeta (p_input, vlc_meta_ ## name, val); \
++} \
++static inline \
++char *input_item_Get ## name (input_item_t *p_input) \
++{ \
++    return input_item_GetMeta (p_input, vlc_meta_ ## name); \
++}
++
++INPUT_META(Title)
++INPUT_META(Artist)
++INPUT_META(AlbumArtist)
++INPUT_META(Genre)
++INPUT_META(Copyright)
++INPUT_META(Album)
++INPUT_META(TrackNumber)
++INPUT_META(Description)
++INPUT_META(Rating)
++INPUT_META(Date)
++INPUT_META(Setting)
++INPUT_META(URL)
++INPUT_META(Language)
++INPUT_META(NowPlaying)
++INPUT_META(ESNowPlaying)
++INPUT_META(Publisher)
++INPUT_META(EncodedBy)
++INPUT_META(ArtworkURL)
++INPUT_META(TrackID)
++INPUT_META(TrackTotal)
++INPUT_META(Director)
++INPUT_META(Season)
++INPUT_META(Episode)
++INPUT_META(ShowName)
++INPUT_META(Actors)
++INPUT_META(DiscNumber)
++
++#define input_item_SetTrackNum input_item_SetTrackNumber
++#define input_item_GetTrackNum input_item_GetTrackNumber
++#define input_item_SetArtURL   input_item_SetArtworkURL
++#define input_item_GetArtURL   input_item_GetArtworkURL
++
++VLC_API char * input_item_GetInfo( input_item_t *p_i, const char *psz_cat,const char *psz_name ) VLC_USED;
++VLC_API int input_item_AddInfo( input_item_t *p_i, const char *psz_cat, const char *psz_name, const char *psz_format, ... ) VLC_FORMAT( 4, 5 );
++VLC_API int input_item_DelInfo( input_item_t *p_i, const char *psz_cat, const char *psz_name );
++VLC_API void input_item_ReplaceInfos( input_item_t *, info_category_t * );
++VLC_API void input_item_MergeInfos( input_item_t *, info_category_t * );
++
++/**
++ * This function creates a new input_item_t with the provided information.
++ *
++ * XXX You may also use input_item_New, as they need less arguments.
++ */
++VLC_API input_item_t * input_item_NewExt( const char *psz_uri,
++                                          const char *psz_name,
++                                          mtime_t i_duration, int i_type,
++                                          enum input_item_net_type i_net ) VLC_USED;
++
++#define input_item_New( psz_uri, psz_name ) \
++    input_item_NewExt( psz_uri, psz_name, -1, ITEM_TYPE_UNKNOWN, ITEM_NET_UNKNOWN )
++
++#define input_item_NewCard( psz_uri, psz_name ) \
++    input_item_NewExt( psz_uri, psz_name, -1, ITEM_TYPE_CARD, ITEM_LOCAL )
++
++#define input_item_NewDisc( psz_uri, psz_name, i_duration ) \
++    input_item_NewExt( psz_uri, psz_name, i_duration, ITEM_TYPE_DISC, ITEM_LOCAL )
++
++#define input_item_NewStream( psz_uri, psz_name, i_duration ) \
++    input_item_NewExt( psz_uri, psz_name, i_duration, ITEM_TYPE_STREAM, ITEM_NET )
++
++#define input_item_NewDirectory( psz_uri, psz_name, i_net ) \
++    input_item_NewExt( psz_uri, psz_name, -1, ITEM_TYPE_DIRECTORY, i_net )
++
++#define input_item_NewFile( psz_uri, psz_name, i_duration, i_net ) \
++    input_item_NewExt( psz_uri, psz_name, i_duration, ITEM_TYPE_FILE, i_net )
++
++/**
++ * This function creates a new input_item_t as a copy of another.
++ */
++VLC_API input_item_t * input_item_Copy(input_item_t * ) VLC_USED;
++
++/** Holds an input item, i.e. creates a new reference. */
++VLC_API input_item_t *input_item_Hold(input_item_t *);
++
++/** Releases an input item, i.e. decrements its reference counter. */
++VLC_API void input_item_Release(input_item_t *);
++
++typedef enum input_item_meta_request_option_t
++{
++    META_REQUEST_OPTION_NONE          = 0x00,
++    META_REQUEST_OPTION_SCOPE_LOCAL   = 0x01,
++    META_REQUEST_OPTION_SCOPE_NETWORK = 0x02,
++    META_REQUEST_OPTION_SCOPE_ANY     = 0x03,
++    META_REQUEST_OPTION_DO_INTERACT   = 0x04
++} input_item_meta_request_option_t;
++
++/* status of the vlc_InputItemPreparseEnded event */
++enum input_item_preparse_status
++{
++    ITEM_PREPARSE_SKIPPED,
++    ITEM_PREPARSE_FAILED,
++    ITEM_PREPARSE_TIMEOUT,
++    ITEM_PREPARSE_DONE
++};
++
++VLC_API int libvlc_MetadataRequest( libvlc_int_t *, input_item_t *,
++                                    input_item_meta_request_option_t,
++                                    int, void * );
++VLC_API int libvlc_ArtRequest(libvlc_int_t *, input_item_t *,
++                              input_item_meta_request_option_t );
++VLC_API void libvlc_MetadataCancel( libvlc_int_t *, void * );
++
++/******************
++ * Input stats
++ ******************/
++struct input_stats_t
++{
++    vlc_mutex_t         lock;
++
++    /* Input */
++    int64_t i_read_packets;
++    int64_t i_read_bytes;
++    float f_input_bitrate;
++    float f_average_input_bitrate;
++
++    /* Demux */
++    int64_t i_demux_read_packets;
++    int64_t i_demux_read_bytes;
++    float f_demux_bitrate;
++    float f_average_demux_bitrate;
++    int64_t i_demux_corrupted;
++    int64_t i_demux_discontinuity;
++
++    /* Decoders */
++    int64_t i_decoded_audio;
++    int64_t i_decoded_video;
++
++    /* Vout */
++    int64_t i_displayed_pictures;
++    int64_t i_lost_pictures;
++
++    /* Sout */
++    int64_t i_sent_packets;
++    int64_t i_sent_bytes;
++    float f_send_bitrate;
++
++    /* Aout */
++    int64_t i_played_abuffers;
++    int64_t i_lost_abuffers;
++};
++
++/**
++ * Access pf_readdir helper struct
++ * \see vlc_readdir_helper_init()
++ * \see vlc_readdir_helper_additem()
++ * \see vlc_readdir_helper_finish()
++ */
++struct vlc_readdir_helper
++{
++    input_item_node_t *p_node;
++    void **pp_slaves;
++    size_t i_slaves;
++    void **pp_dirs;
++    size_t i_dirs;
++    int i_sub_autodetect_fuzzy;
++    bool b_show_hiddenfiles;
++    bool b_flatten;
++    char *psz_ignored_exts;
++};
++
++/**
++ * Init a vlc_readdir_helper struct
++ *
++ * \param p_rdh need to be cleaned with vlc_readdir_helper_finish()
++ * \param p_node node that will be used to add items
++ */
++VLC_API void vlc_readdir_helper_init(struct vlc_readdir_helper *p_rdh,
++                                     vlc_object_t *p_obj, input_item_node_t *p_node);
++#define vlc_readdir_helper_init(p_rdh, p_obj, p_node) \
++    vlc_readdir_helper_init(p_rdh, VLC_OBJECT(p_obj), p_node)
++
++/**
++ * Finish adding items to the node
++ *
++ * \param b_success if true, items of the node will be sorted.
++ */
++VLC_API void vlc_readdir_helper_finish(struct vlc_readdir_helper *p_rdh, bool b_success);
++
++/**
++ * Add a new input_item_t entry to the node of the vlc_readdir_helper struct.
++ *
++ * \param p_rdh previously inited vlc_readdir_helper struct
++ * \param psz_uri uri of the new item
++ * \param psz_flatpath flattened path of the new item. If not NULL, this
++ *        function will create an input item for each sub folders (separated
++ *        by '/') of psz_flatpath (so, this will un-flatten the folder
++ *        hierarchy). Either psz_flatpath or psz_filename must be valid.
++ * \param psz_filename file name of the new item. If NULL, the file part of path
++ *        will be used as a filename. Either psz_flatpath or psz_filename must
++ *        be valid.
++ * \param i_type see \ref input_item_type_e
++ * \param i_net see \ref input_item_net_type
++ */
++VLC_API int vlc_readdir_helper_additem(struct vlc_readdir_helper *p_rdh,
++                                       const char *psz_uri, const char *psz_flatpath,
++                                       const char *psz_filename,
++                                       int i_type, int i_net);
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_interface.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_interface.h
+new file mode 100644
+index 0000000..1bd325b
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_interface.h
+@@ -0,0 +1,332 @@
++/*****************************************************************************
++ * vlc_interface.h: interface access for other threads
++ * This library provides basic functions for threads to interact with user
++ * interface, such as message output.
++ *****************************************************************************
++ * Copyright (C) 1999, 2000 VLC authors and VideoLAN
++ * $Id: e271314c3120c270a0bef5189cfee21dd9e7b26b $
++ *
++ * Authors: Vincent Seguin <seguin@via.ecp.fr>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_INTF_H_
++#define VLC_INTF_H_
++
++# ifdef __cplusplus
++extern "C" {
++# endif
++
++typedef struct intf_dialog_args_t intf_dialog_args_t;
++
++/**
++ * \defgroup interface Interface
++ * VLC user interfaces
++ * @{
++ * \file
++ * VLC user interface modules
++ */
++
++typedef struct intf_sys_t intf_sys_t;
++
++/** Describe all interface-specific data of the interface thread */
++typedef struct intf_thread_t
++{
++    VLC_COMMON_MEMBERS
++
++    struct intf_thread_t *p_next; /** LibVLC interfaces book keeping */
++
++    /* Specific interfaces */
++    intf_sys_t *        p_sys;                          /** system interface */
++
++    /** Interface module */
++    module_t *   p_module;
++
++    /** Specific for dialogs providers */
++    void ( *pf_show_dialog ) ( struct intf_thread_t *, int, int,
++                               intf_dialog_args_t * );
++
++    config_chain_t *p_cfg;
++} intf_thread_t;
++
++/** \brief Arguments passed to a dialogs provider
++ *  This describes the arguments passed to the dialogs provider. They are
++ *  mainly used with INTF_DIALOG_FILE_GENERIC.
++ */
++struct intf_dialog_args_t
++{
++    intf_thread_t *p_intf;
++    char *psz_title;
++
++    char **psz_results;
++    int  i_results;
++
++    void (*pf_callback) ( intf_dialog_args_t * );
++    void *p_arg;
++
++    /* Specifically for INTF_DIALOG_FILE_GENERIC */
++    char *psz_extensions;
++    bool b_save;
++    bool b_multiple;
++
++    /* Specific to INTF_DIALOG_INTERACTION */
++    struct interaction_dialog_t *p_dialog;
++};
++
++VLC_API int intf_Create( playlist_t *, const char * );
++
++VLC_API void libvlc_Quit( libvlc_int_t * );
++
++static inline playlist_t *pl_Get( struct intf_thread_t *intf )
++{
++    return (playlist_t *)(intf->obj.parent);
++}
++
++/**
++ * Retrieves the current input thread from the playlist.
++ * @note The returned object must be released with vlc_object_release().
++ */
++#define pl_CurrentInput(intf) (playlist_CurrentInput(pl_Get(intf)))
++
++/**
++ * @ingroup messages
++ * @{
++ */
++
++VLC_API void vlc_LogSet(libvlc_int_t *, vlc_log_cb cb, void *data);
++
++/*@}*/
++
++/* Interface dialog ids for dialog providers */
++typedef enum vlc_intf_dialog {
++    INTF_DIALOG_FILE_SIMPLE = 1,
++    INTF_DIALOG_FILE,
++    INTF_DIALOG_DISC,
++    INTF_DIALOG_NET,
++    INTF_DIALOG_CAPTURE,
++    INTF_DIALOG_SAT,
++    INTF_DIALOG_DIRECTORY,
++
++    INTF_DIALOG_STREAMWIZARD,
++    INTF_DIALOG_WIZARD,
++
++    INTF_DIALOG_PLAYLIST,
++    INTF_DIALOG_MESSAGES,
++    INTF_DIALOG_FILEINFO,
++    INTF_DIALOG_PREFS,
++    INTF_DIALOG_BOOKMARKS,
++    INTF_DIALOG_EXTENDED,
++    INTF_DIALOG_RENDERER,
++
++    INTF_DIALOG_POPUPMENU = 20,
++    INTF_DIALOG_AUDIOPOPUPMENU,
++    INTF_DIALOG_VIDEOPOPUPMENU,
++    INTF_DIALOG_MISCPOPUPMENU,
++
++    INTF_DIALOG_FILE_GENERIC = 30,
++    INTF_DIALOG_INTERACTION = 50,
++    INTF_DIALOG_SENDKEY = 51,
++
++    INTF_DIALOG_UPDATEVLC = 90,
++    INTF_DIALOG_VLM,
++
++    INTF_DIALOG_EXIT = 99
++} vlc_intf_dialog;
++
++/* Useful text messages shared by interfaces */
++#define INTF_ABOUT_MSG LICENSE_MSG
++
++#define EXTENSIONS_AUDIO_CSV "3ga", "669", "a52", "aac", "ac3", "adt", "adts", "aif", "aifc", "aiff", \
++                         "amb", "amr", "aob", "ape", "au", "awb", "caf", "dts", "flac", "it", "kar", \
++                         "m4a", "m4b", "m4p", "m5p", "mka", "mlp", "mod", "mpa", "mp1", "mp2", "mp3", "mpc", "mpga", "mus", \
++                         "oga", "ogg", "oma", "opus", "qcp", "ra", "rmi", "s3m", "sid", "spx", "tak", "thd", "tta", \
++                         "voc", "vqf", "w64", "wav", "wma", "wv", "xa", "xm"
++
++#define EXTENSIONS_VIDEO_CSV "3g2", "3gp", "3gp2", "3gpp", "amv", "asf", "avi", "bik", "crf", "divx", "drc", "dv", "dvr-ms" \
++                             "evo", "f4v", "flv", "gvi", "gxf", "iso", \
++                             "m1v", "m2v", "m2t", "m2ts", "m4v", "mkv", "mov",\
++                             "mp2", "mp2v", "mp4", "mp4v", "mpe", "mpeg", "mpeg1", \
++                             "mpeg2", "mpeg4", "mpg", "mpv2", "mts", "mtv", "mxf", "mxg", "nsv", "nuv", \
++                             "ogg", "ogm", "ogv", "ogx", "ps", \
++                             "rec", "rm", "rmvb", "rpl", "thp", "tod", "ts", "tts", "txd", "vob", "vro", \
++                             "webm", "wm", "wmv", "wtv", "xesc"
++
++#define EXTENSIONS_AUDIO \
++    "*.3ga;" \
++    "*.669;" \
++    "*.a52;" \
++    "*.aac;" \
++    "*.ac3;" \
++    "*.adt;" \
++    "*.adts;" \
++    "*.aif;"\
++    "*.aifc;"\
++    "*.aiff;"\
++    "*.amb;" \
++    "*.amr;" \
++    "*.aob;" \
++    "*.ape;" \
++    "*.au;" \
++    "*.awb;" \
++    "*.caf;" \
++    "*.dts;" \
++    "*.flac;"\
++    "*.it;"  \
++    "*.kar;" \
++    "*.m4a;" \
++    "*.m4b;" \
++    "*.m4p;" \
++    "*.m5p;" \
++    "*.mid;" \
++    "*.mka;" \
++    "*.mlp;" \
++    "*.mod;" \
++    "*.mpa;" \
++    "*.mp1;" \
++    "*.mp2;" \
++    "*.mp3;" \
++    "*.mpc;" \
++    "*.mpga;" \
++    "*.mus;" \
++    "*.oga;" \
++    "*.ogg;" \
++    "*.oma;" \
++    "*.opus;" \
++    "*.qcp;" \
++    "*.ra;" \
++    "*.rmi;" \
++    "*.s3m;" \
++    "*.sid;" \
++    "*.spx;" \
++    "*.tak;" \
++    "*.thd;" \
++    "*.tta;" \
++    "*.voc;" \
++    "*.vqf;" \
++    "*.w64;" \
++    "*.wav;" \
++    "*.wma;" \
++    "*.wv;"  \
++    "*.xa;"  \
++    "*.xm"
++
++#define EXTENSIONS_VIDEO "*.3g2;*.3gp;*.3gp2;*.3gpp;*.amv;*.asf;*.avi;*.bik;*.bin;*.crf;*.divx;*.drc;*.dv;*.dvr-ms;*.evo;*.f4v;*.flv;*.gvi;*.gxf;*.iso;*.m1v;*.m2v;" \
++                         "*.m2t;*.m2ts;*.m4v;*.mkv;*.mov;*.mp2;*.mp2v;*.mp4;*.mp4v;*.mpe;*.mpeg;*.mpeg1;" \
++                         "*.mpeg2;*.mpeg4;*.mpg;*.mpv2;*.mts;*.mtv;*.mxf;*.mxg;*.nsv;*.nuv;" \
++                         "*.ogg;*.ogm;*.ogv;*.ogx;*.ps;" \
++                         "*.rec;*.rm;*.rmvb;*.rpl;*.thp;*.tod;*.tp;*.ts;*.tts;*.txd;*.vob;*.vro;*.webm;*.wm;*.wmv;*.wtv;*.xesc"
++
++#define EXTENSIONS_PLAYLIST "*.asx;*.b4s;*.cue;*.ifo;*.m3u;*.m3u8;*.pls;*.ram;*.rar;*.sdp;*.vlc;*.xspf;*.wax;*.wvx;*.zip;*.conf"
++
++#define EXTENSIONS_MEDIA EXTENSIONS_VIDEO ";" EXTENSIONS_AUDIO ";" \
++                          EXTENSIONS_PLAYLIST
++
++#define EXTENSIONS_SUBTITLE "*.cdg;*.idx;*.srt;" \
++                            "*.sub;*.utf;*.ass;" \
++                            "*.ssa;*.aqt;" \
++                            "*.jss;*.psb;" \
++                            "*.rt;*.sami;*.smi;*.txt;" \
++                            "*.smil;*.stl;*.usf;" \
++                            "*.dks;*.pjs;*.mpl2;*.mks;" \
++                            "*.vtt;*.tt;*.ttml;*.dfxp;" \
++                            "*.scc"
++
++/** \defgroup interaction Interaction
++ * \ingroup interface
++ * Interaction between user and modules
++ * @{
++ */
++
++/**
++ * This structure describes a piece of interaction with the user
++ */
++typedef struct interaction_dialog_t
++{
++    int             i_type;             ///< Type identifier
++    char           *psz_title;          ///< Title
++    char           *psz_description;    ///< Descriptor string
++    char           *psz_default_button;  ///< default button title (~OK)
++    char           *psz_alternate_button;///< alternate button title (~NO)
++    /// other button title (optional,~Cancel)
++    char           *psz_other_button;
++
++    char           *psz_returned[1];    ///< returned responses from the user
++
++    vlc_value_t     val;                ///< value coming from core for dialogue
++    int             i_timeToGo;         ///< time (in sec) until shown progress is finished
++    bool      b_cancelled;        ///< was the dialogue cancelled ?
++
++    void *          p_private;          ///< Private interface data
++
++    int             i_status;           ///< Dialog status;
++    int             i_action;           ///< Action to perform;
++    int             i_flags;            ///< Misc flags
++    int             i_return;           ///< Return status
++
++    vlc_object_t   *p_parent;           ///< The vlc object that asked
++                                        //for interaction
++    intf_thread_t  *p_interface;
++    vlc_mutex_t    *p_lock;
++} interaction_dialog_t;
++
++/**
++ * Possible flags . Dialog types
++ */
++#define DIALOG_GOT_ANSWER           0x01
++#define DIALOG_YES_NO_CANCEL        0x02
++#define DIALOG_LOGIN_PW_OK_CANCEL   0x04
++#define DIALOG_PSZ_INPUT_OK_CANCEL  0x08
++#define DIALOG_BLOCKING_ERROR       0x10
++#define DIALOG_NONBLOCKING_ERROR    0x20
++#define DIALOG_USER_PROGRESS        0x80
++#define DIALOG_INTF_PROGRESS        0x100
++
++/** Possible return codes */
++enum
++{
++    DIALOG_OK_YES,
++    DIALOG_NO,
++    DIALOG_CANCELLED
++};
++
++/** Possible status  */
++enum
++{
++    ANSWERED_DIALOG,            ///< Got "answer"
++    DESTROYED_DIALOG,           ///< Interface has destroyed it
++};
++
++/** Possible actions */
++enum
++{
++    INTERACT_NEW,
++    INTERACT_UPDATE,
++    INTERACT_HIDE,
++    INTERACT_DESTROY
++};
++
++#define intf_UserStringInput( a, b, c, d ) (VLC_OBJECT(a),b,c,d, VLC_EGENERIC)
++#define interaction_Register( t ) (t, VLC_EGENERIC)
++#define interaction_Unregister( t ) (t, VLC_EGENERIC)
++
++
++/** @} */
++/** @} */
++
++# ifdef __cplusplus
++}
++# endif
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_interrupt.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_interrupt.h
+new file mode 100644
+index 0000000..b98bbe2
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_interrupt.h
+@@ -0,0 +1,238 @@
++/*****************************************************************************
++ * vlc_interrupt.h:
++ *****************************************************************************
++ * Copyright (C) 2015 Remlab T:mi
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++/**
++ * @file
++ * This file declares interruptible sleep functions.
++ */
++
++#ifndef VLC_INTERRUPT_H
++# define VLC_INTERRUPT_H 1
++# include <vlc_threads.h>
++# ifndef _WIN32
++#  include <sys/socket.h> /* socklen_t */
++# else
++#  include <ws2tcpip.h>
++# endif
++
++struct pollfd;
++struct iovec;
++struct sockaddr;
++struct msghdr;
++
++/**
++ * @defgroup interrupt Interruptible sleep
++ * @{
++ * @defgroup interrupt_sleep Interruptible sleep functions
++ * @{
++ */
++
++/**
++ * Interruptible variant of vlc_sem_wait().
++ *
++ * Waits on a semaphore like vlc_sem_wait(). If the calling thread has an
++ * interruption context (as set by vlc_interrupt_set()), and another thread
++ * invokes vlc_interrupt_raise() on that context, the semaphore is incremented.
++ *
++ * @warning The calling thread should be the only thread ever to wait on the
++ * specified semaphore. Otherwise, interruptions may not be delivered
++ * accurately (the wrong thread may be woken up).
++ *
++ * @note This function is (always) a cancellation point.
++ *
++ * @return EINTR if the semaphore was incremented due to an interruption,
++ * otherwise zero.
++ */
++VLC_API int vlc_sem_wait_i11e(vlc_sem_t *);
++
++/**
++ * Interruptible variant of mwait().
++ *
++ * Waits for a specified timestamp or, if the calling thread has an
++ * interruption context, an interruption.
++ *
++ * @return EINTR if an interruption occurred, otherwise 0 once the timestamp is
++ * reached.
++ */
++VLC_API int vlc_mwait_i11e(mtime_t);
++
++/**
++ * Interruptible variant of msleep().
++ *
++ * Waits for a specified timeout duration or, if the calling thread has an
++ * interruption context, an interruption.
++ *
++ * @param delay timeout value (in microseconds)
++ *
++ * @return EINTR if an interruption occurred, otherwise 0 once the timeout
++ * expired.
++ */
++static inline int vlc_msleep_i11e(mtime_t delay)
++{
++    return vlc_mwait_i11e(mdate() + delay);
++}
++
++/**
++ * Interruptible variant of poll().
++ *
++ * Waits for file descriptors I/O events, a timeout, a signal or a VLC I/O
++ * interruption. Except for VLC I/O interruptions, this function behaves
++ * just like the standard poll().
++ *
++ * @note This function is always a cancellation point (as poll()).
++ * @see poll() manual page
++ *
++ * @param fds table of events to wait for
++ * @param nfds number of entries in the table
++ * @param timeout time to wait in milliseconds or -1 for infinite
++ *
++ * @return A strictly positive result represent the number of pending events.
++ * 0 is returned if the time-out is reached without events.
++ * -1 is returned if a VLC I/O interrupt occurs (and errno is set to EINTR)
++ * or if an error occurs.
++ */
++VLC_API int vlc_poll_i11e(struct pollfd *, unsigned, int);
++
++VLC_API ssize_t vlc_readv_i11e(int fd, struct iovec *, int);
++VLC_API ssize_t vlc_writev_i11e(int fd, const struct iovec *, int);
++VLC_API ssize_t vlc_read_i11e(int fd, void *, size_t);
++VLC_API ssize_t vlc_write_i11e(int fd, const void *, size_t);
++
++VLC_API ssize_t vlc_recvmsg_i11e(int fd, struct msghdr *, int flags);
++VLC_API ssize_t vlc_sendmsg_i11e(int fd, const struct msghdr *, int flags);
++
++VLC_API ssize_t vlc_recvfrom_i11e(int fd, void *, size_t, int flags,
++                                struct sockaddr *, socklen_t *);
++VLC_API ssize_t vlc_sendto_i11e(int fd, const void *, size_t, int flags,
++                              const struct sockaddr *, socklen_t);
++
++static inline ssize_t vlc_recv_i11e(int fd, void *buf, size_t len, int flags)
++{
++    return vlc_recvfrom_i11e(fd, buf, len, flags, NULL, NULL);
++}
++
++static inline
++ssize_t vlc_send_i11e(int fd, const void *buf, size_t len, int flags)
++{
++    return vlc_sendto_i11e(fd, buf, len, flags, NULL, 0);
++}
++
++VLC_API int vlc_accept_i11e(int fd, struct sockaddr *, socklen_t *, bool);
++
++/**
++ * Registers a custom interrupt handler.
++ *
++ * Registers a custom callback as interrupt handler for the calling thread.
++ * The callback must be unregistered with vlc_interrupt_unregister() before
++ * thread termination and before any further callback registration.
++ *
++ * If the calling thread has no interruption context, this function has no
++ * effects.
++ */
++VLC_API void vlc_interrupt_register(void (*cb)(void *), void *opaque);
++
++VLC_API int vlc_interrupt_unregister(void);
++
++/**
++ * @}
++ * @defgroup interrupt_context Interrupt context signaling and manipulation
++ * @{
++ */
++typedef struct vlc_interrupt vlc_interrupt_t;
++
++/**
++ * Creates an interruption context.
++ */
++VLC_API vlc_interrupt_t *vlc_interrupt_create(void) VLC_USED;
++
++/**
++ * Destroys an interrupt context.
++ */
++VLC_API void vlc_interrupt_destroy(vlc_interrupt_t *);
++
++/**
++ * Sets the interruption context for the calling thread.
++ * @param newctx the interruption context to attach or NULL for none
++ * @return the previous interruption context or NULL if none
++ *
++ * @note This function is not a cancellation point.
++ * @warning A context can be attached to no more than one thread at a time.
++ */
++VLC_API vlc_interrupt_t *vlc_interrupt_set(vlc_interrupt_t *);
++
++/**
++ * Raises an interruption through a specified context.
++ *
++ * This is used to asynchronously wake a thread up while it is waiting on some
++ * other events (typically I/O events).
++ *
++ * @note This function is thread-safe.
++ * @note This function is not a cancellation point.
++ */
++VLC_API void vlc_interrupt_raise(vlc_interrupt_t *);
++
++/**
++ * Marks the interruption context as "killed".
++ *
++ * This is not reversible.
++ */
++VLC_API void vlc_interrupt_kill(vlc_interrupt_t *);
++
++/**
++ * Checks if the interruption context was "killed".
++ *
++ * Indicates whether the interruption context of the calling thread (if any)
++ * was killed with vlc_interrupt_kill().
++ */
++VLC_API bool vlc_killed(void) VLC_USED;
++
++/**
++ * Enables forwarding of interruption.
++ *
++ * If an interruption is raised through the context of the calling thread,
++ * it will be forwarded to the specified other context. This is used to cross
++ * thread boundaries.
++ *
++ * If the calling thread has no interrupt context, this function does nothing.
++ *
++ * @param to context to forward to
++ */
++VLC_API void vlc_interrupt_forward_start(vlc_interrupt_t *to,
++                                         void *data[2]);
++
++/**
++ * Undoes vlc_interrupt_forward_start().
++ *
++ * This function must be called after each successful call to
++ * vlc_interrupt_forward_start() before any other interruptible call is made
++ * in the same thread.
++ *
++ * If an interruption was raised against the context of the calling thread
++ * (after the previous call to vlc_interrupt_forward_start()), it is dequeued.
++ *
++ * If the calling thread has no interrupt context, this function does nothing
++ * and returns zero.
++ *
++ * @return 0 if no interrupt was raised, EINTR if an interrupt was raised
++ */
++VLC_API int vlc_interrupt_forward_stop(void *const data[2]);
++
++/** @} @} */
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_keystore.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_keystore.h
+new file mode 100644
+index 0000000..5588711
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_keystore.h
+@@ -0,0 +1,317 @@
++/*****************************************************************************
++ * vlc_keystore.h:
++ *****************************************************************************
++ * Copyright (C) 2015-2016 VLC authors and VideoLAN
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_KEYSTORE_H
++# define VLC_KEYSTORE_H
++
++#include <vlc_common.h>
++
++typedef struct vlc_keystore vlc_keystore;
++typedef struct vlc_keystore_entry vlc_keystore_entry;
++typedef struct vlc_credential vlc_credential;
++
++/* Called from src/libvlc.c */
++int
++libvlc_InternalKeystoreInit(libvlc_int_t *p_libvlc);
++
++/* Called from src/libvlc.c */
++void
++libvlc_InternalKeystoreClean(libvlc_int_t *p_libvlc);
++
++/**
++ * @defgroup keystore Keystore and credential API
++ * @{
++ * @file
++ * This file declares vlc keystore API
++ * @defgroup keystore_public Keystore public API
++ * @{
++ */
++
++/**
++ * List of keys that can be stored via the keystore API
++ */
++enum vlc_keystore_key {
++    KEY_PROTOCOL,
++    KEY_USER,
++    KEY_SERVER,
++    KEY_PATH,
++    KEY_PORT,
++    KEY_REALM,
++    KEY_AUTHTYPE,
++    KEY_MAX,
++};
++#define VLC_KEYSTORE_VALUES_INIT(ppsz_values) memset(ppsz_values, 0, sizeof(const char *) * KEY_MAX)
++
++/**
++ * Keystore entry returned by vlc_keystore_find()
++ */
++struct vlc_keystore_entry
++{
++    /** Set of key/values. Values can be NULL */
++    char *              ppsz_values[KEY_MAX];
++    /** Secret password */
++    uint8_t *           p_secret;
++    /** Length of the secret */
++    size_t              i_secret_len;
++};
++
++/**
++ * Create a keystore object
++ *
++ * A keystore object is persistent across runtime. It is saved on local
++ * filesystem via a vlc keystore module (KWallet, SecretService, Apple Keychain
++ * Service ...).
++ *
++ * @note to be released with vlc_keystore_release()
++ *
++ * @param p_parent the parent object used to create the keystore object
++ *
++ * @return a pointer to the keystore object, or NULL in case of error
++ */
++VLC_API vlc_keystore *
++vlc_keystore_create(vlc_object_t *p_parent);
++#define vlc_keystore_create(x) vlc_keystore_create(VLC_OBJECT(x))
++
++/**
++ * Release a keystore object
++ */
++VLC_API void
++vlc_keystore_release(vlc_keystore *p_keystore);
++
++
++/**
++ * Store a secret associated with a set of key/values
++ *
++ * @param ppsz_values set of key/values, see vlc_keystore_key.
++ *        ppsz_values[KEY_PROTOCOL] and  ppsz_values[KEY_SERVER] must be valid
++ *        strings
++ * @param p_secret binary secret or string password
++ * @param i_secret_len length of p_secret. If it's less than 0, then p_secret
++ * is assumed to be a '\0' terminated string
++ * @param psz_label user friendly label
++ *
++ * @return VLC_SUCCESS on success, or VLC_EGENERIC on error
++ */
++VLC_API int
++vlc_keystore_store(vlc_keystore *p_keystore,
++                   const char *const ppsz_values[KEY_MAX],
++                   const uint8_t* p_secret, ssize_t i_secret_len,
++                   const char *psz_label);
++
++/**
++ * Find all entries that match a set of key/values
++ *
++ * @param ppsz_values set of key/values, see vlc_keystore_key, any values can
++ * be NULL
++ * @param pp_entries list of found entries. To be released with
++ * vlc_keystore_release_entries()
++ *
++ * @return the number of entries
++ */
++VLC_API unsigned int
++vlc_keystore_find(vlc_keystore *p_keystore,
++                  const char *const ppsz_values[KEY_MAX],
++                  vlc_keystore_entry **pp_entries) VLC_USED;
++
++/**
++ * Remove all entries that match a set of key/values
++ *
++ * @note only entries added by VLC can be removed
++ *
++ * @param ppsz_values set of key/values, see vlc_keystore_key, any values can
++ * be NULL
++ *
++ * @return the number of entries
++ */
++VLC_API unsigned int
++vlc_keystore_remove(vlc_keystore *p_keystore,
++                    const char *const ppsz_values[KEY_MAX]);
++
++/**
++ * Release the list of entries returned by vlc_keystore_find()
++ */
++VLC_API void
++vlc_keystore_release_entries(vlc_keystore_entry *p_entries, unsigned int i_count);
++
++/**
++ * @}
++ * @defgroup credential Credential API
++ * @{
++ */
++
++/**
++ * @note init with vlc_credential_init()
++ */
++struct vlc_credential
++{
++    /** url to store or to search */
++    const vlc_url_t *p_url;
++    /** http realm or smb domain to search, can be overridden after a call to
++     * vlc_credential_get() */
++    const char *psz_realm;
++    /** http authtype to search, can be overridden after a call to
++     * vlc_credential_get() */
++    const char *psz_authtype;
++    /** valid only if vlc_credential_get() returned true */
++    const char *psz_username;
++    /** valid only if vlc_credential_get() returned true */
++    const char *psz_password;
++
++    /* internal */
++    enum {
++        GET_FROM_URL,
++        GET_FROM_OPTION,
++        GET_FROM_MEMORY_KEYSTORE,
++        GET_FROM_KEYSTORE,
++        GET_FROM_DIALOG,
++    } i_get_order;
++
++    vlc_keystore *p_keystore;
++    vlc_keystore_entry *p_entries;
++    unsigned int i_entries_count;
++
++    char *psz_split_domain;
++    char *psz_var_username;
++    char *psz_var_password;
++
++    char *psz_dialog_username;
++    char *psz_dialog_password;
++    bool b_from_keystore;
++    bool b_store;
++};
++
++/**
++ * Init a credential struct
++ *
++ * @note to be cleaned with vlc_credential_clean()
++ *
++ * @param psz_url url to store or to search
++ */
++VLC_API void
++vlc_credential_init(vlc_credential *p_credential, const vlc_url_t *p_url);
++
++/**
++ * Clean a credential struct
++ */
++VLC_API void
++vlc_credential_clean(vlc_credential *p_credential);
++
++/**
++ * Get a username/password couple
++ *
++ * This will search for a credential using url, VLC options, the vlc_keystore
++ * or by asking the user via dialog_Login(). This function can be called
++ * indefinitely, it will first return the user/password from the url (if any),
++ * then from VLC options (if any), then from the keystore (if any), and finally
++ * from the dialog (if any). This function will return true as long as the user
++ * fill the dialog texts and will return false when the user cancel it.
++ *
++ * @param p_parent the parent object (for var, keystore and dialog)
++ * @param psz_option_username VLC option name for the username
++ * @param psz_option_password VLC option name for the password
++ * @param psz_dialog_title dialog title, if NULL, this function won't use the
++ * keystore or the dialog
++ * @param psz_dialog_fmt dialog text using format
++ *
++ * @return true if vlc_credential.psz_username and vlc_credential.psz_password
++ * are valid, otherwise this function should not be called again.
++ */
++
++VLC_API bool
++vlc_credential_get(vlc_credential *p_credential, vlc_object_t *p_parent,
++                   const char *psz_option_username,
++                   const char *psz_option_password,
++                   const char *psz_dialog_title,
++                   const char *psz_dialog_fmt, ...) VLC_FORMAT(6, 7);
++#define vlc_credential_get(a, b, c, d, e, f, ...) \
++    vlc_credential_get(a, VLC_OBJECT(b), c, d, e, f, ##__VA_ARGS__)
++
++/**
++ * Store the last dialog credential returned by vlc_credential_get()
++ *
++ * This function will store the credential in the memory keystore if it's
++ * valid, or will store in the permanent one if it comes from the dialog and if
++ * the user asked for it.
++ *
++ * @return true if the credential was stored or comes from the keystore, false
++ * otherwise
++ */
++VLC_API bool
++vlc_credential_store(vlc_credential *p_credential, vlc_object_t *p_parent);
++#define vlc_credential_store(a, b) \
++    vlc_credential_store(a, VLC_OBJECT(b))
++
++/**
++ * @}
++ * @defgroup keystore_implementation Implemented by keystore modules
++ * @{
++ */
++
++#define VLC_KEYSTORE_NAME "libVLC"
++
++static inline int
++vlc_keystore_entry_set_secret(vlc_keystore_entry *p_entry,
++                              const uint8_t *p_secret, size_t i_secret_len)
++{
++    p_entry->p_secret = (uint8_t*) malloc(i_secret_len);
++    if (!p_entry->p_secret)
++        return VLC_EGENERIC;
++    memcpy(p_entry->p_secret, p_secret, i_secret_len);
++    p_entry->i_secret_len = i_secret_len;
++    return VLC_SUCCESS;
++}
++
++static inline void
++vlc_keystore_release_entry(vlc_keystore_entry *p_entry)
++{
++    for (unsigned int j = 0; j < KEY_MAX; ++j)
++    {
++        free(p_entry->ppsz_values[j]);
++        p_entry->ppsz_values[j] = NULL;
++    }
++    free(p_entry->p_secret);
++    p_entry->p_secret = NULL;
++}
++
++typedef struct vlc_keystore_sys vlc_keystore_sys;
++struct vlc_keystore
++{
++    VLC_COMMON_MEMBERS
++    module_t            *p_module;
++    vlc_keystore_sys    *p_sys;
++
++    /** See vlc_keystore_store() */
++    int                 (*pf_store)(vlc_keystore *p_keystore,
++                                    const char *const ppsz_values[KEY_MAX],
++                                    const uint8_t *p_secret,
++                                    size_t i_secret_len, const char *psz_label);
++    /**  See vlc_keystore_find() */
++    unsigned int        (*pf_find)(vlc_keystore *p_keystore,
++                                   const char *const ppsz_values[KEY_MAX],
++                                   vlc_keystore_entry **pp_entries);
++
++    /** See vlc_keystore_remove() */
++    unsigned int        (*pf_remove)(vlc_keystore *p_keystore,
++                                     const char *const ppsz_values[KEY_MAX]);
++};
++
++/** @} @} */
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_main.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_main.h
+new file mode 100644
+index 0000000..77866f2
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_main.h
+@@ -0,0 +1,38 @@
++/*****************************************************************************
++ * vlc_main.h: access to all program variables
++ * Declaration and extern access to LibVLC instance object.
++ *****************************************************************************
++ * Copyright (C) 1999, 2000, 2001, 2002, 2008 VLC authors and VideoLAN
++ *
++ * Authors: Vincent Seguin <seguin@via.ecp.fr>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++/**
++ * \file
++ * This file defines libvlc_int_t internal libvlc instance
++ */
++
++/*****************************************************************************
++ * libvlc_internal_instance_t
++ *****************************************************************************
++ * This structure is a LibVLC instance, for use by libvlc core and plugins
++ *****************************************************************************/
++struct libvlc_int_t
++{
++    VLC_COMMON_MEMBERS
++};
++
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_md5.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_md5.h
+new file mode 100644
+index 0000000..e72ff2f
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_md5.h
+@@ -0,0 +1,59 @@
++/*****************************************************************************
++ * vlc_md5.h: MD5 hash
++ *****************************************************************************
++ * Copyright © 2004-2011 VLC authors and VideoLAN
++ *
++ * Authors: Rémi Denis-Courmont
++ *          Rafaël Carré
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_MD5_H
++# define VLC_MD5_H
++
++/**
++ * \file
++ * This file defines functions and structures to compute MD5 digests
++ */
++
++struct md5_s
++{
++    uint32_t A, B, C, D;          /* chaining variables */
++    uint32_t nblocks;
++    uint8_t buf[64];
++    int count;
++};
++
++VLC_API void InitMD5( struct md5_s * );
++VLC_API void AddMD5( struct md5_s *, const void *, size_t );
++VLC_API void EndMD5( struct md5_s * );
++
++/**
++ * Returns a char representation of the md5 hash, as shown by UNIX md5 or
++ * md5sum tools.
++ */
++static inline char * psz_md5_hash( struct md5_s *md5_s )
++{
++    char *psz = (char*)malloc( 33 ); /* md5 string is 32 bytes + NULL character */
++    if( likely(psz) )
++    {
++        for( int i = 0; i < 16; i++ )
++            sprintf( &psz[2*i], "%02" PRIx8, md5_s->buf[i] );
++    }
++    return psz;
++}
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_media_library.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_media_library.h
+new file mode 100644
+index 0000000..e7e1f70
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_media_library.h
+@@ -0,0 +1,127 @@
++/*****************************************************************************
++ * vlc_media_library.h: SQL-based media library
++ *****************************************************************************
++ * Copyright (C) 2008-2010 the VideoLAN Team and AUTHORS
++ * $Id: a35d9729ca3705ec792b7be9e1819919f6e601f6 $
++ *
++ * Authors: Antoine Lejeune <phytos@videolan.org>
++ *          Jean-Philippe André <jpeg@videolan.org>
++ *          Rémi Duraffort <ivoire@videolan.org>
++ *          Adrien Maglo <magsoft@videolan.org>
++ *          Srikanth Raju <srikiraju at gmail dot com>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_MEDIA_LIBRARY_H
++# define VLC_MEDIA_LIBRARY_H
++
++# ifdef __cplusplus
++extern "C" {
++# endif
++
++/*****************************************************************************
++ * ML Enums
++ *****************************************************************************/
++
++#define ML_PERSON_ARTIST        "Artist"
++#define ML_PERSON_ALBUM_ARTIST  "Album Artist"
++#define ML_PERSON_ENCODER       "Encoder"
++#define ML_PERSON_PUBLISHER     "Publisher"
++
++
++/** List of Query select types.
++ * In a query array or variable argument list, each select type is followed
++ * by an argument (X) of variable type (char* or int, @see ml_element_t).
++ * These types can be used either in the query list or in the result array.
++ * Some types are reserved for the result array:
++ */
++typedef enum
++{
++    ML_ALBUM = 1,              /**< Album Title */
++    ML_ALBUM_ID,               /**< Album ID */
++    ML_ALBUM_COVER,            /**< Album Cover art url */
++    /* FIXME: Remove ML_ARTIST */
++    ML_ARTIST,                 /**< Artist, interpreted as ML_PEOPLE
++                                    && ML_PEOPLE_ROLE = ML_PERSON_ARTIST */
++    ML_ARTIST_ID,              /**< Artist ID, interpreted as ML_PEOPLE_ID
++                                    && ML_PEOPLE_ROLE = ML_PERSON_ARTIST */
++    ML_COMMENT,                /**< Comment about media */
++    ML_COUNT_MEDIA,            /**< Number of medias */
++    ML_COUNT_ALBUM,            /**< Number of albums */
++    ML_COUNT_PEOPLE,           /**< Number of people */
++    ML_COVER,                  /**< Cover art url */
++    ML_DURATION,               /**< Duration in ms */
++    ML_DISC_NUMBER,            /**< Disc number of the track */
++    ML_EXTRA,                  /**< Extra/comment (string) on the media */
++    ML_FIRST_PLAYED,           /**< First time media was played */
++    ML_FILESIZE,               /**< Size of the media file */
++    ML_GENRE,                  /**< Genre of the media (if any) */
++    ML_ID,                     /**< Media ID */
++    ML_IMPORT_TIME,            /**< Date when media was imported */
++    ML_LANGUAGE,               /**< Language */
++    ML_LAST_PLAYED,            /**< Last play UNIX timestamp */
++    ML_LAST_SKIPPED,           /**< Time when media was last skipped */
++    ML_ORIGINAL_TITLE,         /**< Media original title (if any) */
++    ML_PEOPLE,                 /**< Any People associated with this media */
++    ML_PEOPLE_ID,              /**< Id of a person */
++    ML_PEOPLE_ROLE,            /**< Person role */
++    ML_PLAYED_COUNT,           /**< Media play count */
++    ML_PREVIEW,                /**< Url of the video preview */
++    ML_SKIPPED_COUNT,          /**< Number of times skipped */
++    ML_SCORE,                  /**< Computed media score */
++    ML_TITLE,                  /**< Media title */
++    ML_TRACK_NUMBER,           /**< Media track number (if any) */
++    ML_TYPE,                   /**< Media type. @see ml_type_e */
++    ML_URI,                    /**< Media full URI. */
++    ML_VOTE,                   /**< Media user vote value */
++    ML_YEAR,                   /**< Media publishing year */
++    ML_DIRECTORY,              /**< Monitored directory */
++    ML_MEDIA,                  /**< Full media descriptor. @see ml_media_t */
++    ML_MEDIA_SPARSE,           /**< Sparse media. @see ml_media_t */
++    ML_MEDIA_EXTRA,            /**< Sparse + Extra = Full media */
++
++    /* Some special elements */
++    ML_LIMIT     = -1,         /**< Limit a query to X results */
++    ML_SORT_DESC = -2,         /**< Sort a query descending on argument X */
++    ML_SORT_ASC  = -3,         /**< Sort a query ascending on argument X */
++    ML_DISTINCT  = -4,         /**< Add DISTINCT to SELECT statements. */
++    ML_END       = -42         /**< End of argument list */
++} ml_select_e;
++
++/** Media types (audio, video, etc...) */
++typedef enum
++{
++    ML_UNKNOWN   = 0,       /**< Unknown media type */
++    ML_AUDIO     = 1 << 0,  /**< Audio only media */
++    ML_VIDEO     = 1 << 1,  /**< Video media. May contain audio channels */
++    ML_STREAM    = 1 << 2,  /**< Streamed media = not a local file */
++    ML_NODE      = 1 << 3,  /**< Nodes like simple nodes, directories, playlists, etc */
++    ML_REMOVABLE = 1 << 4,  /**< Removable media: CD/DVD/Card/... */
++} ml_type_e;
++
++/** Query result item/list type: integers, strings, medias, timestamps */
++typedef enum {
++    ML_TYPE_INT,        /**< Object is an int */
++    ML_TYPE_PSZ,        /**< A string char* */
++    ML_TYPE_TIME,       /**< A timestamp mtime_t */
++    ML_TYPE_MEDIA,      /**< A pointer to a media ml_media_t* */
++} ml_result_type_e;
++
++#ifdef __cplusplus
++}
++#endif /* C++ */
++
++#endif /* VLC_MEDIA_LIBRARY_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_memstream.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_memstream.h
+new file mode 100644
+index 0000000..0ed78a7
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_memstream.h
+@@ -0,0 +1,76 @@
++/*****************************************************************************
++ * vlc_memstream.h:
++ *****************************************************************************
++ * Copyright (C) 2016 Rémi Denis-Courmont
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_MEMSTREAM_H
++# define VLC_MEMSTREAM_H 1
++
++# include <stdarg.h>
++# include <stdio.h>
++
++struct vlc_memstream
++{
++    union
++    {
++        FILE *stream;
++        int error;
++    };
++    char *ptr;
++    size_t length;
++};
++
++VLC_API
++int vlc_memstream_open(struct vlc_memstream *ms);
++
++VLC_API
++int vlc_memstream_flush(struct vlc_memstream *ms) VLC_USED;
++
++VLC_API
++int vlc_memstream_close(struct vlc_memstream *ms) VLC_USED;
++
++VLC_API
++size_t vlc_memstream_write(struct vlc_memstream *ms,
++                           const void *ptr, size_t len);
++
++VLC_API
++int vlc_memstream_putc(struct vlc_memstream *ms, int c);
++
++VLC_API
++int vlc_memstream_puts(struct vlc_memstream *ms, const char *str);
++
++VLC_API
++int vlc_memstream_vprintf(struct vlc_memstream *ms, const char *fmt,
++                          va_list args);
++
++VLC_API
++int vlc_memstream_printf(struct vlc_memstream *s, const char *fmt,
++                         ...) VLC_FORMAT(2,3);
++
++# ifdef __GNUC__
++static inline int vlc_memstream_puts_len(struct vlc_memstream *ms,
++                                         const char *str, size_t len)
++{
++    return (vlc_memstream_write(ms, str, len) == len) ? (int)len : EOF;
++}
++#  define vlc_memstream_puts(ms,s) \
++    (__builtin_constant_p(__builtin_strlen(s)) ? \
++        vlc_memstream_puts_len(ms,s,__builtin_strlen(s)) : \
++        vlc_memstream_puts(ms,s))
++# endif
++#endif /* VLC_MEMSTREAM_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_messages.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_messages.h
+new file mode 100644
+index 0000000..bcf1bca
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_messages.h
+@@ -0,0 +1,108 @@
++/*****************************************************************************
++ * vlc_messages.h: messages interface
++ * This library provides basic functions for threads to interact with user
++ * interface, such as message output.
++ *****************************************************************************
++ * Copyright (C) 1999, 2000, 2001, 2002 VLC authors and VideoLAN
++ * $Id: 63f9476cd5e6d6d4e274b4d4a7b947ec59d2843e $
++ *
++ * Authors: Vincent Seguin <seguin@via.ecp.fr>
++ *          Samuel Hocevar <sam@zoy.org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_MESSAGES_H_
++#define VLC_MESSAGES_H_
++
++#include <stdarg.h>
++
++/**
++ * \defgroup messages Logging
++ * \brief Message logs
++ *
++ * Functions for modules to emit log messages.
++ *
++ * @{
++ * \file
++ * Logging functions
++ */
++
++/** Message types */
++enum vlc_log_type
++{
++    VLC_MSG_INFO=0, /**< Important information */
++    VLC_MSG_ERR,    /**< Error */
++    VLC_MSG_WARN,   /**< Warning */
++    VLC_MSG_DBG,    /**< Debug */
++};
++
++/**
++ * Log message
++ */
++typedef struct vlc_log_t
++{
++    uintptr_t   i_object_id; /**< Emitter (temporarily) unique object ID or 0 */
++    const char *psz_object_type; /**< Emitter object type name */
++    const char *psz_module; /**< Emitter module (source code) */
++    const char *psz_header; /**< Additional header (used by VLM media) */
++    const char *file; /**< Source code file name or NULL */
++    int line; /**< Source code file line number or -1 */
++    const char *func; /**< Source code calling function name or NULL */
++    unsigned long tid; /**< Emitter thread ID */
++} vlc_log_t;
++
++VLC_API void vlc_Log(vlc_object_t *obj, int prio, const char *module,
++                     const char *file, unsigned line, const char *func,
++                     const char *format, ...) VLC_FORMAT(7, 8);
++VLC_API void vlc_vaLog(vlc_object_t *obj, int prio, const char *module,
++                       const char *file, unsigned line, const char *func,
++                       const char *format, va_list ap);
++#define msg_GenericVa(o, p, fmt, ap) \
++    vlc_vaLog(VLC_OBJECT(o), p, vlc_module_name, __FILE__, __LINE__, \
++              __func__, fmt, ap)
++
++#define msg_Generic(o, p, ...) \
++    vlc_Log(VLC_OBJECT(o), p, vlc_module_name, __FILE__, __LINE__, \
++            __func__, __VA_ARGS__)
++#define msg_Info(p_this, ...) \
++    msg_Generic(p_this, VLC_MSG_INFO, __VA_ARGS__)
++#define msg_Err(p_this, ...) \
++    msg_Generic(p_this, VLC_MSG_ERR, __VA_ARGS__)
++#define msg_Warn(p_this, ...) \
++    msg_Generic(p_this, VLC_MSG_WARN, __VA_ARGS__)
++#define msg_Dbg(p_this, ...) \
++    msg_Generic(p_this, VLC_MSG_DBG, __VA_ARGS__)
++
++extern const char vlc_module_name[];
++
++VLC_API const char *vlc_strerror(int);
++VLC_API const char *vlc_strerror_c(int);
++
++/**
++ * Message logging callback signature.
++ * \param data data pointer as provided to vlc_msg_SetCallback().
++ * \param type message type (VLC_MSG_* values from enum vlc_log_type)
++ * \param item meta information
++ * \param fmt format string
++ * \param args format string arguments
++ */
++typedef void (*vlc_log_cb) (void *data, int type, const vlc_log_t *item,
++                            const char *fmt, va_list args);
++
++/**
++ * @}
++ */
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_meta.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_meta.h
+new file mode 100644
+index 0000000..9791bb6
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_meta.h
+@@ -0,0 +1,165 @@
++/*****************************************************************************
++ * vlc_meta.h: Stream meta-data
++ *****************************************************************************
++ * Copyright (C) 2004 VLC authors and VideoLAN
++ * $Id: d390d0bc4df47994d296c5720d1869c458b16cb5 $
++ *
++ * Authors: Laurent Aimar <fenrir@via.ecp.fr>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_META_H
++#define VLC_META_H 1
++
++/**
++ * \file
++ * This file defines functions and structures for stream meta-data in vlc
++ *
++ */
++
++typedef enum vlc_meta_type_t
++{
++    vlc_meta_Title,
++    vlc_meta_Artist,
++    vlc_meta_Genre,
++    vlc_meta_Copyright,
++    vlc_meta_Album,
++    vlc_meta_TrackNumber,
++    vlc_meta_Description,
++    vlc_meta_Rating,
++    vlc_meta_Date,
++    vlc_meta_Setting,
++    vlc_meta_URL,
++    vlc_meta_Language,
++    vlc_meta_NowPlaying,
++    vlc_meta_ESNowPlaying,
++    vlc_meta_Publisher,
++    vlc_meta_EncodedBy,
++    vlc_meta_ArtworkURL,
++    vlc_meta_TrackID,
++    vlc_meta_TrackTotal,
++    vlc_meta_Director,
++    vlc_meta_Season,
++    vlc_meta_Episode,
++    vlc_meta_ShowName,
++    vlc_meta_Actors,
++    vlc_meta_AlbumArtist,
++    vlc_meta_DiscNumber,
++    vlc_meta_DiscTotal
++} vlc_meta_type_t;
++
++#define VLC_META_TYPE_COUNT 27
++
++#define ITEM_PREPARSED       1
++#define ITEM_ART_FETCHED     2
++#define ITEM_ART_NOTFOUND    4
++
++/**
++ * Basic function to deal with meta
++ */
++struct vlc_meta_t;
++
++VLC_API vlc_meta_t * vlc_meta_New( void ) VLC_USED;
++VLC_API void vlc_meta_Delete( vlc_meta_t *m );
++VLC_API void vlc_meta_Set( vlc_meta_t *p_meta, vlc_meta_type_t meta_type, const char *psz_val );
++VLC_API const char * vlc_meta_Get( const vlc_meta_t *p_meta, vlc_meta_type_t meta_type );
++
++VLC_API void vlc_meta_AddExtra( vlc_meta_t *m, const char *psz_name, const char *psz_value );
++VLC_API const char * vlc_meta_GetExtra( const vlc_meta_t *m, const char *psz_name );
++VLC_API unsigned vlc_meta_GetExtraCount( const vlc_meta_t *m );
++
++/**
++ * Allocate a copy of all extra meta names and a table with it.
++ * Be sure to free both the returned pointers and its name.
++ */
++VLC_API char ** vlc_meta_CopyExtraNames( const vlc_meta_t *m ) VLC_USED;
++
++VLC_API void vlc_meta_Merge( vlc_meta_t *dst, const vlc_meta_t *src );
++
++VLC_API int vlc_meta_GetStatus( vlc_meta_t *m );
++VLC_API void vlc_meta_SetStatus( vlc_meta_t *m, int status );
++
++/**
++ * Returns a localizes string describing the meta
++ */
++VLC_API const char * vlc_meta_TypeToLocalizedString( vlc_meta_type_t meta_type );
++
++typedef struct meta_export_t
++{
++    VLC_COMMON_MEMBERS
++    input_item_t *p_item;
++    const char *psz_file;
++} meta_export_t;
++
++VLC_API int input_item_WriteMeta(vlc_object_t *, input_item_t *);
++
++/* Setters for meta.
++ * Warning: Make sure to use the input_item meta setters (defined in vlc_input_item.h)
++ * instead of those one. */
++#define vlc_meta_SetTitle( meta, b )       vlc_meta_Set( meta, vlc_meta_Title, b )
++#define vlc_meta_SetArtist( meta, b )      vlc_meta_Set( meta, vlc_meta_Artist, b )
++#define vlc_meta_SetGenre( meta, b )       vlc_meta_Set( meta, vlc_meta_Genre, b )
++#define vlc_meta_SetCopyright( meta, b )   vlc_meta_Set( meta, vlc_meta_Copyright, b )
++#define vlc_meta_SetAlbum( meta, b )       vlc_meta_Set( meta, vlc_meta_Album, b )
++#define vlc_meta_SetTrackNum( meta, b )    vlc_meta_Set( meta, vlc_meta_TrackNumber, b )
++#define vlc_meta_SetDescription( meta, b ) vlc_meta_Set( meta, vlc_meta_Description, b )
++#define vlc_meta_SetRating( meta, b )      vlc_meta_Set( meta, vlc_meta_Rating, b )
++#define vlc_meta_SetDate( meta, b )        vlc_meta_Set( meta, vlc_meta_Date, b )
++#define vlc_meta_SetSetting( meta, b )     vlc_meta_Set( meta, vlc_meta_Setting, b )
++#define vlc_meta_SetURL( meta, b )         vlc_meta_Set( meta, vlc_meta_URL, b )
++#define vlc_meta_SetLanguage( meta, b )    vlc_meta_Set( meta, vlc_meta_Language, b )
++#define vlc_meta_SetNowPlaying( meta, b )  vlc_meta_Set( meta, vlc_meta_NowPlaying, b )
++#define vlc_meta_SetPublisher( meta, b )   vlc_meta_Set( meta, vlc_meta_Publisher, b )
++#define vlc_meta_SetEncodedBy( meta, b )   vlc_meta_Set( meta, vlc_meta_EncodedBy, b )
++#define vlc_meta_SetArtURL( meta, b )      vlc_meta_Set( meta, vlc_meta_ArtworkURL, b )
++#define vlc_meta_SetTrackID( meta, b )     vlc_meta_Set( meta, vlc_meta_TrackID, b )
++#define vlc_meta_SetTrackTotal( meta, b )  vlc_meta_Set( meta, vlc_meta_TrackTotal, b )
++#define vlc_meta_SetDirector( meta, b )    vlc_meta_Set( meta, vlc_meta_Director, b )
++#define vlc_meta_SetSeason( meta, b )      vlc_meta_Set( meta, vlc_meta_Season, b )
++#define vlc_meta_SetEpisode( meta, b )     vlc_meta_Set( meta, vlc_meta_Episode, b )
++#define vlc_meta_SetShowName( meta, b )    vlc_meta_Set( meta, vlc_meta_ShowName, b )
++#define vlc_meta_SetActors( meta, b )      vlc_meta_Set( meta, vlc_meta_Actors, b )
++#define vlc_meta_SetAlbumArtist( meta, b ) vlc_meta_Set( meta, vlc_meta_AlbumArtist, b )
++#define vlc_meta_SetDiscNumber( meta, b )  vlc_meta_Set( meta, vlc_meta_DiscNumber, b )
++
++#define VLC_META_TITLE              vlc_meta_TypeToLocalizedString( vlc_meta_Title )
++#define VLC_META_ARTIST             vlc_meta_TypeToLocalizedString( vlc_meta_Artist )
++#define VLC_META_GENRE              vlc_meta_TypeToLocalizedString( vlc_meta_Genre )
++#define VLC_META_COPYRIGHT          vlc_meta_TypeToLocalizedString( vlc_meta_Copyright )
++#define VLC_META_ALBUM              vlc_meta_TypeToLocalizedString( vlc_meta_Album )
++#define VLC_META_TRACK_NUMBER       vlc_meta_TypeToLocalizedString( vlc_meta_TrackNumber )
++#define VLC_META_DESCRIPTION        vlc_meta_TypeToLocalizedString( vlc_meta_Description )
++#define VLC_META_RATING             vlc_meta_TypeToLocalizedString( vlc_meta_Rating )
++#define VLC_META_DATE               vlc_meta_TypeToLocalizedString( vlc_meta_Date )
++#define VLC_META_SETTING            vlc_meta_TypeToLocalizedString( vlc_meta_Setting )
++#define VLC_META_URL                vlc_meta_TypeToLocalizedString( vlc_meta_URL )
++#define VLC_META_LANGUAGE           vlc_meta_TypeToLocalizedString( vlc_meta_Language )
++#define VLC_META_NOW_PLAYING        vlc_meta_TypeToLocalizedString( vlc_meta_NowPlaying )
++#define VLC_META_PUBLISHER          vlc_meta_TypeToLocalizedString( vlc_meta_Publisher )
++#define VLC_META_ENCODED_BY         vlc_meta_TypeToLocalizedString( vlc_meta_EncodedBy )
++#define VLC_META_ART_URL            vlc_meta_TypeToLocalizedString( vlc_meta_ArtworkURL )
++#define VLC_META_TRACKID            vlc_meta_TypeToLocalizedString( vlc_meta_TrackID )
++#define VLC_META_DIRECTOR           vlc_meta_TypeToLocalizedString( vlc_meta_Director )
++#define VLC_META_SEASON             vlc_meta_TypeToLocalizedString( vlc_meta_Season )
++#define VLC_META_EPISODE            vlc_meta_TypeToLocalizedString( vlc_meta_Episode )
++#define VLC_META_SHOW_NAME          vlc_meta_TypeToLocalizedString( vlc_meta_ShowName )
++#define VLC_META_ACTORS             vlc_meta_TypeToLocalizedString( vlc_meta_Actors )
++#define VLC_META_ALBUMARTIST        vlc_meta_TypeToLocalizedString( vlc_meta_AlbumArtist )
++#define VLC_META_DISCNUMBER         vlc_meta_TypeToLocalizedString( vlc_meta_DiscNumber )
++
++#define VLC_META_EXTRA_MB_ALBUMID   "MB_ALBUMID"
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_meta_fetcher.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_meta_fetcher.h
+new file mode 100644
+index 0000000..e806145
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_meta_fetcher.h
+@@ -0,0 +1,38 @@
++/*****************************************************************************
++ * vlc_meta_fetcher.h
++ *****************************************************************************
++ * Copyright (C) 2009 Rémi Denis-Courmont
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_META_FETCHER_H
++#define VLC_META_FETCHER_H 1
++
++typedef enum meta_fetcher_scope_t
++{
++    FETCHER_SCOPE_LOCAL   = 0x01,
++    FETCHER_SCOPE_NETWORK = 0x02,
++    FETCHER_SCOPE_ANY     = 0x03
++} meta_fetcher_scope_t;
++
++typedef struct meta_fetcher_t
++{
++    VLC_COMMON_MEMBERS
++    input_item_t *p_item;
++    meta_fetcher_scope_t e_scope;
++} meta_fetcher_t;
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_mime.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_mime.h
+new file mode 100644
+index 0000000..f04fc95
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_mime.h
+@@ -0,0 +1,31 @@
++/*****************************************************************************
++ * vlc_mime.h: Mime type recognition
++ *****************************************************************************
++ * Copyright (C) 2012 VLC authors and VideoLAN
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_MIME_H
++#define VLC_MIME_H 1
++
++/**
++ * \file
++ * Mime type recognition helpers.
++ */
++
++VLC_API const char * vlc_mime_Ext2Mime( const char *psz_url );
++
++#endif /* _VLC_MIME_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_modules.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_modules.h
+new file mode 100644
+index 0000000..a425fe8
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_modules.h
+@@ -0,0 +1,85 @@
++/*****************************************************************************
++ * vlc_modules.h : Module descriptor and load functions
++ *****************************************************************************
++ * Copyright (C) 2001-2011 VLC authors and VideoLAN
++ * $Id: c2d3c26d20c3c45529bc01afb40377560cdf7306 $
++ *
++ * Authors: Samuel Hocevar <sam@zoy.org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_MODULES_H
++#define VLC_MODULES_H 1
++
++/**
++ * \file
++ * This file defines functions for modules in vlc
++ */
++
++typedef int (*vlc_activate_t)(void *func, va_list args);
++typedef void (*vlc_deactivate_t)(void *func, va_list args);
++
++/*****************************************************************************
++ * Exported functions.
++ *****************************************************************************/
++
++VLC_API module_t * vlc_module_load( vlc_object_t *obj, const char *cap, const char *name, bool strict, vlc_activate_t probe, ... ) VLC_USED;
++#define vlc_module_load(o,c,n,s,...) \
++        vlc_module_load(VLC_OBJECT(o),c,n,s,__VA_ARGS__)
++VLC_API void vlc_module_unload( vlc_object_t *obj, module_t *,
++                                vlc_deactivate_t deinit, ... );
++#define vlc_module_unload(o,m,d,...) \
++        vlc_module_unload(VLC_OBJECT(o),m,d,__VA_ARGS__)
++
++VLC_API module_t * module_need( vlc_object_t *, const char *, const char *, bool ) VLC_USED;
++#define module_need(a,b,c,d) module_need(VLC_OBJECT(a),b,c,d)
++VLC_API void module_unneed( vlc_object_t *, module_t * );
++#define module_unneed(a,b) module_unneed(VLC_OBJECT(a),b)
++VLC_API bool module_exists(const char *) VLC_USED;
++VLC_API module_t * module_find(const char *) VLC_USED;
++
++int module_start(vlc_object_t *, const module_t *);
++#define module_start(o, m) module_start(VLC_OBJECT(o),m)
++void module_stop(vlc_object_t *, const module_t *);
++#define module_stop(o, m) module_stop(VLC_OBJECT(o),m)
++
++VLC_API module_config_t * module_config_get( const module_t *, unsigned * ) VLC_USED;
++VLC_API void module_config_free( module_config_t * );
++
++VLC_API void module_list_free(module_t **);
++VLC_API module_t ** module_list_get(size_t *n) VLC_USED;
++
++VLC_API bool module_provides( const module_t *m, const char *cap );
++VLC_API const char * module_get_object( const module_t *m ) VLC_USED;
++VLC_API const char * module_get_name( const module_t *m, bool long_name ) VLC_USED;
++#define module_GetLongName( m ) module_get_name( m, true )
++VLC_API const char * module_get_help( const module_t *m ) VLC_USED;
++VLC_API const char * module_get_capability( const module_t *m ) VLC_USED;
++VLC_API int module_get_score( const module_t *m ) VLC_USED;
++VLC_API const char * module_gettext( const module_t *, const char * ) VLC_USED;
++
++VLC_USED static inline module_t *module_get_main (void)
++{
++    return module_find ("core");
++}
++#define module_get_main(a) module_get_main()
++
++VLC_USED static inline bool module_is_main( const module_t * p_module )
++{
++    return !strcmp( module_get_object( p_module ), "core" );
++}
++
++#endif /* VLC_MODULES_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_mouse.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_mouse.h
+new file mode 100644
+index 0000000..fa07ef1
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_mouse.h
+@@ -0,0 +1,148 @@
++/*****************************************************************************
++ * vlc_mouse.h: mouse related structures and functions
++ *****************************************************************************
++ * Copyright (C) 2009 Laurent Aimar
++ * $Id: 481c3598e905db66805cf9a8ca58f6702921e4f0 $
++ *
++ * Authors: Laurent Aimar <fenrir _AT_ videolan _DOT_ org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef _VLC_MOUSE_H
++#define _VLC_MOUSE_H 1
++
++/**
++ * Mouse buttons
++ */
++enum
++{
++    MOUSE_BUTTON_LEFT=0,
++    MOUSE_BUTTON_CENTER,
++    MOUSE_BUTTON_RIGHT,
++    MOUSE_BUTTON_WHEEL_UP,
++    MOUSE_BUTTON_WHEEL_DOWN,
++    MOUSE_BUTTON_WHEEL_LEFT,
++    MOUSE_BUTTON_WHEEL_RIGHT,
++    MOUSE_BUTTON_MAX
++};
++
++/**
++ * Mouse state
++ */
++typedef struct vlc_mouse_t
++{
++    /* Coordinate */
++    int i_x;
++    int i_y;
++    /* Mask of pressed button */
++    int i_pressed;
++    /* Is double clicked */
++    bool b_double_click;
++} vlc_mouse_t;
++
++static inline void vlc_mouse_Init( vlc_mouse_t *p_mouse )
++{
++    p_mouse->i_x = 0;
++    p_mouse->i_y = 0;
++    p_mouse->i_pressed = 0;
++    p_mouse->b_double_click = false;
++}
++
++/* */
++static inline void vlc_mouse_SetPressed( vlc_mouse_t *p_mouse,
++                                         int i_button )
++{
++    p_mouse->i_pressed |= 1 << i_button;
++}
++static inline void vlc_mouse_SetReleased( vlc_mouse_t *p_mouse,
++                                          int i_button )
++{
++    p_mouse->i_pressed &= ~(1 << i_button);
++}
++static inline void vlc_mouse_SetPosition( vlc_mouse_t *p_mouse,
++                                          int i_x, int i_y )
++{
++    p_mouse->i_x = i_x;
++    p_mouse->i_y = i_y;
++}
++
++/* */
++static inline bool vlc_mouse_IsPressed( const vlc_mouse_t *p_mouse,
++                                        int i_button )
++{
++    return ( p_mouse->i_pressed & (1 << i_button) ) != 0;
++}
++static inline bool vlc_mouse_IsLeftPressed( const vlc_mouse_t *p_mouse )
++{
++    return vlc_mouse_IsPressed( p_mouse, MOUSE_BUTTON_LEFT );
++}
++static inline bool vlc_mouse_IsCenterPressed( const vlc_mouse_t *p_mouse )
++{
++    return vlc_mouse_IsPressed( p_mouse, MOUSE_BUTTON_CENTER );
++}
++static inline bool vlc_mouse_IsRightPressed( const vlc_mouse_t *p_mouse )
++{
++    return vlc_mouse_IsPressed( p_mouse, MOUSE_BUTTON_RIGHT );
++}
++static inline bool vlc_mouse_IsWheelUpPressed( const vlc_mouse_t *p_mouse )
++{
++    return vlc_mouse_IsPressed( p_mouse, MOUSE_BUTTON_WHEEL_UP );
++}
++static inline bool vlc_mouse_IsWheelDownPressed( const vlc_mouse_t *p_mouse )
++{
++    return vlc_mouse_IsPressed( p_mouse, MOUSE_BUTTON_WHEEL_DOWN );
++}
++static inline void vlc_mouse_GetMotion( int *pi_x, int *pi_y,
++                                        const vlc_mouse_t *p_old,
++                                        const vlc_mouse_t *p_new )
++{
++    *pi_x = p_new->i_x - p_old->i_x;
++    *pi_y = p_new->i_y - p_old->i_y;
++}
++
++/* */
++static inline bool vlc_mouse_HasChanged( const vlc_mouse_t *p_old,
++                                         const vlc_mouse_t *p_new )
++{
++    return p_old->i_x != p_new->i_x || p_old->i_y != p_new->i_y ||
++           p_old->i_pressed != p_new->i_pressed;
++}
++static inline bool vlc_mouse_HasMoved( const vlc_mouse_t *p_old,
++                                       const vlc_mouse_t *p_new )
++{
++    return p_old->i_x != p_new->i_x || p_old->i_y != p_new->i_y;
++}
++static inline bool vlc_mouse_HasButton( const vlc_mouse_t *p_old,
++                                        const vlc_mouse_t *p_new )
++{
++    return p_old->i_pressed != p_new->i_pressed;
++}
++static inline bool vlc_mouse_HasPressed( const vlc_mouse_t *p_old,
++                                         const vlc_mouse_t *p_new,
++                                         int i_button )
++{
++    const int i_mask = 1 << i_button;
++    return (p_old->i_pressed & i_mask) == 0 && (p_new->i_pressed & i_mask);
++}
++static inline bool vlc_mouse_HasReleased( const vlc_mouse_t *p_old,
++                                          const vlc_mouse_t *p_new,
++                                          int i_button )
++{
++    const int i_mask = 1 << i_button;
++    return (p_old->i_pressed & i_mask) && (p_new->i_pressed & i_mask) == 0;
++}
++#endif /* _VLC_MOUSE_H */
++
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_mtime.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_mtime.h
+new file mode 100644
+index 0000000..4ba1a57
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_mtime.h
+@@ -0,0 +1,78 @@
++/*****************************************************************************
++ * vlc_mtime.h: high resolution time management functions
++ *****************************************************************************
++ * This header provides portable high precision time management functions,
++ * which should be the only ones used in other segments of the program, since
++ * functions like gettimeofday() and ftime() are not always supported.
++ * Most functions are declared as inline or as macros since they are only
++ * interfaces to system calls and have to be called frequently.
++ * 'm' stands for 'micro', since maximum resolution is the microsecond.
++ * Functions prototyped are implemented in interface/mtime.c.
++ *****************************************************************************
++ * Copyright (C) 1996, 1997, 1998, 1999, 2000 VLC authors and VideoLAN
++ * $Id: 311eb670eb7b9f35668196b78c9fa3c5cf1779db $
++ *
++ * Authors: Vincent Seguin <seguin@via.ecp.fr>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef __VLC_MTIME_H
++# define __VLC_MTIME_H 1
++
++/*****************************************************************************
++ * LAST_MDATE: date which will never happen
++ *****************************************************************************
++ * This date can be used as a 'never' date, to mark missing events in a function
++ * supposed to return a date, such as nothing to display in a function
++ * returning the date of the first image to be displayed. It can be used in
++ * comparaison with other values: all existing dates will be earlier.
++ *****************************************************************************/
++#define LAST_MDATE ((mtime_t)((uint64_t)(-1)/2))
++
++/*****************************************************************************
++ * MSTRTIME_MAX_SIZE: maximum possible size of mstrtime
++ *****************************************************************************
++ * This values is the maximal possible size of the string returned by the
++ * mstrtime() function, including '-' and the final '\0'. It should be used to
++ * allocate the buffer.
++ *****************************************************************************/
++#define MSTRTIME_MAX_SIZE 22
++
++/*****************************************************************************
++ * Prototypes
++ *****************************************************************************/
++VLC_API char * secstotimestr( char *psz_buffer, int32_t secs );
++
++/*****************************************************************************
++ * date_t: date incrementation without long-term rounding errors
++ *****************************************************************************/
++struct date_t
++{
++    mtime_t  date;
++    uint32_t i_divider_num;
++    uint32_t i_divider_den;
++    uint32_t i_remainder;
++};
++
++VLC_API void date_Init( date_t *, uint32_t, uint32_t );
++VLC_API void date_Change( date_t *, uint32_t, uint32_t );
++VLC_API void date_Set( date_t *, mtime_t );
++VLC_API mtime_t date_Get( const date_t * );
++VLC_API void date_Move( date_t *, mtime_t );
++VLC_API mtime_t date_Increment( date_t *, uint32_t );
++VLC_API mtime_t date_Decrement( date_t *, uint32_t );
++VLC_API uint64_t NTPtime64( void );
++#endif /* !__VLC_MTIME_ */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_network.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_network.h
+new file mode 100644
+index 0000000..caa4dcc
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_network.h
+@@ -0,0 +1,299 @@
++/*****************************************************************************
++ * vlc_network.h: interface to communicate with network plug-ins
++ *****************************************************************************
++ * Copyright (C) 2002-2005 VLC authors and VideoLAN
++ * Copyright © 2006-2007 Rémi Denis-Courmont
++ * $Id: 184c23acae9ddf2413b3df600523280a8f43975b $
++ *
++ * Authors: Christophe Massiot <massiot@via.ecp.fr>
++ *          Laurent Aimar <fenrir@via.ecp.fr>
++ *          Rémi Denis-Courmont <rem # videolan.org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_NETWORK_H
++# define VLC_NETWORK_H
++
++/**
++ * \ingroup os
++ * \defgroup net Networking
++ * @{
++ * \file
++ * Definitions for sockets and low-level networking
++ * \defgroup sockets Internet sockets
++ * @{
++ */
++
++#include <sys/types.h>
++#include <unistd.h>
++
++#if defined( _WIN32 )
++#   define _NO_OLDNAMES 1
++#   include <winsock2.h>
++#   include <ws2tcpip.h>
++#   define net_errno (WSAGetLastError())
++#   define net_Close(fd) ((void)closesocket((SOCKET)fd))
++#   ifndef IPV6_V6ONLY
++#       define IPV6_V6ONLY 27
++#   endif
++#else
++#   include <sys/socket.h>
++#   include <netinet/in.h>
++#   include <netdb.h>
++#   define net_errno errno
++#   define net_Close(fd) ((void)vlc_close(fd))
++#endif
++
++#ifndef MSG_NOSIGNAL
++# define MSG_NOSIGNAL 0
++#endif
++
++/**
++ * Creates a socket file descriptor.
++ *
++ * This function creates a socket, similar to the standard socket() function.
++ * However, the new file descriptor has the close-on-exec flag set atomically,
++ * so as to avoid leaking the descriptor to child processes.
++ *
++ * The non-blocking flag can also optionally be set.
++ *
++ * @param pf protocol family
++ * @param type socket type
++ * @param proto network protocol
++ * @param nonblock true to create a non-blocking socket
++ * @return a new file descriptor or -1 on error
++ */
++VLC_API int vlc_socket(int pf, int type, int proto, bool nonblock) VLC_USED;
++
++/**
++ * Creates a pair of socket file descriptors.
++ *
++ * This function creates a pair of sockets that are mutually connected,
++ * much like the standard socketpair() function. However, the new file
++ * descriptors have the close-on-exec flag set atomically.
++ * See also vlc_socket().
++ *
++ * @param pf protocol family
++ * @param type socket type
++ * @param proto network protocol
++ * @param nonblock true to create non-blocking sockets
++ * @retval 0 on success
++ * @retval -1 on failure
++ */
++VLC_API int vlc_socketpair(int pf, int type, int proto, int fds[2],
++                           bool nonblock);
++
++struct sockaddr;
++
++/**
++ * Accepts an inbound connection request on a listening socket.
++ *
++ * This function creates a connected socket from a listening socket, much like
++ * the standard accept() function. However, the new file descriptor has the
++ * close-on-exec flag set atomically. See also vlc_socket().
++ *
++ * @param lfd listening socket file descriptor
++ * @param addr pointer to the peer address or NULL [OUT]
++ * @param alen pointer to the length of the peer address or NULL [OUT]
++ * @param nonblock whether to put the new socket in non-blocking mode
++ * @return a new file descriptor or -1 on error
++ */
++VLC_API int vlc_accept(int lfd, struct sockaddr *addr, socklen_t *alen,
++                       bool nonblock) VLC_USED;
++
++# ifdef __cplusplus
++extern "C" {
++# endif
++
++/* Portable networking layer communication */
++int net_Socket (vlc_object_t *obj, int family, int socktype, int proto);
++
++VLC_API int net_Connect(vlc_object_t *p_this, const char *psz_host, int i_port, int socktype, int protocol);
++#define net_Connect(a, b, c, d, e) net_Connect(VLC_OBJECT(a), b, c, d, e)
++
++VLC_API int * net_Listen(vlc_object_t *p_this, const char *psz_host, int i_port, int socktype, int protocol);
++
++#define net_ListenTCP(a, b, c) net_Listen(VLC_OBJECT(a), b, c, \
++                                          SOCK_STREAM, IPPROTO_TCP)
++
++static inline int net_ConnectTCP (vlc_object_t *obj, const char *host, int port)
++{
++    return net_Connect (obj, host, port, SOCK_STREAM, IPPROTO_TCP);
++}
++#define net_ConnectTCP(a, b, c) net_ConnectTCP(VLC_OBJECT(a), b, c)
++
++VLC_API int net_AcceptSingle(vlc_object_t *obj, int lfd);
++
++VLC_API int net_Accept( vlc_object_t *, int * );
++#define net_Accept(a, b) \
++        net_Accept(VLC_OBJECT(a), b)
++
++VLC_API int net_ConnectDgram( vlc_object_t *p_this, const char *psz_host, int i_port, int hlim, int proto );
++#define net_ConnectDgram(a, b, c, d, e ) \
++        net_ConnectDgram(VLC_OBJECT(a), b, c, d, e)
++
++static inline int net_ConnectUDP (vlc_object_t *obj, const char *host, int port, int hlim)
++{
++    return net_ConnectDgram (obj, host, port, hlim, IPPROTO_UDP);
++}
++
++VLC_API int net_OpenDgram( vlc_object_t *p_this, const char *psz_bind, int i_bind, const char *psz_server, int i_server, int proto );
++#define net_OpenDgram( a, b, c, d, e, g ) \
++        net_OpenDgram(VLC_OBJECT(a), b, c, d, e, g)
++
++static inline int net_ListenUDP1 (vlc_object_t *obj, const char *host, int port)
++{
++    return net_OpenDgram (obj, host, port, NULL, 0, IPPROTO_UDP);
++}
++
++VLC_API void net_ListenClose( int *fd );
++
++int net_Subscribe (vlc_object_t *obj, int fd, const struct sockaddr *addr,
++                   socklen_t addrlen);
++
++VLC_API int net_SetCSCov( int fd, int sendcov, int recvcov );
++
++VLC_API ssize_t net_Read( vlc_object_t *p_this, int fd, void *p_data, size_t i_data );
++#define net_Read(a,b,c,d) net_Read(VLC_OBJECT(a),b,c,d)
++VLC_API ssize_t net_Write( vlc_object_t *p_this, int fd, const void *p_data, size_t i_data );
++#define net_Write(a,b,c,d) net_Write(VLC_OBJECT(a),b,c,d)
++VLC_API char * net_Gets( vlc_object_t *p_this, int fd );
++#define net_Gets(a,b) net_Gets(VLC_OBJECT(a),b)
++
++
++VLC_API ssize_t net_Printf( vlc_object_t *p_this, int fd, const char *psz_fmt, ... ) VLC_FORMAT( 3, 4 );
++#define net_Printf(o,fd,...) net_Printf(VLC_OBJECT(o),fd, __VA_ARGS__)
++VLC_API ssize_t net_vaPrintf( vlc_object_t *p_this, int fd, const char *psz_fmt, va_list args );
++#define net_vaPrintf(a,b,c,d) net_vaPrintf(VLC_OBJECT(a),b,c,d)
++
++VLC_API int vlc_close(int);
++
++/** @} */
++
++/* Portable network names/addresses resolution layer */
++
++#define NI_MAXNUMERICHOST 64
++
++#ifndef AI_NUMERICSERV
++# define AI_NUMERICSERV 0
++#endif
++#ifndef AI_IDN
++# define AI_IDN 0 /* GNU/libc extension */
++#endif
++
++#ifdef _WIN32
++# if !defined(WINAPI_FAMILY) || WINAPI_FAMILY != WINAPI_FAMILY_APP
++#  undef gai_strerror
++#  define gai_strerror gai_strerrorA
++# endif
++#endif
++
++VLC_API int vlc_getnameinfo( const struct sockaddr *, int, char *, int, int *, int );
++VLC_API int vlc_getaddrinfo (const char *, unsigned,
++                             const struct addrinfo *, struct addrinfo **);
++VLC_API int vlc_getaddrinfo_i11e(const char *, unsigned,
++                                 const struct addrinfo *, struct addrinfo **);
++
++static inline bool
++net_SockAddrIsMulticast (const struct sockaddr *addr, socklen_t len)
++{
++    switch (addr->sa_family)
++    {
++#ifdef IN_MULTICAST
++        case AF_INET:
++        {
++            const struct sockaddr_in *v4 = (const struct sockaddr_in *)addr;
++            if ((size_t)len < sizeof (*v4))
++                return false;
++            return IN_MULTICAST (ntohl (v4->sin_addr.s_addr)) != 0;
++        }
++#endif
++
++#ifdef IN6_IS_ADDR_MULTICAST
++        case AF_INET6:
++        {
++            const struct sockaddr_in6 *v6 = (const struct sockaddr_in6 *)addr;
++            if ((size_t)len < sizeof (*v6))
++                return false;
++            return IN6_IS_ADDR_MULTICAST (&v6->sin6_addr) != 0;
++        }
++#endif
++    }
++
++    return false;
++}
++
++
++static inline int net_GetSockAddress( int fd, char *address, int *port )
++{
++    struct sockaddr_storage addr;
++    socklen_t addrlen = sizeof( addr );
++
++    return getsockname( fd, (struct sockaddr *)&addr, &addrlen )
++        || vlc_getnameinfo( (struct sockaddr *)&addr, addrlen, address,
++                            NI_MAXNUMERICHOST, port, NI_NUMERICHOST )
++        ? VLC_EGENERIC : 0;
++}
++
++static inline int net_GetPeerAddress( int fd, char *address, int *port )
++{
++    struct sockaddr_storage addr;
++    socklen_t addrlen = sizeof( addr );
++
++    return getpeername( fd, (struct sockaddr *)&addr, &addrlen )
++        || vlc_getnameinfo( (struct sockaddr *)&addr, addrlen, address,
++                            NI_MAXNUMERICHOST, port, NI_NUMERICHOST )
++        ? VLC_EGENERIC : 0;
++}
++
++static inline uint16_t net_GetPort (const struct sockaddr *addr)
++{
++    switch (addr->sa_family)
++    {
++#ifdef AF_INET6
++        case AF_INET6:
++            return ((const struct sockaddr_in6 *)addr)->sin6_port;
++#endif
++        case AF_INET:
++            return ((const struct sockaddr_in *)addr)->sin_port;
++    }
++    return 0;
++}
++
++static inline void net_SetPort (struct sockaddr *addr, uint16_t port)
++{
++    switch (addr->sa_family)
++    {
++#ifdef AF_INET6
++        case AF_INET6:
++            ((struct sockaddr_in6 *)addr)->sin6_port = port;
++        break;
++#endif
++        case AF_INET:
++            ((struct sockaddr_in *)addr)->sin_port = port;
++        break;
++    }
++}
++
++VLC_API char *vlc_getProxyUrl(const char *);
++
++# ifdef __cplusplus
++}
++# endif
++
++/** @} */
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_objects.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_objects.h
+new file mode 100644
+index 0000000..53a65dc
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_objects.h
+@@ -0,0 +1,75 @@
++/*****************************************************************************
++ * vlc_objects.h: vlc_object_t definition and manipulation methods
++ *****************************************************************************
++ * Copyright (C) 2002-2008 VLC authors and VideoLAN
++ * $Id: 4a2814187a5cc68b0e65d6dce3dd4a0d9e8fbe59 $
++ *
++ * Authors: Samuel Hocevar <sam@zoy.org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++/**
++ * \defgroup vlc_object VLC objects
++ * @{
++ * \file
++ * Common VLC object defintions
++ */
++
++/* Object flags */
++#define OBJECT_FLAGS_QUIET       0x0002
++#define OBJECT_FLAGS_NOINTERACT  0x0004
++#define OBJECT_FLAGS_INSECURE    0x1000 /* VLC 3.0 only, will be removed */
++
++/*****************************************************************************
++ * The vlc_object_t type. Yes, it's that simple :-)
++ *****************************************************************************/
++/** The main vlc_object_t structure */
++struct vlc_object_t
++{
++    VLC_COMMON_MEMBERS
++};
++
++/*****************************************************************************
++ * Prototypes
++ *****************************************************************************/
++VLC_API void *vlc_object_create( vlc_object_t *, size_t ) VLC_MALLOC VLC_USED;
++VLC_API vlc_object_t *vlc_object_find_name( vlc_object_t *, const char * ) VLC_USED VLC_DEPRECATED;
++VLC_API void * vlc_object_hold( vlc_object_t * );
++VLC_API void vlc_object_release( vlc_object_t * );
++VLC_API vlc_list_t *vlc_list_children( vlc_object_t * ) VLC_USED;
++VLC_API void vlc_list_release( vlc_list_t * );
++VLC_API char *vlc_object_get_name( const vlc_object_t * ) VLC_USED;
++#define vlc_object_get_name(o) vlc_object_get_name(VLC_OBJECT(o))
++
++#define vlc_object_create(a,b) vlc_object_create( VLC_OBJECT(a), b )
++
++#define vlc_object_find_name(a,b) \
++    vlc_object_find_name( VLC_OBJECT(a),b)
++
++#define vlc_object_hold(a) \
++    vlc_object_hold( VLC_OBJECT(a) )
++
++#define vlc_object_release(a) \
++    vlc_object_release( VLC_OBJECT(a) )
++
++#define vlc_list_children(a) \
++    vlc_list_children( VLC_OBJECT(a) )
++
++VLC_API VLC_MALLOC void *vlc_obj_malloc(vlc_object_t *, size_t);
++VLC_API VLC_MALLOC void *vlc_obj_calloc(vlc_object_t *, size_t, size_t);
++VLC_API void vlc_obj_free(vlc_object_t *, void *);
++
++/** @} */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_opengl.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_opengl.h
+new file mode 100644
+index 0000000..fdebfeb
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_opengl.h
+@@ -0,0 +1,121 @@
++/*****************************************************************************
++ * vlc_opengl.h: VLC GL API
++ *****************************************************************************
++ * Copyright (C) 2009 Laurent Aimar
++ * Copyright (C) 2011 Rémi Denis-Courmont
++ *
++ * Authors: Laurent Aimar <fenrir _AT_ videolan _DOT_ org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_GL_H
++#define VLC_GL_H 1
++
++/**
++ * \file
++ * This file defines GL structures and functions.
++ */
++
++struct vout_window_t;
++struct vout_window_cfg_t;
++
++/**
++ * A VLC GL context (and its underlying surface)
++ */
++typedef struct vlc_gl_t vlc_gl_t;
++
++struct vlc_gl_t
++{
++    VLC_COMMON_MEMBERS
++
++    struct vout_window_t *surface;
++    module_t *module;
++    void *sys;
++
++    int  (*makeCurrent)(vlc_gl_t *);
++    void (*releaseCurrent)(vlc_gl_t *);
++    void (*resize)(vlc_gl_t *, unsigned, unsigned);
++    void (*swap)(vlc_gl_t *);
++    void*(*getProcAddress)(vlc_gl_t *, const char *);
++
++    enum {
++        VLC_GL_EXT_DEFAULT,
++        VLC_GL_EXT_EGL,
++        VLC_GL_EXT_WGL,
++    } ext;
++
++    union {
++        /* if ext == VLC_GL_EXT_EGL */
++        struct {
++            /* call eglQueryString() with current display */
++            const char *(*queryString)(vlc_gl_t *, int32_t name);
++            /* call eglCreateImageKHR() with current display and context, can
++             * be NULL */
++            void *(*createImageKHR)(vlc_gl_t *, unsigned target, void *buffer,
++                                    const int32_t *attrib_list);
++            /* call eglDestroyImageKHR() with current display, can be NULL */
++            bool (*destroyImageKHR)(vlc_gl_t *, void *image);
++        } egl;
++        /* if ext == VLC_GL_EXT_WGL */
++        struct
++        {
++            const char *(*getExtensionsString)(vlc_gl_t *);
++        } wgl;
++    };
++};
++
++enum {
++    VLC_OPENGL,
++    VLC_OPENGL_ES2,
++};
++
++VLC_API vlc_gl_t *vlc_gl_Create(struct vout_window_t *, unsigned, const char *) VLC_USED;
++VLC_API void vlc_gl_Release(vlc_gl_t *);
++VLC_API void vlc_gl_Hold(vlc_gl_t *);
++
++static inline int vlc_gl_MakeCurrent(vlc_gl_t *gl)
++{
++    return gl->makeCurrent(gl);
++}
++
++static inline void vlc_gl_ReleaseCurrent(vlc_gl_t *gl)
++{
++    gl->releaseCurrent(gl);
++}
++
++static inline void vlc_gl_Resize(vlc_gl_t *gl, unsigned w, unsigned h)
++{
++    if (gl->resize != NULL)
++        gl->resize(gl, w, h);
++}
++
++static inline void vlc_gl_Swap(vlc_gl_t *gl)
++{
++    gl->swap(gl);
++}
++
++static inline void *vlc_gl_GetProcAddress(vlc_gl_t *gl, const char *name)
++{
++    return (gl->getProcAddress != NULL) ? gl->getProcAddress(gl, name) : NULL;
++}
++
++VLC_API vlc_gl_t *vlc_gl_surface_Create(vlc_object_t *,
++                                        const struct vout_window_cfg_t *,
++                                        struct vout_window_t **) VLC_USED;
++VLC_API bool vlc_gl_surface_CheckSize(vlc_gl_t *, unsigned *w, unsigned *h);
++VLC_API void vlc_gl_surface_Destroy(vlc_gl_t *);
++
++#endif /* VLC_GL_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_picture.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_picture.h
+new file mode 100644
+index 0000000..fb35adc
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_picture.h
+@@ -0,0 +1,259 @@
++/*****************************************************************************
++ * vlc_picture.h: picture definitions
++ *****************************************************************************
++ * Copyright (C) 1999 - 2009 VLC authors and VideoLAN
++ * $Id: 74f156fbbd6e6a4479754c0e79fbd5374a4a1e2e $
++ *
++ * Authors: Vincent Seguin <seguin@via.ecp.fr>
++ *          Samuel Hocevar <sam@via.ecp.fr>
++ *          Olivier Aubert <oaubert 47 videolan d07 org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_PICTURE_H
++#define VLC_PICTURE_H 1
++
++/**
++ * \file
++ * This file defines picture structures and functions in vlc
++ */
++
++#include <vlc_es.h>
++
++/** Description of a planar graphic field */
++typedef struct plane_t
++{
++    uint8_t *p_pixels;                        /**< Start of the plane's data */
++
++    /* Variables used for fast memcpy operations */
++    int i_lines;           /**< Number of lines, including margins */
++    int i_pitch;           /**< Number of bytes in a line, including margins */
++
++    /** Size of a macropixel, defaults to 1 */
++    int i_pixel_pitch;
++
++    /* Variables used for pictures with margins */
++    int i_visible_lines;            /**< How many visible lines are there ? */
++    int i_visible_pitch;            /**< How many visible pixels are there ? */
++
++} plane_t;
++
++/**
++ * Maximum number of plane for a picture
++ */
++#define PICTURE_PLANE_MAX (VOUT_MAX_PLANES)
++
++typedef struct picture_context_t
++{
++    void (*destroy)(struct picture_context_t *);
++    struct picture_context_t *(*copy)(struct picture_context_t *);
++} picture_context_t;
++
++/**
++ * Video picture
++ */
++struct picture_t
++{
++    /**
++     * The properties of the picture
++     */
++    video_frame_format_t format;
++
++    plane_t         p[PICTURE_PLANE_MAX];     /**< description of the planes */
++    int             i_planes;                /**< number of allocated planes */
++
++    /** \name Picture management properties
++     * These properties can be modified using the video output thread API,
++     * but should never be written directly */
++    /**@{*/
++    mtime_t         date;                                  /**< display date */
++    bool            b_force;
++    /**@}*/
++
++    /** \name Picture dynamic properties
++     * Those properties can be changed by the decoder
++     * @{
++     */
++    bool            b_progressive;          /**< is it a progressive frame ? */
++    bool            b_top_field_first;             /**< which field is first */
++    unsigned int    i_nb_fields;                  /**< # of displayed fields */
++    picture_context_t *context;      /**< video format-specific data pointer */
++    /**@}*/
++
++    /** Private data - the video output plugin might want to put stuff here to
++     * keep track of the picture */
++    picture_sys_t * p_sys;
++
++    /** Next picture in a FIFO a pictures */
++    struct picture_t *p_next;
++};
++
++/**
++ * This function will create a new picture.
++ * The picture created will implement a default release management compatible
++ * with picture_Hold and picture_Release. This default management will release
++ * p_sys, gc.p_sys fields if non NULL.
++ */
++VLC_API picture_t * picture_New( vlc_fourcc_t i_chroma, int i_width, int i_height, int i_sar_num, int i_sar_den ) VLC_USED;
++
++/**
++ * This function will create a new picture using the given format.
++ *
++ * When possible, it is preferred to use this function over picture_New
++ * as more information about the format is kept.
++ */
++VLC_API picture_t * picture_NewFromFormat( const video_format_t *p_fmt ) VLC_USED;
++
++/**
++ * Resource for a picture.
++ */
++typedef struct
++{
++    picture_sys_t *p_sys;
++    void (*pf_destroy)(picture_t *);
++
++    /* Plane resources
++     * XXX all fields MUST be set to the right value.
++     */
++    struct
++    {
++        uint8_t *p_pixels;  /**< Start of the plane's data */
++        int i_lines;        /**< Number of lines, including margins */
++        int i_pitch;        /**< Number of bytes in a line, including margins */
++    } p[PICTURE_PLANE_MAX];
++
++} picture_resource_t;
++
++/**
++ * This function will create a new picture using the provided resource.
++ *
++ * If the resource is NULL then a plain picture_NewFromFormat is returned.
++ */
++VLC_API picture_t * picture_NewFromResource( const video_format_t *, const picture_resource_t * ) VLC_USED;
++
++/**
++ * This function will increase the picture reference count.
++ * It will not have any effect on picture obtained from vout
++ *
++ * It returns the given picture for convenience.
++ */
++VLC_API picture_t *picture_Hold( picture_t *p_picture );
++
++/**
++ * This function will release a picture.
++ * It will not have any effect on picture obtained from vout
++ */
++VLC_API void picture_Release( picture_t *p_picture );
++
++/**
++ * This function will copy all picture dynamic properties.
++ */
++VLC_API void picture_CopyProperties( picture_t *p_dst, const picture_t *p_src );
++
++/**
++ * This function will reset a picture information (properties and quantizers).
++ * It is sometimes useful for reusing pictures (like from a pool).
++ */
++VLC_API void picture_Reset( picture_t * );
++
++/**
++ * This function will copy the picture pixels.
++ * You can safely copy between pictures that do not have the same size,
++ * only the compatible(smaller) part will be copied.
++ */
++VLC_API void picture_CopyPixels( picture_t *p_dst, const picture_t *p_src );
++VLC_API void plane_CopyPixels( plane_t *p_dst, const plane_t *p_src );
++
++/**
++ * This function will copy both picture dynamic properties and pixels.
++ * You have to notice that sometime a simple picture_Hold may do what
++ * you want without the copy overhead.
++ * Provided for convenience.
++ *
++ * \param p_dst pointer to the destination picture.
++ * \param p_src pointer to the source picture.
++ */
++VLC_API void picture_Copy( picture_t *p_dst, const picture_t *p_src );
++
++/**
++ * Perform a shallow picture copy
++ *
++ * This function makes a shallow copy of an existing picture. The same planes
++ * and resources will be used, and the cloned picture reference count will be
++ * incremented.
++ *
++ * \return A clone picture on success, NULL on error.
++ */
++VLC_API picture_t *picture_Clone(picture_t *pic);
++
++/**
++ * This function will export a picture to an encoded bitstream.
++ *
++ * pp_image will contain the encoded bitstream in psz_format format.
++ *
++ * p_fmt can be NULL otherwise it will be set with the format used for the
++ * picture before encoding.
++ *
++ * i_override_width/height allow to override the width and/or the height of the
++ * picture to be encoded:
++ *  - if strictly lower than 0, the original dimension will be used.
++ *  - if equal to 0, it will be deduced from the other dimension which must be
++ *  different to 0.
++ *  - if strictly higher than 0, it will override the dimension.
++ * If at most one of them is > 0 then the picture aspect ratio will be kept.
++ */
++VLC_API int picture_Export( vlc_object_t *p_obj, block_t **pp_image, video_format_t *p_fmt, picture_t *p_picture, vlc_fourcc_t i_format, int i_override_width, int i_override_height );
++
++/**
++ * This function will setup all fields of a picture_t without allocating any
++ * memory.
++ * XXX The memory must already be initialized.
++ * It does not need to be released.
++ *
++ * It will return VLC_EGENERIC if the core does not understand the requested
++ * format.
++ *
++ * It can be useful to get the properties of planes.
++ */
++VLC_API int picture_Setup( picture_t *, const video_format_t * );
++
++
++/*****************************************************************************
++ * Shortcuts to access image components
++ *****************************************************************************/
++
++/* Plane indices */
++enum
++{
++    Y_PLANE = 0,
++    U_PLANE = 1,
++    V_PLANE = 2,
++    A_PLANE = 3,
++};
++
++/* Shortcuts */
++#define Y_PIXELS     p[Y_PLANE].p_pixels
++#define Y_PITCH      p[Y_PLANE].i_pitch
++#define U_PIXELS     p[U_PLANE].p_pixels
++#define U_PITCH      p[U_PLANE].i_pitch
++#define V_PIXELS     p[V_PLANE].p_pixels
++#define V_PITCH      p[V_PLANE].i_pitch
++#define A_PIXELS     p[A_PLANE].p_pixels
++#define A_PITCH      p[A_PLANE].i_pitch
++
++/**@}*/
++
++#endif /* VLC_PICTURE_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_picture_fifo.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_picture_fifo.h
+new file mode 100644
+index 0000000..d337a3b
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_picture_fifo.h
+@@ -0,0 +1,89 @@
++/*****************************************************************************
++ * vlc_picture_fifo.h: picture fifo definitions
++ *****************************************************************************
++ * Copyright (C) 2009 VLC authors and VideoLAN
++ * $Id: 73d1b20c279f628cf94bc7cfc83b2548878bcc07 $
++ *
++ * Authors: Laurent Aimar <fenrir _AT_ videolan _DOT_ org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_PICTURE_FIFO_H
++#define VLC_PICTURE_FIFO_H 1
++
++/**
++ * \file
++ * This file defines picture fifo structures and functions in vlc
++ */
++
++#include <vlc_picture.h>
++
++/**
++ * Picture fifo handle
++ *
++ * It is thread safe (push/pop).
++ */
++typedef struct picture_fifo_t picture_fifo_t;
++
++/**
++ * It creates an empty picture_fifo_t.
++ */
++VLC_API picture_fifo_t * picture_fifo_New( void ) VLC_USED;
++
++/**
++ * It destroys a fifo created by picture_fifo_New.
++ *
++ * All pictures inside the fifo will be released by picture_Release.
++ */
++VLC_API void picture_fifo_Delete( picture_fifo_t * );
++
++/**
++ * It retreives a picture_t from the fifo.
++ *
++ * If the fifo is empty, it return NULL without waiting.
++ */
++VLC_API picture_t * picture_fifo_Pop( picture_fifo_t * ) VLC_USED;
++
++/**
++ * It returns the first picture_t pointer from the fifo but does not
++ * remove it. The picture returned has been hold for you so you
++ * must call picture_Release on it.
++ *
++ * If the fifo is empty, it return NULL without waiting.
++ */
++VLC_API picture_t * picture_fifo_Peek( picture_fifo_t * ) VLC_USED;
++
++/**
++ * It saves a picture_t into the fifo.
++ */
++VLC_API void picture_fifo_Push( picture_fifo_t *, picture_t * );
++
++/**
++ * It release all picture inside the fifo that have a lower or equal date
++ * if flush_before or higher or equal to if not flush_before than the given one.
++ *
++ * All pictures inside the fifo will be released by picture_Release.
++ */
++VLC_API void picture_fifo_Flush( picture_fifo_t *, mtime_t date, bool flush_before );
++
++/**
++ * It applies a delta on all the picture timestamp.
++ */
++VLC_API void picture_fifo_OffsetDate( picture_fifo_t *, mtime_t delta );
++
++
++#endif /* VLC_PICTURE_FIFO_H */
++
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_picture_pool.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_picture_pool.h
+new file mode 100644
+index 0000000..73f3f6c
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_picture_pool.h
+@@ -0,0 +1,189 @@
++/*****************************************************************************
++ * vlc_picture_pool.h: picture pool definitions
++ *****************************************************************************
++ * Copyright (C) 2009 VLC authors and VideoLAN
++ * $Id: 8b04370bfb320749eec6bcf09aaf0ba76b78058f $
++ *
++ * Authors: Laurent Aimar <fenrir _AT_ videolan _DOT_ org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_PICTURE_POOL_H
++#define VLC_PICTURE_POOL_H 1
++
++/**
++ * \file
++ * This file defines picture pool structures and functions in vlc
++ */
++
++#include <vlc_picture.h>
++
++/**
++ * Picture pool handle
++ */
++typedef struct picture_pool_t picture_pool_t;
++
++/**
++ * Picture pool configuration
++ */
++typedef struct {
++    unsigned  picture_count;
++    picture_t *const *picture;
++
++    int       (*lock)(picture_t *);
++    void      (*unlock)(picture_t *);
++} picture_pool_configuration_t;
++
++/**
++ * Creates a pool of preallocated pictures. Free pictures can be allocated from
++ * the pool, and are returned to the pool when they are no longer referenced.
++ *
++ * This avoids allocating and deallocationg pictures repeatedly, and ensures
++ * that memory consumption remains within limits.
++ *
++ * To obtain a picture from the pool, use picture_pool_Get(). To increase and
++ * decrease the reference count, use picture_Hold() and picture_Release()
++ * respectively.
++ *
++ * If defined, picture_pool_configuration_t::lock will be called before
++ * a picture is used, and picture_pool_configuration_t::unlock will be called
++ * as soon as a picture is returned to the pool.
++ * Those callbacks can modify picture_t::p and access picture_t::p_sys.
++ *
++ * @return A pointer to the new pool on success, or NULL on error
++ * (pictures are <b>not</b> released on error).
++ */
++VLC_API picture_pool_t * picture_pool_NewExtended( const picture_pool_configuration_t * ) VLC_USED;
++
++/**
++ * Creates a picture pool with pictures in a given array.
++ * This is a convenience wrapper for picture_pool_NewExtended() without the
++ * lock and unlock callbacks.
++ *
++ * @param count number of pictures in the array
++ * @param tab array of pictures
++ *
++ * @return a pointer to the new pool on success, or NULL on error
++ * (pictures are <b>not</b> released on error)
++ */
++VLC_API picture_pool_t * picture_pool_New(unsigned count,
++                                          picture_t *const *tab) VLC_USED;
++
++/**
++ * Allocates pictures from the heap and creates a picture pool with them.
++ * This is a convenience wrapper for picture_NewFromFormat() and
++ * picture_pool_New().
++ *
++ * @param fmt video format of pictures to allocate from the heap
++ * @param count number of pictures to allocate
++ *
++ * @return a pointer to the new pool on success, NULL on error
++ */
++VLC_API picture_pool_t * picture_pool_NewFromFormat(const video_format_t *fmt,
++                                                    unsigned count) VLC_USED;
++
++/**
++ * Releases a pool created by picture_pool_NewExtended(), picture_pool_New()
++ * or picture_pool_NewFromFormat().
++ *
++ * @note If there are no pending references to the pooled pictures, and the
++ * picture_resource_t.pf_destroy callback was not NULL, it will be invoked.
++ * Otherwise the default callback will be used.
++ *
++ * @warning If there are pending references (a.k.a. late pictures), the
++ * pictures will remain valid until the all pending references are dropped by
++ * picture_Release().
++ */
++VLC_API void picture_pool_Release( picture_pool_t * );
++
++/**
++ * Obtains a picture from a pool if any is immediately available.
++ *
++ * The picture must be released with picture_Release().
++ *
++ * @return a picture, or NULL if all pictures in the pool are allocated
++ *
++ * @note This function is thread-safe.
++ */
++VLC_API picture_t * picture_pool_Get( picture_pool_t * ) VLC_USED;
++
++/**
++ * Obtains a picture from a pool.
++ *
++ * The picture must be released with picture_Release().
++ *
++ * @return a picture or NULL on memory error
++ *
++ * @note This function is thread-safe.
++ */
++VLC_API picture_t *picture_pool_Wait(picture_pool_t *) VLC_USED;
++
++/**
++ * Enumerates all pictures in a pool, both free and allocated.
++ *
++ * @param cb callback to invoke once for each picture
++ * @param data opaque data parameter for the callback (first argument)
++ *
++ * @note Allocated pictures may be accessed asynchronously by other threads.
++ * Therefore, only read-only picture parameters can be read by the callback,
++ * typically picture_t.p_sys.
++ * Provided those rules are respected, the function is thread-safe.
++ */
++VLC_API void picture_pool_Enum( picture_pool_t *,
++                                void (*cb)(void *, picture_t *), void *data );
++
++/**
++ * Cancel the picture pool.
++ *
++ * It won't return any pictures via picture_pool_Get or picture_pool_Wait if
++ * canceled is true. This function will also unblock picture_pool_Wait.
++ * picture_pool_Reset will also reset the cancel state to false.
++ */
++void picture_pool_Cancel( picture_pool_t *, bool canceled );
++
++/**
++ * Test if a picture belongs to the picture pool
++ *
++ * FIXME: remove this function when the vout_PutPicture() hack is fixed.
++ */
++bool picture_pool_OwnsPic( picture_pool_t *, picture_t *);
++
++/**
++ * Reserves pictures from a pool and creates a new pool with those.
++ *
++ * When the new pool is released, pictures are returned to the master pool.
++ * If the master pool was already released, pictures will be destroyed.
++ *
++ * @param count number of picture to reserve
++ *
++ * @return the new pool, or NULL if there were not enough pictures available
++ * or on error
++ *
++ * @note This function is thread-safe (but it might return NULL if other
++ * threads have already allocated too many pictures).
++ */
++VLC_API picture_pool_t * picture_pool_Reserve(picture_pool_t *, unsigned count)
++VLC_USED;
++
++/**
++ * @return the total number of pictures in the given pool
++ * @note This function is thread-safe.
++ */
++VLC_API unsigned picture_pool_GetSize(const picture_pool_t *);
++
++
++#endif /* VLC_PICTURE_POOL_H */
++
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_playlist.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_playlist.h
+new file mode 100644
+index 0000000..e19d4b9
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_playlist.h
+@@ -0,0 +1,443 @@
++/*****************************************************************************
++ * vlc_playlist.h : Playlist functions
++ *****************************************************************************
++ * Copyright (C) 1999-2004 VLC authors and VideoLAN
++ * $Id: 9498e622cac22fc9c70cb4b298cca02722092d2e $
++ *
++ * Authors: Samuel Hocevar <sam@zoy.org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_PLAYLIST_H_
++#define VLC_PLAYLIST_H_
++
++# ifdef __cplusplus
++extern "C" {
++# endif
++
++#include <vlc_events.h>
++#include <vlc_aout.h>
++
++TYPEDEF_ARRAY(playlist_item_t*, playlist_item_array_t)
++
++struct intf_thread_t;
++
++/**
++ * \defgroup playlist VLC playlist
++ * VLC playlist controls
++ * @{
++ * \file
++ * VLC playlist control interface
++ *
++ * The VLC playlist system has a tree structure. This allows advanced
++ * categorization, like for SAP streams (which are grouped by "sap groups").
++ *
++ * The base structure for all playlist operations is the playlist_item_t.
++ * This is essentially a node within the playlist tree. Each playlist item
++ * references an input_item_t which contains the input stream info, such as
++ * location, name and meta-data.
++ *
++ * A playlist item is uniquely identified by its input item:
++ * \ref playlist_ItemGetByInput(). A single input item cannot be used by more
++ * than one playlist item at a time; if necessary, a copy of the input item can
++ * be made instead.
++ *
++ * The same playlist tree is visible to all user interfaces. To arbitrate
++ * access, a lock is used, see \ref playlist_Lock() and \ref playlist_Unlock().
++ *
++ * Under the playlist root item node, the top-level items are the main
++ * media sources and include:
++ * - the actual playlist,
++ * - the media library,
++ * - the service discovery root node, whose children are services discovery
++ *   module instances.
++ *
++ * So, here is an example:
++ * \verbatim
++ * Inputs array
++ *  - input 1 -> name = foo 1 uri = ...
++ *  - input 2 -> name = foo 2 uri = ...
++ *
++ * Playlist items tree
++ * - playlist (id 1)
++ *    - category 1 (id 2)
++ *      - foo 2 (id 6 - input 2)
++ * - media library (id 2)
++ *    - foo 1 (id 5 - input 1)
++ * \endverbatim
++ *
++ * Sometimes, an item creates subitems. This happens for the directory access
++ * for example. In that case, if the item is under the "playlist" top-level
++ * item and playlist is configured to be flat then the item will be deleted and
++ * replaced with new subitems. If the item is under another top-level item, it
++ * will be transformed to a node and removed from the list of all items without
++ * nodes.
++ *
++ * For "standard" item addition, you can use playlist_Add(), playlist_AddExt()
++ * (more options) or playlist_AddInput() if you already created your input
++ * item. This will add the item at the root of "Playlist" or of "Media library"
++ * in each of the two trees.
++ *
++ * You can create nodes with playlist_NodeCreate() and can create items from
++ * existing input items to be placed under any node with
++ * playlist_NodeAddInput().
++ *
++ * To delete an item, use playlist_NodeDelete( p_item ).
++ *
++ * The playlist defines the following event variables:
++ *
++ * - "item-change": It will contain a pointer to the input_item_t of a
++ * changed input item monitored by the playlist.
++ *
++ * - "playlist-item-append": It will contain a pointer to a playlist_item_t.
++ * - "playlist-item-deleted": It will contain a pointer to the playlist_item_t
++ * about to be deleted.
++ *
++ * - "leaf-to-parent": It will contain the playlist_item_t->i_id of an item that is transformed
++ *   into a node.
++ *
++ * The playlist contains rate-variable which is propagated to current input if
++ * available also rate-slower/rate-faster is in use.
++ */
++
++/** Helper structure to export to file part of the playlist */
++typedef struct playlist_export_t
++{
++    VLC_COMMON_MEMBERS
++    char *base_url;
++    FILE *p_file;
++    playlist_item_t *p_root;
++} playlist_export_t;
++
++/** playlist item / node */
++struct playlist_item_t
++{
++    input_item_t           *p_input;    /**< Linked input item */
++
++    playlist_item_t      **pp_children; /**< Children nodes/items */
++    playlist_item_t       *p_parent;    /**< Item parent */
++    int                    i_children;  /**< Number of children, -1 if not a node */
++    unsigned               i_nb_played; /**< Times played */
++
++    int                    i_id;        /**< Playlist item specific id */
++    uint8_t                i_flags;     /**< Flags \see playlist_item_flags_e */
++};
++
++typedef enum {
++    PLAYLIST_DBL_FLAG          = 0x04,  /**< Is it disabled ? */
++    PLAYLIST_RO_FLAG           = 0x08,  /**< Write-enabled ? */
++    PLAYLIST_SUBITEM_STOP_FLAG = 0x40,  /**< Must playlist stop if the item gets subitems ?*/
++    PLAYLIST_NO_INHERIT_FLAG   = 0x80,  /**< Will children inherit flags the R/O flag ? */
++} playlist_item_flags_e;
++
++/** Playlist status */
++typedef enum
++{ PLAYLIST_STOPPED,PLAYLIST_RUNNING,PLAYLIST_PAUSED } playlist_status_t;
++
++/** Structure containing information about the playlist */
++struct playlist_t
++{
++    VLC_COMMON_MEMBERS
++
++    playlist_item_array_t items; /**< Arrays of items */
++
++    playlist_item_array_t current; /**< Items currently being played */
++    int                   i_current_index; /**< Index in current array */
++
++    /* Predefined items */
++    playlist_item_t  root;
++    playlist_item_t *p_playing;
++    playlist_item_t *p_media_library;
++};
++
++/* A bit of macro magic to generate an enum out of the following list,
++ * and later, to generate a list of static functions out of the same list.
++ * There is also SORT_RANDOM, which is always last and handled specially.
++ */
++#define VLC_DEFINE_SORT_FUNCTIONS \
++    DEF( SORT_ID )\
++    DEF( SORT_TITLE )\
++    DEF( SORT_TITLE_NODES_FIRST )\
++    DEF( SORT_ARTIST )\
++    DEF( SORT_GENRE )\
++    DEF( SORT_DURATION )\
++    DEF( SORT_TITLE_NUMERIC )\
++    DEF( SORT_ALBUM )\
++    DEF( SORT_TRACK_NUMBER )\
++    DEF( SORT_DESCRIPTION )\
++    DEF( SORT_RATING )\
++    DEF( SORT_URI )\
++    DEF( SORT_DISC_NUMBER )\
++    DEF( SORT_DATE )
++
++#define DEF( s ) s,
++enum
++{
++    VLC_DEFINE_SORT_FUNCTIONS
++    SORT_RANDOM,
++    NUM_SORT_FNS=SORT_RANDOM
++};
++#undef  DEF
++#ifndef VLC_INTERNAL_PLAYLIST_SORT_FUNCTIONS
++#undef  VLC_DEFINE_SORT_FUNCTIONS
++#endif
++
++enum
++{
++    ORDER_NORMAL = 0,
++    ORDER_REVERSE = 1,
++};
++
++#define PLAYLIST_END           -1
++
++enum pl_locked_state
++{
++    pl_Locked = true,
++    pl_Unlocked = false
++};
++
++/*****************************************************************************
++ * Prototypes
++ *****************************************************************************/
++
++/* Helpers */
++#define PL_LOCK playlist_Lock( p_playlist )
++#define PL_UNLOCK playlist_Unlock( p_playlist )
++#define PL_ASSERT_LOCKED playlist_AssertLocked( p_playlist )
++
++/** Playlist commands */
++enum {
++    PLAYLIST_PLAY,      /**< No arg.                            res=can fail*/
++    PLAYLIST_VIEWPLAY,  /**< arg1= playlist_item_t*,*/
++                        /**  arg2 = playlist_item_t*          , res=can fail */
++    PLAYLIST_TOGGLE_PAUSE, /**< No arg                          res=can fail */
++    PLAYLIST_STOP,      /**< No arg                             res=can fail*/
++    PLAYLIST_SKIP,      /**< arg1=int,                          res=can fail*/
++    PLAYLIST_PAUSE,     /**< No arg */
++    PLAYLIST_RESUME,    /**< No arg */
++};
++
++#define playlist_Play(p) playlist_Control(p,PLAYLIST_PLAY, pl_Unlocked )
++#define playlist_TogglePause(p) \
++        playlist_Control(p, PLAYLIST_TOGGLE_PAUSE, pl_Unlocked)
++#define playlist_Stop(p) playlist_Control(p,PLAYLIST_STOP, pl_Unlocked )
++#define playlist_Next(p) playlist_Control(p,PLAYLIST_SKIP, pl_Unlocked, 1)
++#define playlist_Prev(p) playlist_Control(p,PLAYLIST_SKIP, pl_Unlocked, -1)
++#define playlist_Skip(p,i) playlist_Control(p,PLAYLIST_SKIP, pl_Unlocked,  (i) )
++#define playlist_Pause(p) \
++        playlist_Control(p, PLAYLIST_PAUSE, pl_Unlocked)
++#define playlist_Resume(p) \
++        playlist_Control(p, PLAYLIST_RESUME, pl_Unlocked)
++
++/**
++ * Locks the playlist.
++ *
++ * This function locks the playlist. While the playlist is locked, no other
++ * thread can modify the playlist tree layout or current playing item and node.
++ *
++ * Locking the playlist is necessary before accessing, either for reading or
++ * writing, any playlist item.
++ *
++ * \note Because of the potential for lock inversion / deadlocks, locking the
++ * playlist shall not be attemped while holding an input item lock. An input
++ * item lock can be acquired while holding the playlist lock.
++ *
++ * While holding the playlist lock, a thread shall not attempt to:
++ * - probe, initialize or deinitialize a module or a plugin,
++ * - install or deinstall a variable or event callback,
++ * - set a variable or trigger a variable callback, with the sole exception
++ *   of the playlist core triggering add/remove/leaf item callbacks,
++ * - invoke a module/plugin callback other than:
++ *   - playlist export,
++ *   - logger message callback.
++ */
++VLC_API void playlist_Lock( playlist_t * );
++
++/**
++ * Unlocks the playlist.
++ *
++ * This function unlocks the playlist, allowing other threads to lock it. The
++ * calling thread must have called playlist_Lock() before.
++ *
++ * This function invalidates all or any playlist item pointers.
++ * There are no ways to ensure that playlist items are not modified or deleted
++ * by another thread past this function call.
++ *
++ * To retain a reference to a playlist item while not holding the playlist
++ * lock, a thread should take a reference to the input item within the
++ * playlist item before unlocking. If this is not practical, then the thread
++ * can store the playlist item ID (i_id) before unlocking.
++ * Either way, this will not ensure that the playlist item is not deleted, so
++ * the thread must be ready to handle that case later when calling
++ * playlist_ItemGetByInput() or playlist_ItemGetById().
++ *
++ * Furthermore, if ID is used, then the playlist item might be deleted, and
++ * another item could be assigned the same ID. To avoid that problem, use
++ * the input item instead of the ID.
++ */
++VLC_API void playlist_Unlock( playlist_t * );
++
++VLC_API void playlist_AssertLocked( playlist_t * );
++VLC_API void playlist_Deactivate( playlist_t * );
++
++/**
++ * Do a playlist action.
++ * If there is something in the playlist then you can do playlist actions.
++ * Possible queries are listed in vlc_common.h
++ * \param p_playlist the playlist to do the command on
++ * \param i_query the command to do
++ * \param b_locked TRUE if playlist is locked when entering this function
++ * \param variable number of arguments
++ */
++VLC_API void playlist_Control( playlist_t *p_playlist, int i_query, int b_locked, ...  );
++
++static inline void playlist_ViewPlay(playlist_t *pl, playlist_item_t *node,
++                                     playlist_item_t *item)
++{
++    playlist_Control(pl, PLAYLIST_VIEWPLAY, pl_Locked, node, item);
++}
++
++/** Get current playing input. The object is retained.
++ */
++VLC_API input_thread_t * playlist_CurrentInput( playlist_t *p_playlist ) VLC_USED;
++VLC_API input_thread_t *playlist_CurrentInputLocked( playlist_t *p_playlist ) VLC_USED;
++
++/** Get the duration of all items in a node.
++ */
++VLC_API mtime_t playlist_GetNodeDuration( playlist_item_t * );
++
++/** Clear the playlist
++ * \param b_locked TRUE if playlist is locked when entering this function
++ */
++VLC_API void playlist_Clear( playlist_t *, bool );
++
++/* Playlist sorting */
++VLC_API int playlist_TreeMove( playlist_t *, playlist_item_t *, playlist_item_t *, int );
++VLC_API int playlist_TreeMoveMany( playlist_t *, int, playlist_item_t **, playlist_item_t *, int );
++VLC_API int playlist_RecursiveNodeSort( playlist_t *, playlist_item_t *,int, int );
++
++VLC_API playlist_item_t * playlist_CurrentPlayingItem( playlist_t * ) VLC_USED;
++VLC_API int playlist_Status( playlist_t * );
++
++/**
++ * Export a node of the playlist to a certain type of playlistfile
++ * \param b_playlist true for the playlist, false for the media library
++ * \param psz_filename the location where the exported file will be saved
++ * \param psz_type the type of playlist file to create (m3u, pls, ..)
++ * \return VLC_SUCCESS on success
++ */
++VLC_API int playlist_Export( playlist_t *p_playlist, const char *psz_name,
++                             bool b_playlist, const char *psz_type );
++
++/**
++ * Open a playlist file, add its content to the current playlist
++ */
++VLC_API int playlist_Import( playlist_t *p_playlist, const char *psz_file );
++
++/********************** Services discovery ***********************/
++
++/** Add a service discovery module */
++VLC_API int playlist_ServicesDiscoveryAdd(playlist_t *, const char *);
++/** Remove a services discovery module by name */
++VLC_API int playlist_ServicesDiscoveryRemove(playlist_t *, const char *);
++/** Check whether a given SD is loaded */
++VLC_API bool playlist_IsServicesDiscoveryLoaded( playlist_t *,const char *) VLC_DEPRECATED;
++/** Query a services discovery */
++VLC_API int playlist_ServicesDiscoveryControl( playlist_t *, const char *, int, ... );
++
++/********************** Renderer ***********************/
++/**
++ * Sets a renderer or remove the current one
++ * @param p_item    The renderer item to be used, or NULL to disable the current
++ *                  one. If a renderer is provided, its reference count will be
++ *                  incremented.
++ */
++VLC_API int playlist_SetRenderer( playlist_t* p_pl, vlc_renderer_item_t* p_item );
++
++
++/********************************************************
++ * Item management
++ ********************************************************/
++
++/******************** Item addition ********************/
++VLC_API int playlist_Add( playlist_t *, const char *, bool );
++VLC_API int playlist_AddExt( playlist_t *, const char *, const char *, bool, int, const char *const *, unsigned, bool );
++VLC_API int playlist_AddInput( playlist_t *, input_item_t *, bool, bool );
++VLC_API playlist_item_t * playlist_NodeAddInput( playlist_t *, input_item_t *, playlist_item_t *, int );
++VLC_API int playlist_NodeAddCopy( playlist_t *, playlist_item_t *, playlist_item_t *, int );
++
++/********************************** Item search *************************/
++VLC_API playlist_item_t * playlist_ItemGetById(playlist_t *, int ) VLC_USED;
++VLC_API playlist_item_t *playlist_ItemGetByInput(playlist_t *,
++                                                 const input_item_t * )
++VLC_USED;
++
++VLC_API int playlist_LiveSearchUpdate(playlist_t *, playlist_item_t *, const char *, bool );
++
++/********************************************************
++ * Tree management
++ ********************************************************/
++/* Node management */
++VLC_API playlist_item_t * playlist_NodeCreate( playlist_t *, const char *, playlist_item_t * p_parent, int i_pos, int i_flags );
++VLC_API playlist_item_t * playlist_ChildSearchName(playlist_item_t*, const char* ) VLC_USED;
++VLC_API void playlist_NodeDelete( playlist_t *, playlist_item_t * );
++
++/**************************
++ * Audio output management
++ **************************/
++
++VLC_API audio_output_t *playlist_GetAout( playlist_t * );
++
++VLC_API float playlist_VolumeGet( playlist_t * );
++VLC_API int playlist_VolumeSet( playlist_t *, float );
++VLC_API int playlist_VolumeUp( playlist_t *, int, float * );
++#define playlist_VolumeDown(a, b, c) playlist_VolumeUp(a, -(b), c)
++VLC_API int playlist_MuteSet( playlist_t *, bool );
++VLC_API int playlist_MuteGet( playlist_t * );
++
++static inline int playlist_MuteToggle( playlist_t *pl )
++{
++    int val = playlist_MuteGet( pl );
++    if (val >= 0)
++        val = playlist_MuteSet( pl, !val );
++    return val;
++}
++
++VLC_API void playlist_EnableAudioFilter( playlist_t *, const char *, bool );
++
++/***********************************************************************
++ * Inline functions
++ ***********************************************************************/
++/** Tell if the playlist is empty */
++static inline bool playlist_IsEmpty( playlist_t *p_playlist )
++{
++    PL_ASSERT_LOCKED;
++    return p_playlist->items.i_size == 0;
++}
++
++/** Tell the number of items in the current playing context */
++static inline int playlist_CurrentSize( playlist_t *p_playlist )
++{
++    PL_ASSERT_LOCKED;
++    return p_playlist->current.i_size;
++}
++
++/** @} */
++# ifdef __cplusplus
++}
++# endif
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_plugin.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_plugin.h
+new file mode 100644
+index 0000000..ce28562
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_plugin.h
+@@ -0,0 +1,557 @@
++/*****************************************************************************
++ * vlc_plugin.h : Macros used from within a module.
++ *****************************************************************************
++ * Copyright (C) 2001-2006 VLC authors and VideoLAN
++ * Copyright © 2007-2009 Rémi Denis-Courmont
++ *
++ * Authors: Samuel Hocevar <sam@zoy.org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef LIBVLC_MODULES_MACROS_H
++# define LIBVLC_MODULES_MACROS_H 1
++
++/**
++ * \file
++ * This file implements plugin (module) macros used to define a vlc module.
++ */
++
++enum vlc_module_properties
++{
++    VLC_MODULE_CREATE,
++    VLC_CONFIG_CREATE,
++
++    /* DO NOT EVER REMOVE, INSERT OR REPLACE ANY ITEM! It would break the ABI!
++     * Append new items at the end ONLY. */
++    VLC_MODULE_CPU_REQUIREMENT=0x100,
++    VLC_MODULE_SHORTCUT,
++    VLC_MODULE_CAPABILITY,
++    VLC_MODULE_SCORE,
++    VLC_MODULE_CB_OPEN,
++    VLC_MODULE_CB_CLOSE,
++    VLC_MODULE_NO_UNLOAD,
++    VLC_MODULE_NAME,
++    VLC_MODULE_SHORTNAME,
++    VLC_MODULE_DESCRIPTION,
++    VLC_MODULE_HELP,
++    VLC_MODULE_TEXTDOMAIN,
++    /* Insert new VLC_MODULE_* here */
++
++    /* DO NOT EVER REMOVE, INSERT OR REPLACE ANY ITEM! It would break the ABI!
++     * Append new items at the end ONLY. */
++    VLC_CONFIG_NAME=0x1000,
++    /* command line name (args=const char *) */
++
++    VLC_CONFIG_VALUE,
++    /* actual value (args=int64_t/double/const char *) */
++
++    VLC_CONFIG_RANGE,
++    /* minimum value (args=int64_t/double/const char * twice) */
++
++    VLC_CONFIG_ADVANCED,
++    /* enable advanced flag (args=none) */
++
++    VLC_CONFIG_VOLATILE,
++    /* don't write variable to storage (args=none) */
++
++    VLC_CONFIG_PERSISTENT_OBSOLETE,
++    /* unused (ignored) */
++
++    VLC_CONFIG_PRIVATE,
++    /* hide from user (args=none) */
++
++    VLC_CONFIG_REMOVED,
++    /* tag as no longer supported (args=none) */
++
++    VLC_CONFIG_CAPABILITY,
++    /* capability for a module or list thereof (args=const char*) */
++
++    VLC_CONFIG_SHORTCUT,
++    /* one-character (short) command line option name (args=char) */
++
++    VLC_CONFIG_OLDNAME_OBSOLETE,
++    /* unused (ignored) */
++
++    VLC_CONFIG_SAFE,
++    /* tag as modifiable by untrusted input item "sources" (args=none) */
++
++    VLC_CONFIG_DESC,
++    /* description (args=const char *, const char *, const char *) */
++
++    VLC_CONFIG_LIST_OBSOLETE,
++    /* unused (ignored) */
++
++    VLC_CONFIG_ADD_ACTION_OBSOLETE,
++    /* unused (ignored) */
++
++    VLC_CONFIG_LIST,
++    /* list of suggested values
++     * (args=size_t, const <type> *, const char *const *) */
++
++    VLC_CONFIG_LIST_CB,
++    /* callback for suggested values
++     * (args=const char *, size_t (*)(vlc_object_t *, <type> **, char ***)) */
++
++    /* Insert new VLC_CONFIG_* here */
++};
++
++/* Configuration hint types */
++#define CONFIG_HINT_CATEGORY                0x02  /* Start of new category */
++#define CONFIG_HINT_USAGE                   0x05  /* Usage information */
++
++#define CONFIG_CATEGORY                     0x06 /* Set category */
++#define CONFIG_SUBCATEGORY                  0x07 /* Set subcategory */
++#define CONFIG_SECTION                      0x08 /* Start of new section */
++
++/* Configuration item types */
++#define CONFIG_ITEM_FLOAT                   0x20  /* Float option */
++#define CONFIG_ITEM_INTEGER                 0x40  /* Integer option */
++#define CONFIG_ITEM_RGB                     0x41  /* RGB color option */
++#define CONFIG_ITEM_BOOL                    0x60  /* Bool option */
++#define CONFIG_ITEM_STRING                  0x80  /* String option */
++#define CONFIG_ITEM_PASSWORD                0x81  /* Password option (*) */
++#define CONFIG_ITEM_KEY                     0x82  /* Hot key option */
++#define CONFIG_ITEM_MODULE                  0x84  /* Module option */
++#define CONFIG_ITEM_MODULE_CAT              0x85  /* Module option */
++#define CONFIG_ITEM_MODULE_LIST             0x86  /* Module option */
++#define CONFIG_ITEM_MODULE_LIST_CAT         0x87  /* Module option */
++#define CONFIG_ITEM_LOADFILE                0x8C  /* Read file option */
++#define CONFIG_ITEM_SAVEFILE                0x8D  /* Written file option */
++#define CONFIG_ITEM_DIRECTORY               0x8E  /* Directory option */
++#define CONFIG_ITEM_FONT                    0x8F  /* Font option */
++
++#define CONFIG_ITEM(x) (((x) & ~0xF) != 0)
++
++/* Categories and subcategories */
++#define CAT_INTERFACE 1
++#define SUBCAT_INTERFACE_GENERAL 101
++#define SUBCAT_INTERFACE_MAIN 102
++#define SUBCAT_INTERFACE_CONTROL 103
++#define SUBCAT_INTERFACE_HOTKEYS 104
++
++#define CAT_AUDIO 2
++#define SUBCAT_AUDIO_GENERAL 201
++#define SUBCAT_AUDIO_AOUT 202
++#define SUBCAT_AUDIO_AFILTER 203
++#define SUBCAT_AUDIO_VISUAL 204
++#define SUBCAT_AUDIO_MISC 205
++#define SUBCAT_AUDIO_RESAMPLER 206
++
++#define CAT_VIDEO 3
++#define SUBCAT_VIDEO_GENERAL 301
++#define SUBCAT_VIDEO_VOUT 302
++#define SUBCAT_VIDEO_VFILTER 303
++#define SUBCAT_VIDEO_SUBPIC 305
++#define SUBCAT_VIDEO_SPLITTER 306
++
++#define CAT_INPUT 4
++#define SUBCAT_INPUT_GENERAL 401
++#define SUBCAT_INPUT_ACCESS 402
++#define SUBCAT_INPUT_DEMUX 403
++#define SUBCAT_INPUT_VCODEC 404
++#define SUBCAT_INPUT_ACODEC 405
++#define SUBCAT_INPUT_SCODEC 406
++#define SUBCAT_INPUT_STREAM_FILTER 407
++
++#define CAT_SOUT 5
++#define SUBCAT_SOUT_GENERAL 501
++#define SUBCAT_SOUT_STREAM 502
++#define SUBCAT_SOUT_MUX 503
++#define SUBCAT_SOUT_ACO 504
++#define SUBCAT_SOUT_PACKETIZER 505
++#define SUBCAT_SOUT_VOD 507
++#define SUBCAT_SOUT_RENDERER 508
++
++#define CAT_ADVANCED 6
++#define SUBCAT_ADVANCED_MISC 602
++#define SUBCAT_ADVANCED_NETWORK 603
++
++#define CAT_PLAYLIST 7
++#define SUBCAT_PLAYLIST_GENERAL 701
++#define SUBCAT_PLAYLIST_SD 702
++#define SUBCAT_PLAYLIST_EXPORT 703
++
++
++/**
++ * Current plugin ABI version
++ */
++# define MODULE_SYMBOL 3_0_0f
++# define MODULE_SUFFIX "__3_0_0f"
++
++/*****************************************************************************
++ * Add a few defines. You do not want to read this section. Really.
++ *****************************************************************************/
++
++/* Explanation:
++ *
++ * if linking a module statically, we will need:
++ * #define MODULE_FUNC( zog ) module_foo_zog
++ *
++ * this can't easily be done with the C preprocessor, thus a few ugly hacks.
++ */
++
++/* I need to do _this_ to change « foo bar » to « module_foo_bar » ! */
++#define CONCATENATE( y, z ) CRUDE_HACK( y, z )
++#define CRUDE_HACK( y, z )  y##__##z
++
++/* If the module is built-in, then we need to define foo_InitModule instead
++ * of InitModule. Same for Activate- and DeactivateModule. */
++#ifdef __PLUGIN__
++# define __VLC_SYMBOL( symbol  ) CONCATENATE( symbol, MODULE_SYMBOL )
++# define VLC_MODULE_NAME_HIDDEN_SYMBOL \
++    const char vlc_module_name[] = MODULE_STRING;
++#else
++# define __VLC_SYMBOL( symbol )  CONCATENATE( symbol, MODULE_NAME )
++# define VLC_MODULE_NAME_HIDDEN_SYMBOL
++#endif
++
++#define CDECL_SYMBOL
++#if defined (__PLUGIN__)
++# if defined (_WIN32)
++#   define DLL_SYMBOL              __declspec(dllexport)
++#   undef CDECL_SYMBOL
++#   define CDECL_SYMBOL            __cdecl
++# elif defined (__GNUC__)
++#   define DLL_SYMBOL              __attribute__((visibility("default")))
++# else
++#  define DLL_SYMBOL
++# endif
++#else
++# define DLL_SYMBOL
++#endif
++
++#if defined( __cplusplus )
++#   define EXTERN_SYMBOL           extern "C"
++#else
++#   define EXTERN_SYMBOL
++#endif
++
++EXTERN_SYMBOL typedef int (*vlc_set_cb) (void *, void *, int, ...);
++
++#define vlc_plugin_set(...) vlc_set (opaque,   NULL, __VA_ARGS__)
++#define vlc_module_set(...) vlc_set (opaque, module, __VA_ARGS__)
++#define vlc_config_set(...) vlc_set (opaque, config, __VA_ARGS__)
++
++/*
++ * InitModule: this function is called once and only once, when the module
++ * is looked at for the first time. We get the useful data from it, for
++ * instance the module name, its shortcuts, its capabilities... we also create
++ * a copy of its config because the module can be unloaded at any time.
++ */
++#define vlc_module_begin() \
++EXTERN_SYMBOL DLL_SYMBOL \
++int CDECL_SYMBOL __VLC_SYMBOL(vlc_entry) (vlc_set_cb, void *); \
++EXTERN_SYMBOL DLL_SYMBOL \
++int CDECL_SYMBOL __VLC_SYMBOL(vlc_entry) (vlc_set_cb vlc_set, void *opaque) \
++{ \
++    module_t *module; \
++    module_config_t *config = NULL; \
++    if (vlc_plugin_set (VLC_MODULE_CREATE, &module)) \
++        goto error; \
++    if (vlc_module_set (VLC_MODULE_NAME, (MODULE_STRING))) \
++        goto error;
++
++#define vlc_module_end() \
++    (void) config; \
++    return 0; \
++error: \
++    return -1; \
++} \
++VLC_MODULE_NAME_HIDDEN_SYMBOL \
++VLC_METADATA_EXPORTS
++
++#define add_submodule( ) \
++    if (vlc_plugin_set (VLC_MODULE_CREATE, &module)) \
++        goto error;
++
++#define add_shortcut( ... ) \
++{ \
++    const char *shortcuts[] = { __VA_ARGS__ }; \
++    if (vlc_module_set (VLC_MODULE_SHORTCUT, \
++                        sizeof(shortcuts)/sizeof(shortcuts[0]), shortcuts)) \
++        goto error; \
++}
++
++#define set_shortname( shortname ) \
++    if (vlc_module_set (VLC_MODULE_SHORTNAME, (const char *)(shortname))) \
++        goto error;
++
++#define set_description( desc ) \
++    if (vlc_module_set (VLC_MODULE_DESCRIPTION, (const char *)(desc))) \
++        goto error;
++
++#define set_help( help ) \
++    if (vlc_module_set (VLC_MODULE_HELP, (const char *)(help))) \
++        goto error;
++
++#define set_capability( cap, score ) \
++    if (vlc_module_set (VLC_MODULE_CAPABILITY, (const char *)(cap)) \
++     || vlc_module_set (VLC_MODULE_SCORE, (int)(score))) \
++        goto error;
++
++#define set_callbacks( activate, deactivate ) \
++    if (vlc_module_set(VLC_MODULE_CB_OPEN, #activate, (void *)(activate)) \
++     || vlc_module_set(VLC_MODULE_CB_CLOSE, #deactivate, \
++                       (void *)(deactivate))) \
++        goto error;
++
++#define cannot_unload_broken_library( ) \
++    if (vlc_module_set (VLC_MODULE_NO_UNLOAD)) \
++        goto error;
++
++#define set_text_domain( dom ) \
++    if (vlc_plugin_set (VLC_MODULE_TEXTDOMAIN, (dom))) \
++        goto error;
++
++/*****************************************************************************
++ * Macros used to build the configuration structure.
++ *
++ * Note that internally we support only 3 types of config data: int, float
++ *   and string.
++ *   The other types declared here just map to one of these 3 basic types but
++ *   have the advantage of also providing very good hints to a configuration
++ *   interface so as to make it more user friendly.
++ * The configuration structure also includes category hints. These hints can
++ *   provide a configuration interface with some very useful data and again
++ *   allow for a more user friendly interface.
++ *****************************************************************************/
++
++#define add_type_inner( type ) \
++    vlc_plugin_set (VLC_CONFIG_CREATE, (type), &config);
++
++#define add_typedesc_inner( type, text, longtext ) \
++    add_type_inner( type ) \
++    vlc_config_set (VLC_CONFIG_DESC, \
++                    (const char *)(text), (const char *)(longtext));
++
++#define add_typeadv_inner( type, text, longtext, advc ) \
++    add_typedesc_inner( type, text, longtext ) \
++    if (advc) vlc_config_set (VLC_CONFIG_ADVANCED);
++
++#define add_typename_inner( type, name, text, longtext, advc ) \
++    add_typeadv_inner( type, text, longtext, advc ) \
++    vlc_config_set (VLC_CONFIG_NAME, (const char *)(name));
++
++#define add_string_inner( type, name, text, longtext, advc, v ) \
++    add_typename_inner( type, name, text, longtext, advc ) \
++    vlc_config_set (VLC_CONFIG_VALUE, (const char *)(v));
++
++#define add_int_inner( type, name, text, longtext, advc, v ) \
++    add_typename_inner( type, name, text, longtext, advc ) \
++    vlc_config_set (VLC_CONFIG_VALUE, (int64_t)(v));
++
++
++#define set_category( i_id ) \
++    add_type_inner( CONFIG_CATEGORY ) \
++    vlc_config_set (VLC_CONFIG_VALUE, (int64_t)(i_id));
++
++#define set_subcategory( i_id ) \
++    add_type_inner( CONFIG_SUBCATEGORY ) \
++    vlc_config_set (VLC_CONFIG_VALUE, (int64_t)(i_id));
++
++#define set_section( text, longtext ) \
++    add_typedesc_inner( CONFIG_SECTION, text, longtext )
++
++#define add_category_hint( text, longtext, advc ) \
++    add_typeadv_inner( CONFIG_HINT_CATEGORY, text, longtext, advc )
++
++#define add_usage_hint( text ) \
++    add_typedesc_inner( CONFIG_HINT_USAGE, text, NULL )
++
++#define add_string( name, value, text, longtext, advc ) \
++    add_string_inner( CONFIG_ITEM_STRING, name, text, longtext, advc, \
++                      value )
++
++#define add_password( name, value, text, longtext, advc ) \
++    add_string_inner( CONFIG_ITEM_PASSWORD, name, text, longtext, advc, \
++                      value )
++
++#define add_loadfile( name, value, text, longtext, advc ) \
++    add_string_inner( CONFIG_ITEM_LOADFILE, name, text, longtext, advc, \
++                      value )
++
++#define add_savefile( name, value, text, longtext, advc ) \
++    add_string_inner( CONFIG_ITEM_SAVEFILE, name, text, longtext, advc, \
++                      value )
++
++#define add_directory( name, value, text, longtext, advc ) \
++    add_string_inner( CONFIG_ITEM_DIRECTORY, name, text, longtext, advc, \
++                      value )
++
++#define add_font( name, value, text, longtext, advc )\
++    add_string_inner( CONFIG_ITEM_FONT, name, text, longtext, advc, \
++                      value )
++
++#define add_module( name, psz_caps, value, text, longtext, advc ) \
++    add_string_inner( CONFIG_ITEM_MODULE, name, text, longtext, advc, \
++                      value ) \
++    vlc_config_set (VLC_CONFIG_CAPABILITY, (const char *)(psz_caps));
++
++#define add_module_list( name, psz_caps, value, text, longtext, advc ) \
++    add_string_inner( CONFIG_ITEM_MODULE_LIST, name, text, longtext, advc, \
++                      value ) \
++    vlc_config_set (VLC_CONFIG_CAPABILITY, (const char *)(psz_caps));
++
++#ifndef __PLUGIN__
++#define add_module_cat( name, i_subcategory, value, text, longtext, advc ) \
++    add_string_inner( CONFIG_ITEM_MODULE_CAT, name, text, longtext, advc, \
++                      value ) \
++    change_integer_range (i_subcategory /* gruik */, 0);
++
++#define add_module_list_cat( name, i_subcategory, value, text, longtext, advc ) \
++    add_string_inner( CONFIG_ITEM_MODULE_LIST_CAT, name, text, longtext, \
++                      advc, value ) \
++    change_integer_range (i_subcategory /* gruik */, 0);
++#endif
++
++#define add_integer( name, value, text, longtext, advc ) \
++    add_int_inner( CONFIG_ITEM_INTEGER, name, text, longtext, advc, value )
++
++#define add_rgb( name, value, text, longtext, advc ) \
++    add_int_inner( CONFIG_ITEM_RGB, name, text, longtext, advc, value ) \
++    change_integer_range( 0, 0xFFFFFF )
++
++#define add_key( name, value, text, longtext, advc ) \
++    add_string_inner( CONFIG_ITEM_KEY, "global-" name, text, longtext, advc, \
++                   KEY_UNSET ) \
++    add_string_inner( CONFIG_ITEM_KEY, name, text, longtext, advc, value )
++
++#define add_integer_with_range( name, value, i_min, i_max, text, longtext, advc ) \
++    add_integer( name, value, text, longtext, advc ) \
++    change_integer_range( i_min, i_max )
++
++#define add_float( name, v, text, longtext, advc ) \
++    add_typename_inner( CONFIG_ITEM_FLOAT, name, text, longtext, advc ) \
++    vlc_config_set (VLC_CONFIG_VALUE, (double)(v));
++
++#define add_float_with_range( name, value, f_min, f_max, text, longtext, advc ) \
++    add_float( name, value, text, longtext, advc ) \
++    change_float_range( f_min, f_max )
++
++#define add_bool( name, v, text, longtext, advc ) \
++    add_typename_inner( CONFIG_ITEM_BOOL, name, text, longtext, advc ) \
++    if (v) vlc_config_set (VLC_CONFIG_VALUE, (int64_t)true);
++
++/* For removed option */
++#define add_obsolete_inner( name, type ) \
++    add_type_inner( type ) \
++    vlc_config_set (VLC_CONFIG_NAME, (const char *)(name)); \
++    vlc_config_set (VLC_CONFIG_REMOVED);
++
++#define add_obsolete_bool( name ) \
++        add_obsolete_inner( name, CONFIG_ITEM_BOOL )
++
++#define add_obsolete_integer( name ) \
++        add_obsolete_inner( name, CONFIG_ITEM_INTEGER )
++
++#define add_obsolete_float( name ) \
++        add_obsolete_inner( name, CONFIG_ITEM_FLOAT )
++
++#define add_obsolete_string( name ) \
++        add_obsolete_inner( name, CONFIG_ITEM_STRING )
++
++/* Modifier macros for the config options (used for fine tuning) */
++
++#define change_short( ch ) \
++    vlc_config_set (VLC_CONFIG_SHORTCUT, (int)(ch));
++
++#define change_string_list( list, list_text ) \
++    vlc_config_set (VLC_CONFIG_LIST, \
++                    (size_t)(sizeof (list) / sizeof (char *)), \
++                    (const char *const *)(list), \
++                    (const char *const *)(list_text));
++
++#define change_string_cb( cb ) \
++    vlc_config_set (VLC_CONFIG_LIST_CB, #cb, (void *)(cb));
++
++#define change_integer_list( list, list_text ) \
++    vlc_config_set (VLC_CONFIG_LIST, \
++                    (size_t)(sizeof (list) / sizeof (int)), \
++                    (const int *)(list), \
++                    (const char *const *)(list_text));
++
++#define change_integer_cb( cb ) \
++    vlc_config_set (VLC_CONFIG_LIST_CB, #cb, (cb));
++
++#define change_integer_range( minv, maxv ) \
++    vlc_config_set (VLC_CONFIG_RANGE, (int64_t)(minv), (int64_t)(maxv));
++
++#define change_float_range( minv, maxv ) \
++    vlc_config_set (VLC_CONFIG_RANGE, (double)(minv), (double)(maxv));
++
++/* For options that are saved but hidden from the preferences panel */
++#define change_private() \
++    vlc_config_set (VLC_CONFIG_PRIVATE);
++
++/* For options that cannot be saved in the configuration */
++#define change_volatile() \
++    change_private() \
++    vlc_config_set (VLC_CONFIG_VOLATILE);
++
++#define change_safe() \
++    vlc_config_set (VLC_CONFIG_SAFE);
++
++/* Meta data plugin exports */
++#define VLC_META_EXPORT( name, value ) \
++    EXTERN_SYMBOL DLL_SYMBOL const char * CDECL_SYMBOL \
++    __VLC_SYMBOL(vlc_entry_ ## name) (void); \
++    EXTERN_SYMBOL DLL_SYMBOL const char * CDECL_SYMBOL \
++    __VLC_SYMBOL(vlc_entry_ ## name) (void) \
++    { \
++         return value; \
++    }
++
++#define VLC_COPYRIGHT_VIDEOLAN \
++    "\x43\x6f\x70\x79\x72\x69\x67\x68\x74\x20\x28\x43\x29\x20\x74\x68" \
++    "\x65\x20\x56\x69\x64\x65\x6f\x4c\x41\x4e\x20\x56\x4c\x43\x20\x6d" \
++    "\x65\x64\x69\x61\x20\x70\x6c\x61\x79\x65\x72\x20\x64\x65\x76\x65" \
++    "\x6c\x6f\x70\x65\x72\x73"
++#define VLC_LICENSE_LGPL_2_1_PLUS \
++    "\x4c\x69\x63\x65\x6e\x73\x65\x64\x20\x75\x6e\x64\x65\x72\x20\x74" \
++    "\x68\x65\x20\x74\x65\x72\x6d\x73\x20\x6f\x66\x20\x74\x68\x65\x20" \
++    "\x47\x4e\x55\x20\x4c\x65\x73\x73\x65\x72\x20\x47\x65\x6e\x65\x72" \
++    "\x61\x6c\x20\x50\x75\x62\x6c\x69\x63\x20\x4c\x69\x63\x65\x6e\x73" \
++    "\x65\x2c\x20\x76\x65\x72\x73\x69\x6f\x6e\x20\x32\x2e\x31\x20\x6f" \
++    "\x72\x20\x6c\x61\x74\x65\x72\x2e"
++#define VLC_LICENSE_GPL_2_PLUS \
++    "\x4c\x69\x63\x65\x6e\x73\x65\x64\x20\x75\x6e\x64\x65\x72\x20\x74" \
++    "\x68\x65\x20\x74\x65\x72\x6d\x73\x20\x6f\x66\x20\x74\x68\x65\x20" \
++    "\x47\x4e\x55\x20\x47\x65\x6e\x65\x72\x61\x6c\x20\x50\x75\x62\x6c" \
++    "\x69\x63\x20\x4c\x69\x63\x65\x6e\x73\x65\x2c\x20\x76\x65\x72\x73" \
++    "\x69\x6f\x6e\x20\x32\x20\x6f\x72\x20\x6c\x61\x74\x65\x72\x2e"
++#if defined (__LIBVLC__)
++# define VLC_MODULE_COPYRIGHT VLC_COPYRIGHT_VIDEOLAN
++# ifndef VLC_MODULE_LICENSE
++#  define VLC_MODULE_LICENSE VLC_LICENSE_LGPL_2_1_PLUS
++# endif
++#endif
++
++#ifdef VLC_MODULE_COPYRIGHT
++# define VLC_COPYRIGHT_EXPORT VLC_META_EXPORT(copyright, VLC_MODULE_COPYRIGHT)
++#else
++# define VLC_COPYRIGHT_EXPORT
++#endif
++#ifdef VLC_MODULE_LICENSE
++# define VLC_LICENSE_EXPORT VLC_META_EXPORT(license, VLC_MODULE_LICENSE)
++#else
++# define VLC_LICENSE_EXPORT
++#endif
++
++#define VLC_METADATA_EXPORTS \
++    VLC_COPYRIGHT_EXPORT \
++    VLC_LICENSE_EXPORT
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_probe.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_probe.h
+new file mode 100644
+index 0000000..efa4d97
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_probe.h
+@@ -0,0 +1,69 @@
++/*****************************************************************************
++ * vlc_probe.h: service probing interface
++ *****************************************************************************
++ * Copyright (C) 2009 Rémi Denis-Courmont
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_PROBE_H
++# define VLC_PROBE_H 1
++
++# include <stdlib.h>
++
++/**
++ * \file
++ * This file defines functions and structures to run-time probe VLC extensions
++ */
++
++# ifdef __cplusplus
++extern "C" {
++# endif
++
++void *vlc_probe (vlc_object_t *, const char *, size_t *);
++#define vlc_probe(obj, cap, pcount) \
++        vlc_probe(VLC_OBJECT(obj), cap, pcount)
++
++struct vlc_probe_t
++{
++    VLC_COMMON_MEMBERS
++
++    void  *list;
++    size_t count;
++};
++
++typedef struct vlc_probe_t vlc_probe_t;
++
++static inline int vlc_probe_add(vlc_probe_t *obj, const void *data,
++                                size_t len)
++{
++    char *tab = (char *)realloc (obj->list, (obj->count + 1) * len);
++
++    if (unlikely(tab == NULL))
++        return VLC_ENOMEM;
++    memcpy(tab + (obj->count * len), data, len);
++    obj->list = tab;
++    obj->count++;
++    return VLC_SUCCESS;
++}
++
++# define VLC_PROBE_CONTINUE VLC_EGENERIC
++# define VLC_PROBE_STOP     VLC_SUCCESS
++
++# ifdef __cplusplus
++}
++# endif
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_rand.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_rand.h
+new file mode 100644
+index 0000000..761cee5
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_rand.h
+@@ -0,0 +1,37 @@
++/*****************************************************************************
++ * vlc_rand.h: RNG
++ *****************************************************************************
++ * Copyright © 2007 Rémi Denis-Courmont
++ * $Id: 3ae95ac04c55f46d116481eb89255b013f6d1c32 $
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_RAND_H
++# define VLC_RAND_H
++
++/**
++ * \file
++ * This file defined random number generator function in vlc
++ */
++
++VLC_API void vlc_rand_bytes(void *buf, size_t len);
++
++/* Interlocked (but not reproducible) functions for the POSIX PRNG */
++VLC_API double vlc_drand48(void) VLC_USED;
++VLC_API long vlc_lrand48(void) VLC_USED;
++VLC_API long vlc_mrand48(void) VLC_USED;
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_renderer_discovery.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_renderer_discovery.h
+new file mode 100644
+index 0000000..6193e48
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_renderer_discovery.h
+@@ -0,0 +1,219 @@
++/*****************************************************************************
++ * vlc_renderer_discovery.h : Renderer Discovery functions
++ *****************************************************************************
++ * Copyright (C) 2016 VLC authors and VideoLAN
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_RENDERER_DISCOVERY_H
++#define VLC_RENDERER_DISCOVERY_H 1
++
++#include <vlc_input.h>
++#include <vlc_probe.h>
++#include <vlc_url.h>
++
++/**
++ * @defgroup vlc_renderer VLC renderer discovery
++ * @{
++ *
++ * @file
++ * This file declares VLC renderer discvoery structures and functions
++ *
++ * @defgroup vlc_renderer_item VLC renderer items returned by the discovery
++ * @{
++ */
++
++#define VLC_RENDERER_CAN_AUDIO 0x0001
++#define VLC_RENDERER_CAN_VIDEO 0x0002
++
++/**
++ * Create a new renderer item
++ *
++ * @param psz_type type of the item
++ * @param psz_name name of the item
++ * @param psz_uri uri of the renderer item, must contains a valid protocol and
++ * a valid host
++ * @param psz_extra_sout extra sout options
++ * @param psz_demux_filter demux filter to use with the renderer
++ * @param psz_icon_uri icon uri of the renderer item
++ * @param i_flags flags for the item
++ * @return a renderer item or NULL in case of error
++ */
++VLC_API vlc_renderer_item_t *
++vlc_renderer_item_new(const char *psz_type, const char *psz_name,
++                      const char *psz_uri, const char *psz_extra_sout,
++                      const char *psz_demux_filter, const char *psz_icon_uri,
++                      int i_flags) VLC_USED;
++
++/**
++ * Hold a renderer item, i.e. creates a new reference
++ */
++VLC_API vlc_renderer_item_t *
++vlc_renderer_item_hold(vlc_renderer_item_t *p_item);
++
++/**
++ * Releases a renderer item, i.e. decrements its reference counter
++ */
++VLC_API void
++vlc_renderer_item_release(vlc_renderer_item_t *p_item);
++
++/**
++ * Get the human readable name of a renderer item
++ */
++VLC_API const char *
++vlc_renderer_item_name(const vlc_renderer_item_t *p_item);
++
++/**
++ * Get the type (not translated) of a renderer item. For now, the type can only
++ * be "chromecast" ("upnp", "airplay" may come later).
++ */
++VLC_API const char *
++vlc_renderer_item_type(const vlc_renderer_item_t *p_item);
++
++/**
++ * Get the demux filter to use with a renderer item
++ */
++VLC_API const char *
++vlc_renderer_item_demux_filter(const vlc_renderer_item_t *p_item);
++
++/**
++ * Get the sout command of a renderer item
++ */
++VLC_API const char *
++vlc_renderer_item_sout(const vlc_renderer_item_t *p_item);
++
++/**
++ * Get the icon uri of a renderer item
++ */
++VLC_API const char *
++vlc_renderer_item_icon_uri(const vlc_renderer_item_t *p_item);
++
++/**
++ * Get the flags of a renderer item
++ */
++VLC_API int
++vlc_renderer_item_flags(const vlc_renderer_item_t *p_item);
++
++/**
++ * @}
++ * @defgroup vlc_renderer_discovery VLC renderer discovery interface
++ * @{
++ */
++
++typedef struct vlc_renderer_discovery_sys vlc_renderer_discovery_sys;
++struct vlc_renderer_discovery_owner;
++
++/**
++ * Return a list of renderer discovery modules
++ *
++ * @param pppsz_names a pointer to a list of module name, NULL terminated
++ * @param pppsz_longnames a pointer to a list of module longname, NULL
++ * terminated
++ *
++ * @return VLC_SUCCESS on success, or VLC_EGENERIC on error
++ */
++VLC_API int
++vlc_rd_get_names(vlc_object_t *p_obj, char ***pppsz_names,
++                 char ***pppsz_longnames) VLC_USED;
++#define vlc_rd_get_names(a, b, c) \
++        vlc_rd_get_names(VLC_OBJECT(a), b, c)
++
++/**
++ * Create a new renderer discovery module
++ *
++ * @param psz_name name of the module to load, see vlc_rd_get_names() to get
++ * the list of names
++ *
++ * @return a valid vlc_renderer_discovery, need to be released with
++ * vlc_rd_release()
++ */
++VLC_API vlc_renderer_discovery_t *
++vlc_rd_new(vlc_object_t *p_obj, const char *psz_name,
++           const struct vlc_renderer_discovery_owner *owner) VLC_USED;
++
++VLC_API void vlc_rd_release(vlc_renderer_discovery_t *p_rd);
++
++/**
++ * @}
++ * @defgroup vlc_renderer_discovery_module VLC renderer module
++ * @{
++ */
++
++struct vlc_renderer_discovery_owner
++{
++    void *sys;
++    void (*item_added)(struct vlc_renderer_discovery_t *,
++                       struct vlc_renderer_item_t *);
++    void (*item_removed)(struct vlc_renderer_discovery_t *,
++                         struct vlc_renderer_item_t *);
++};
++
++struct vlc_renderer_discovery_t
++{
++    VLC_COMMON_MEMBERS
++    module_t *          p_module;
++
++    struct vlc_renderer_discovery_owner owner;
++
++    char *              psz_name;
++    config_chain_t *    p_cfg;
++
++    vlc_renderer_discovery_sys *p_sys;
++};
++
++/**
++ * Add a new renderer item
++ *
++ * This will send the vlc_RendererDiscoveryItemAdded event
++ */
++static inline void vlc_rd_add_item(vlc_renderer_discovery_t * p_rd,
++                                   vlc_renderer_item_t * p_item)
++{
++    p_rd->owner.item_added(p_rd, p_item);
++}
++
++/**
++ * Add a new renderer item
++ *
++ * This will send the vlc_RendererDiscoveryItemRemoved event
++ */
++static inline void vlc_rd_remove_item(vlc_renderer_discovery_t * p_rd,
++                                      vlc_renderer_item_t * p_item)
++{
++    p_rd->owner.item_removed(p_rd, p_item);
++}
++
++/**
++ * Renderer Discovery proble helpers
++ */
++VLC_API int
++vlc_rd_probe_add(vlc_probe_t *p_probe, const char *psz_name,
++                 const char *psz_longname);
++
++#define VLC_RD_PROBE_HELPER(name, longname) \
++static int vlc_rd_probe_open(vlc_object_t *obj) \
++{ \
++    return vlc_rd_probe_add((struct vlc_probe_t *)obj, name, longname); \
++}
++
++#define VLC_RD_PROBE_SUBMODULE \
++    add_submodule() \
++        set_capability("renderer probe", 100) \
++        set_callbacks(vlc_rd_probe_open, NULL)
++
++/** @} @} */
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_services_discovery.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_services_discovery.h
+new file mode 100644
+index 0000000..673410c
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_services_discovery.h
+@@ -0,0 +1,234 @@
++/*****************************************************************************
++ * vlc_services_discovery.h : Services Discover functions
++ *****************************************************************************
++ * Copyright (C) 1999-2004 VLC authors and VideoLAN
++ * $Id: e4dfcd3985a6eea1d4b5c540e72219b67d733901 $
++ *
++ * Authors: Pierre d'Herbemont <pdherbemont # videolan.org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_SERVICES_DISCOVERY_H_
++#define VLC_SERVICES_DISCOVERY_H_
++
++#include <vlc_input.h>
++#include <vlc_probe.h>
++
++/**
++ * \file
++ * This file lists functions and structures for service discovery (SD) in vlc
++ */
++
++# ifdef __cplusplus
++extern "C" {
++# endif
++
++/**
++ * @{
++ */
++
++struct services_discovery_owner_t
++{
++    void *sys; /**< Private data for the owner callbacks */
++    void (*item_added)(struct services_discovery_t *sd, input_item_t *parent,
++                       input_item_t *item, const char *category);
++    void (*item_removed)(struct services_discovery_t *sd, input_item_t *item);
++};
++
++/**
++ * Main service discovery structure to build a SD module
++ */
++struct services_discovery_t
++{
++    VLC_COMMON_MEMBERS
++    module_t *          p_module;             /**< Loaded module */
++
++    char *psz_name;                           /**< Main name of the SD */
++    config_chain_t *p_cfg;                    /**< Configuration for the SD */
++
++    const char *description; /**< Human-readable name */
++
++    /** Control function
++     * \see services_discovery_command_e
++     */
++    int ( *pf_control ) ( services_discovery_t *, int, va_list );
++
++    services_discovery_sys_t *p_sys;          /**< Custom private data */
++
++    struct services_discovery_owner_t owner; /**< Owner callbacks */
++};
++
++/**
++ * Service discovery categories
++ * \see vlc_sd_probe_Add
++ */
++enum services_discovery_category_e
++{
++    SD_CAT_DEVICES = 1,           /**< Devices, like portable music players */
++    SD_CAT_LAN,                   /**< LAN/WAN services, like Upnp or SAP */
++    SD_CAT_INTERNET,              /**< Internet or Website channels services */
++    SD_CAT_MYCOMPUTER             /**< Computer services, like Discs or Apps */
++};
++
++/**
++ * Service discovery control commands
++ */
++enum services_discovery_command_e
++{
++    SD_CMD_SEARCH = 1,          /**< arg1 = query */
++    SD_CMD_DESCRIPTOR           /**< arg1 = services_discovery_descriptor_t* */
++};
++
++/**
++ * Service discovery capabilities
++ */
++enum services_discovery_capability_e
++{
++    SD_CAP_SEARCH = 1           /**< One can search in the SD */
++};
++
++/**
++ * Service discovery descriptor
++ * \see services_discovery_command_e
++ */
++typedef struct
++{
++    char *psz_short_desc;       /**< The short description, human-readable */
++    char *psz_icon_url;         /**< URL to the icon that represents it */
++    char *psz_url;              /**< URL for the service */
++    int   i_capabilities;       /**< \see services_discovery_capability_e */
++} services_discovery_descriptor_t;
++
++
++/***********************************************************************
++ * Service Discovery
++ ***********************************************************************/
++
++/**
++ * Ask for a research in the SD
++ * @param p_sd: the Service Discovery
++ * @param i_control: the command to issue
++ * @param args: the argument list
++ * @return VLC_SUCCESS in case of success, the error code overwise
++ */
++static inline int vlc_sd_control( services_discovery_t *p_sd, int i_control, va_list args )
++{
++    if( p_sd->pf_control )
++        return p_sd->pf_control( p_sd, i_control, args );
++    else
++        return VLC_EGENERIC;
++}
++
++/* Get the services discovery modules names to use in Create(), in a null
++ * terminated string array. Array and string must be freed after use. */
++VLC_API char ** vlc_sd_GetNames( vlc_object_t *, char ***, int ** ) VLC_USED;
++#define vlc_sd_GetNames(obj, pln, pcat ) \
++        vlc_sd_GetNames(VLC_OBJECT(obj), pln, pcat)
++
++/**
++ * Creates a services discoverer.
++ */
++VLC_API services_discovery_t *vlc_sd_Create(vlc_object_t *parent,
++    const char *chain, const struct services_discovery_owner_t *owner)
++VLC_USED;
++
++VLC_API void vlc_sd_Destroy( services_discovery_t * );
++
++/**
++ * Added top-level service callback.
++ *
++ * This is a convenience wrapper for services_discovery_AddSubItem().
++ * It covers the most comomn case wherby the added item is a top-level service,
++ * i.e. it has no parent node.
++ */
++static inline void services_discovery_AddItem(services_discovery_t *sd,
++                                              input_item_t *item)
++{
++    sd->owner.item_added(sd, NULL, item, NULL);
++}
++
++/**
++ * Added service callback.
++ *
++ * A services discovery module invokes this function when it "discovers" a new
++ * service, i.e. a new input item.
++ *
++ * @note This callback does not take ownership of the input item; it might
++ * however (and most probably will) add one of more references to the item.
++ *
++ * The caller is responsible for releasing its own reference(s) eventually.
++ * Keeping a reference is necessary to call services_discovery_RemoveItem() or
++ * to alter the item later. However, if the caller will never remove nor alter
++ * the item, it can drop its reference(s) immediately.
++ *
++ * @param sd services discoverer / services discovery module instance
++ * @param item input item to add
++ */
++static inline void services_discovery_AddSubItem(services_discovery_t *sd,
++                                                 input_item_t *parent,
++                                                 input_item_t *item)
++{
++    sd->owner.item_added(sd, parent, item, NULL);
++}
++
++/**
++ * Added service backward compatibility callback.
++ *
++ * @param category Optional name of a group that the item belongs in
++ *                 (for backward compatibility with legacy modules)
++ */
++VLC_DEPRECATED
++static inline void services_discovery_AddItemCat(services_discovery_t *sd,
++                                                 input_item_t *item,
++                                                 const char *category)
++{
++    sd->owner.item_added(sd, NULL, item, category);
++}
++
++/**
++ * Removed service callback.
++ *
++ * A services discovery module invokes this function when it senses that a
++ * service is no longer available.
++ */
++static inline void services_discovery_RemoveItem(services_discovery_t *sd,
++                                                 input_item_t *item)
++{
++    sd->owner.item_removed(sd, item);
++}
++
++/* SD probing */
++
++VLC_API int vlc_sd_probe_Add(vlc_probe_t *, const char *, const char *, int category);
++
++#define VLC_SD_PROBE_SUBMODULE \
++    add_submodule() \
++        set_capability( "services probe", 100 ) \
++        set_callbacks( vlc_sd_probe_Open, NULL )
++
++#define VLC_SD_PROBE_HELPER(name, longname, cat) \
++static int vlc_sd_probe_Open (vlc_object_t *obj) \
++{ \
++    return vlc_sd_probe_Add ((struct vlc_probe_t *)obj, name, \
++                             longname, cat); \
++}
++
++/** @} */
++# ifdef __cplusplus
++}
++# endif
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_sout.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_sout.h
+new file mode 100644
+index 0000000..8e6367e
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_sout.h
+@@ -0,0 +1,311 @@
++/*****************************************************************************
++ * vlc_sout.h : stream output module
++ *****************************************************************************
++ * Copyright (C) 2002-2008 VLC authors and VideoLAN
++ * $Id: c710780e2e15ccd3de5ef3e12a47dcfacfbc744a $
++ *
++ * Authors: Christophe Massiot <massiot@via.ecp.fr>
++ *          Laurent Aimar <fenrir@via.ecp.fr>
++ *          Eric Petit <titer@videolan.org>
++ *          Jean-Paul Saman <jpsaman #_at_# m2x.nl>
++ *          Rémi Denis-Courmont
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_SOUT_H_
++#define VLC_SOUT_H_
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++#include <sys/types.h>
++#include <vlc_es.h>
++
++/**
++ * \defgroup sout Stream output
++ * \ingroup output
++ * @{
++ * \file
++ * Stream output modules interface
++ */
++
++/** Stream output instance (FIXME: should be private to src/ to avoid
++ * invalid unsynchronized access) */
++struct sout_instance_t
++{
++    VLC_COMMON_MEMBERS
++
++    char *psz_sout;
++
++    /** count of output that can't control the space */
++    int                 i_out_pace_nocontrol;
++
++    vlc_mutex_t         lock;
++    sout_stream_t       *p_stream;
++};
++
++/****************************************************************************
++ * sout_stream_id_sys_t: opaque (private for all sout_stream_t)
++ ****************************************************************************/
++typedef struct sout_stream_id_sys_t  sout_stream_id_sys_t;
++
++/**
++ * \defgroup sout_access Access output
++ * Raw output byte streams
++ * @{
++ */
++
++/** Stream output access_output */
++struct sout_access_out_t
++{
++    VLC_COMMON_MEMBERS
++
++    module_t                *p_module;
++    char                    *psz_access;
++
++    char                    *psz_path;
++    sout_access_out_sys_t   *p_sys;
++    int                     (*pf_seek)( sout_access_out_t *, off_t );
++    ssize_t                 (*pf_read)( sout_access_out_t *, block_t * );
++    ssize_t                 (*pf_write)( sout_access_out_t *, block_t * );
++    int                     (*pf_control)( sout_access_out_t *, int, va_list );
++
++    config_chain_t          *p_cfg;
++};
++
++enum access_out_query_e
++{
++    ACCESS_OUT_CONTROLS_PACE, /* arg1=bool *, can fail (assume true) */
++    ACCESS_OUT_CAN_SEEK, /* arg1=bool *, can fail (assume false) */
++};
++
++VLC_API sout_access_out_t * sout_AccessOutNew( vlc_object_t *, const char *psz_access, const char *psz_name ) VLC_USED;
++#define sout_AccessOutNew( obj, access, name ) \
++        sout_AccessOutNew( VLC_OBJECT(obj), access, name )
++VLC_API void sout_AccessOutDelete( sout_access_out_t * );
++VLC_API int sout_AccessOutSeek( sout_access_out_t *, off_t );
++VLC_API ssize_t sout_AccessOutRead( sout_access_out_t *, block_t * );
++VLC_API ssize_t sout_AccessOutWrite( sout_access_out_t *, block_t * );
++VLC_API int sout_AccessOutControl( sout_access_out_t *, int, ... );
++
++static inline bool sout_AccessOutCanControlPace( sout_access_out_t *p_ao )
++{
++    bool b;
++    if( sout_AccessOutControl( p_ao, ACCESS_OUT_CONTROLS_PACE, &b ) )
++        return true;
++    return b;
++}
++
++/**
++ * @}
++ * \defgroup sout_mux Multiplexer
++ * Multiplexers (file formatters)
++ * @{
++ */
++
++/** Muxer structure */
++struct  sout_mux_t
++{
++    VLC_COMMON_MEMBERS
++    module_t            *p_module;
++
++    sout_instance_t     *p_sout;
++
++    char                *psz_mux;
++    config_chain_t          *p_cfg;
++
++    sout_access_out_t   *p_access;
++
++    int                 (*pf_addstream)( sout_mux_t *, sout_input_t * );
++    void                (*pf_delstream)( sout_mux_t *, sout_input_t * );
++    int                 (*pf_mux)      ( sout_mux_t * );
++    int                 (*pf_control)  ( sout_mux_t *, int, va_list );
++
++    /* here are all inputs accepted by muxer */
++    int                 i_nb_inputs;
++    sout_input_t        **pp_inputs;
++
++    /* mux private */
++    sout_mux_sys_t      *p_sys;
++
++    /* XXX private to stream_output.c */
++    /* if muxer doesn't support adding stream at any time then we first wait
++     *  for stream then we refuse all stream and start muxing */
++    bool  b_add_stream_any_time;
++    bool  b_waiting_stream;
++    /* we wait 1.5 second after first stream added */
++    mtime_t     i_add_stream_start;
++};
++
++enum sout_mux_query_e
++{
++    /* capabilities */
++    MUX_CAN_ADD_STREAM_WHILE_MUXING,    /* arg1= bool *,      res=cannot fail */
++    /* properties */
++    MUX_GET_ADD_STREAM_WAIT,            /* arg1= bool *,      res=cannot fail */
++    MUX_GET_MIME,                       /* arg1= char **            res=can fail    */
++};
++
++struct sout_input_t
++{
++    const es_format_t *p_fmt;
++    block_fifo_t      *p_fifo;
++    void              *p_sys;
++    es_format_t        fmt;
++};
++
++
++VLC_API sout_mux_t * sout_MuxNew( sout_instance_t*, const char *, sout_access_out_t * ) VLC_USED;
++VLC_API sout_input_t *sout_MuxAddStream( sout_mux_t *, const es_format_t * ) VLC_USED;
++VLC_API void sout_MuxDeleteStream( sout_mux_t *, sout_input_t * );
++VLC_API void sout_MuxDelete( sout_mux_t * );
++VLC_API int sout_MuxSendBuffer( sout_mux_t *, sout_input_t  *, block_t * );
++VLC_API int sout_MuxGetStream(sout_mux_t *, unsigned, mtime_t *);
++VLC_API void sout_MuxFlush( sout_mux_t *, sout_input_t * );
++
++static inline int sout_MuxControl( sout_mux_t *p_mux, int i_query, ... )
++{
++    va_list args;
++    int     i_result;
++
++    va_start( args, i_query );
++    i_result = p_mux->pf_control( p_mux, i_query, args );
++    va_end( args );
++    return i_result;
++}
++
++/** @} */
++
++enum sout_stream_query_e {
++    SOUT_STREAM_EMPTY,    /* arg1=bool *,       res=can fail (assume true) */
++};
++
++struct sout_stream_t
++{
++    VLC_COMMON_MEMBERS
++
++    module_t          *p_module;
++    sout_instance_t   *p_sout;
++
++    char              *psz_name;
++    config_chain_t    *p_cfg;
++    sout_stream_t     *p_next;
++
++    /* add, remove a stream */
++    sout_stream_id_sys_t *(*pf_add)( sout_stream_t *, const es_format_t * );
++    void              (*pf_del)( sout_stream_t *, sout_stream_id_sys_t * );
++    /* manage a packet */
++    int               (*pf_send)( sout_stream_t *, sout_stream_id_sys_t *, block_t* );
++    int               (*pf_control)( sout_stream_t *, int, va_list );
++    void              (*pf_flush)( sout_stream_t *, sout_stream_id_sys_t * );
++
++    sout_stream_sys_t *p_sys;
++    bool pace_nocontrol;
++};
++
++VLC_API void sout_StreamChainDelete(sout_stream_t *p_first, sout_stream_t *p_last );
++VLC_API sout_stream_t *sout_StreamChainNew(sout_instance_t *p_sout,
++        const char *psz_chain, sout_stream_t *p_next, sout_stream_t **p_last) VLC_USED;
++
++static inline sout_stream_id_sys_t *sout_StreamIdAdd( sout_stream_t *s,
++                                                      const es_format_t *fmt )
++{
++    return s->pf_add( s, fmt );
++}
++
++static inline void sout_StreamIdDel( sout_stream_t *s,
++                                     sout_stream_id_sys_t *id )
++{
++    s->pf_del( s, id );
++}
++
++static inline int sout_StreamIdSend( sout_stream_t *s,
++                                     sout_stream_id_sys_t *id, block_t *b )
++{
++    return s->pf_send( s, id, b );
++}
++
++static inline void sout_StreamFlush( sout_stream_t *s,
++                                     sout_stream_id_sys_t *id )
++{
++    if (s->pf_flush)
++        s->pf_flush( s, id );
++}
++
++static inline int sout_StreamControl( sout_stream_t *s, int i_query, ... )
++{
++    va_list args;
++    int     i_result;
++
++    va_start( args, i_query );
++    if ( !s->pf_control )
++        i_result = VLC_EGENERIC;
++    else
++        i_result = s->pf_control( s, i_query, args );
++    va_end( args );
++    return i_result;
++}
++
++/****************************************************************************
++ * Encoder
++ ****************************************************************************/
++
++VLC_API encoder_t * sout_EncoderCreate( vlc_object_t *obj );
++#define sout_EncoderCreate(o) sout_EncoderCreate(VLC_OBJECT(o))
++
++/****************************************************************************
++ * Announce handler
++ ****************************************************************************/
++VLC_API session_descriptor_t* sout_AnnounceRegisterSDP( vlc_object_t *, const char *, const char * ) VLC_USED;
++VLC_API void sout_AnnounceUnRegister(vlc_object_t *,session_descriptor_t* );
++#define sout_AnnounceRegisterSDP(o, sdp, addr) \
++        sout_AnnounceRegisterSDP(VLC_OBJECT (o), sdp, addr)
++#define sout_AnnounceUnRegister(o, a) \
++        sout_AnnounceUnRegister(VLC_OBJECT (o), a)
++
++/** SDP */
++
++struct sockaddr;
++struct vlc_memstream;
++
++VLC_API int vlc_sdp_Start(struct vlc_memstream *, vlc_object_t *obj,
++                          const char *cfgpref,
++                          const struct sockaddr *src, size_t slen,
++                          const struct sockaddr *addr, size_t alen) VLC_USED;
++VLC_API void sdp_AddMedia(struct vlc_memstream *, const char *type,
++                          const char *protocol, int dport, unsigned pt,
++                          bool bw_indep, unsigned bw, const char *ptname,
++                          unsigned clockrate, unsigned channels,
++                          const char *fmtp);
++VLC_API void sdp_AddAttribute(struct vlc_memstream *, const char *name,
++                              const char *fmt, ...) VLC_FORMAT(3, 4);
++
++/** Description module */
++typedef struct sout_description_data_t
++{
++    int i_es;
++    es_format_t **es;
++    vlc_sem_t *sem;
++} sout_description_data_t;
++
++/** @} */
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_spu.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_spu.h
+new file mode 100644
+index 0000000..ebc4205
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_spu.h
+@@ -0,0 +1,105 @@
++/*****************************************************************************
++ * vlc_spu.h: spu_t definition and functions.
++ *****************************************************************************
++ * Copyright (C) 1999-2010 VLC authors and VideoLAN
++ * Copyright (C) 2010 Laurent Aimar
++ * $Id: 510ee151ec907da9fb6ac88b38cf7ef68a5c4af8 $
++ *
++ * Authors: Gildas Bazin <gbazin@videolan.org>
++ *          Laurent Aimar <fenrir _AT_ videolan _DOT_ org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_SPU_H
++#define VLC_SPU_H 1
++
++#include <vlc_subpicture.h>
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++/**
++ * \defgroup spu Sub-picture channels
++ * \ingroup video_output
++ * @{
++ * \file
++ */
++
++typedef struct spu_private_t spu_private_t;
++
++/**
++ * Subpicture unit descriptor
++ */
++struct spu_t
++{
++    VLC_COMMON_MEMBERS
++
++    spu_private_t *p;
++};
++
++    VLC_API spu_t * spu_Create( vlc_object_t *, vout_thread_t * );
++#define spu_Create(a,b) spu_Create(VLC_OBJECT(a),b)
++VLC_API void spu_Destroy( spu_t * );
++
++/**
++ * This function sends a subpicture to the spu_t core.
++ * 
++ * You cannot use the provided subpicture anymore. The spu_t core
++ * will destroy it at its convenience.
++ */
++VLC_API void spu_PutSubpicture( spu_t *, subpicture_t * );
++
++/**
++ * This function will return an unique subpicture containing the OSD and
++ * subtitles visibles at the requested date.
++ *
++ * \param p_chroma_list is a list of supported chroma for the output (can be NULL)
++ * \param p_fmt_dst is the format of the picture on which the return subpicture will be rendered.
++ * \param p_fmt_src is the format of the original(source) video.
++ *
++ * The returned value if non NULL must be released by subpicture_Delete().
++ */
++VLC_API subpicture_t * spu_Render( spu_t *, const vlc_fourcc_t *p_chroma_list, const video_format_t *p_fmt_dst, const video_format_t *p_fmt_src, mtime_t render_subtitle_date, mtime_t render_osd_date, bool ignore_osd );
++
++/**
++ * It registers a new SPU channel.
++ */
++VLC_API int spu_RegisterChannel( spu_t * );
++
++/**
++ * It clears all subpictures associated to a SPU channel.
++ */
++VLC_API void spu_ClearChannel( spu_t *, int );
++
++/**
++ * It changes the sub sources list
++ */
++VLC_API void spu_ChangeSources( spu_t *, const char * );
++
++/**
++ * It changes the sub filters list
++ */
++VLC_API void spu_ChangeFilters( spu_t *, const char * );
++
++/** @}*/
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif /* VLC_SPU_H */
++
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_stream.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_stream.h
+new file mode 100644
+index 0000000..0d6d0e9
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_stream.h
+@@ -0,0 +1,498 @@
++/*****************************************************************************
++ * vlc_stream.h: Stream (between access and demux) descriptor and methods
++ *****************************************************************************
++ * Copyright (C) 1999-2004 VLC authors and VideoLAN
++ * $Id: 789545e16e59dd99f215d7b2bafb655f49dfbc88 $
++ *
++ * Authors: Laurent Aimar <fenrir@via.ecp.fr>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_STREAM_H
++#define VLC_STREAM_H 1
++
++#include <vlc_block.h>
++
++# ifdef __cplusplus
++extern "C" {
++# endif
++
++/**
++ * \defgroup stream Stream
++ * \ingroup input
++ * Buffered input byte streams
++ * @{
++ * \file
++ * Byte streams and byte stream filter modules interface
++ */
++
++/**
++ * stream_t definition
++ */
++
++struct stream_t
++{
++    VLC_COMMON_MEMBERS
++
++    /* Module properties for stream filter */
++    module_t    *p_module;
++
++    char        *psz_name;
++    char        *psz_url; /**< Full URL or MRL (can be NULL) */
++    const char  *psz_location; /**< Location (URL with the scheme stripped) */
++    char        *psz_filepath; /**< Local file path (if applicable) */
++    bool         b_preparsing; /**< True if this access is used to preparse */
++
++    /* Stream source for stream filter */
++    stream_t *p_source;
++
++    /**
++     * Read data.
++     *
++     * Callback to read data from the stream into a caller-supplied buffer.
++     *
++     * This may be NULL if the stream is actually a directory rather than a
++     * byte stream, or if \ref stream_t.pf_block is non-NULL.
++     *
++     * \param buf buffer to read data into
++     * \param len buffer length (in bytes)
++     *
++     * \retval -1 no data available yet
++     * \retval 0 end of stream (incl. fatal error)
++     * \retval positive number of bytes read (no more than len)
++     */
++    ssize_t     (*pf_read)(stream_t *, void *buf, size_t len);
++
++    /**
++     * Read data block.
++     *
++     * Callback to read a block of data. The data is read into a block of
++     * memory allocated by the stream. For some streams, data can be read more
++     * efficiently in block of a certain size, and/or using a custom allocator
++     * for buffers. In such case, this callback should be provided instead of
++     * \ref stream_t.pf_read; otherwise, this should be NULL.
++     *
++     * \param eof storage space for end-of-stream flag [OUT]
++     * (*eof is always false when invoking pf_block(); pf_block() should set
++     *  *eof to true if it detects the end of the stream)
++     *
++     * \return a data block,
++     * NULL if no data available yet, on error and at end-of-stream
++     */
++    block_t    *(*pf_block)(stream_t *, bool *eof);
++
++    /**
++     * Read directory.
++     *
++     * Callback to fill an item node from a directory
++     * (see doc/browsing.txt for details).
++     *
++     * NULL if the stream is not a directory.
++     */
++    int         (*pf_readdir)(stream_t *, input_item_node_t *);
++
++    /**
++     * Seek.
++     *
++     * Callback to set the stream pointer (in bytes from start).
++     *
++     * May be NULL if seeking is not supported.
++     */
++    int         (*pf_seek)(stream_t *, uint64_t);
++
++    /**
++     * Stream control.
++     *
++     * Cannot be NULL.
++     *
++     * \see stream_query_e
++     */
++    int         (*pf_control)(stream_t *, int i_query, va_list);
++
++    /**
++     * Private data pointer
++     */
++    void *p_sys;
++
++    /* Weak link to parent input */
++    input_thread_t *p_input;
++};
++
++/**
++ * Possible commands to send to vlc_stream_Control() and vlc_stream_vaControl()
++ */
++enum stream_query_e
++{
++    /* capabilities */
++    STREAM_CAN_SEEK,            /**< arg1= bool *   res=cannot fail*/
++    STREAM_CAN_FASTSEEK,        /**< arg1= bool *   res=cannot fail*/
++    STREAM_CAN_PAUSE,           /**< arg1= bool *   res=cannot fail*/
++    STREAM_CAN_CONTROL_PACE,    /**< arg1= bool *   res=cannot fail*/
++    /* */
++    STREAM_GET_SIZE=6,          /**< arg1= uint64_t *     res=can fail */
++    STREAM_IS_DIRECTORY,        /**< res=can fail */
++
++    /* */
++    STREAM_GET_PTS_DELAY = 0x101,/**< arg1= int64_t* res=cannot fail */
++    STREAM_GET_TITLE_INFO, /**< arg1=input_title_t*** arg2=int* res=can fail */
++    STREAM_GET_TITLE,       /**< arg1=unsigned * res=can fail */
++    STREAM_GET_SEEKPOINT,   /**< arg1=unsigned * res=can fail */
++    STREAM_GET_META,        /**< arg1= vlc_meta_t *       res=can fail */
++    STREAM_GET_CONTENT_TYPE,    /**< arg1= char **         res=can fail */
++    STREAM_GET_SIGNAL,      /**< arg1=double *pf_quality, arg2=double *pf_strength   res=can fail */
++    STREAM_GET_TAGS,        /**< arg1=const block_t ** res=can fail */
++
++    STREAM_SET_PAUSE_STATE = 0x200, /**< arg1= bool        res=can fail */
++    STREAM_SET_TITLE,       /**< arg1= int          res=can fail */
++    STREAM_SET_SEEKPOINT,   /**< arg1= int          res=can fail */
++
++    /* XXX only data read through vlc_stream_Read/Block will be recorded */
++    STREAM_SET_RECORD_STATE,     /**< arg1=bool, arg2=const char *psz_ext (if arg1 is true)  res=can fail */
++
++    STREAM_SET_PRIVATE_ID_STATE = 0x1000, /* arg1= int i_private_data, bool b_selected    res=can fail */
++    STREAM_SET_PRIVATE_ID_CA,             /* arg1= int i_program_number, uint16_t i_vpid, uint16_t i_apid1, uint16_t i_apid2, uint16_t i_apid3, uint8_t i_length, uint8_t *p_data */
++    STREAM_GET_PRIVATE_ID_STATE,          /* arg1=int i_private_data arg2=bool *          res=can fail */
++};
++
++/**
++ * Reads data from a byte stream.
++ *
++ * This function always waits for the requested number of bytes, unless a fatal
++ * error is encountered or the end-of-stream is reached first.
++ *
++ * If the buffer is NULL, data is skipped instead of read. This is effectively
++ * a relative forward seek, but it works even on non-seekable streams.
++ *
++ * \param buf start of buffer to read data into [OUT]
++ * \param len number of bytes to read
++ * \return the number of bytes read or a negative value on error.
++ */
++VLC_API ssize_t vlc_stream_Read(stream_t *, void *buf, size_t len) VLC_USED;
++
++/**
++ * Reads partial data from a byte stream.
++ *
++ * This function waits until some data is available for reading from the
++ * stream, a fatal error is encountered or the end-of-stream is reached.
++ *
++ * Unlike vlc_stream_Read(), this function does not wait for the full requested
++ * bytes count. It can return a short count even before the end of the stream
++ * and in the absence of any error.
++ *
++ * \param buf start of buffer to read data into [OUT]
++ * \param len buffer size (maximum number of bytes to read)
++ * \return the number of bytes read or a negative value on error.
++ */
++VLC_API ssize_t vlc_stream_ReadPartial(stream_t *, void *buf, size_t len)
++VLC_USED;
++
++/**
++ * Peeks at data from a byte stream.
++ *
++ * This function buffers for the requested number of bytes, waiting if
++ * necessary. Then it stores a pointer to the buffer. Unlike vlc_stream_Read()
++ * or vlc_stream_Block(), this function does not modify the stream read offset.
++ *
++ * \note
++ * The buffer remains valid until the next read/peek or seek operation on the
++ * same stream. In case of error, the buffer address is undefined.
++ *
++ * \param bufp storage space for the buffer address [OUT]
++ * \param len number of bytes to peek
++ * \return the number of bytes actually available (shorter than requested if
++ * the end-of-stream is reached), or a negative value on error.
++ */
++VLC_API ssize_t vlc_stream_Peek(stream_t *, const uint8_t **, size_t) VLC_USED;
++
++/**
++ * Reads a data block from a byte stream.
++ *
++ * This function dequeues the next block of data from the byte stream. The
++ * byte stream back-end decides on the size of the block; the caller cannot
++ * make any assumption about it.
++ *
++ * The function might also return NULL spuriously - this does not necessarily
++ * imply that the stream is ended nor that it has encountered a nonrecoverable
++ * error.
++ *
++ * This function should be used instead of vlc_stream_Read() or
++ * vlc_stream_Peek() when the caller can handle reads of any size.
++ *
++ * \return either a data block or NULL
++ */
++VLC_API block_t *vlc_stream_ReadBlock(stream_t *) VLC_USED;
++
++/**
++ * Tells the current stream position.
++ *
++ * This function tells the current read offset (in bytes) from the start of
++ * the start of the stream.
++ * @note The read offset may be larger than the stream size, either because of
++ * a seek past the end, or because the stream shrank asynchronously.
++ *
++ * @return the byte offset from the beginning of the stream (cannot fail)
++ */
++VLC_API uint64_t vlc_stream_Tell(const stream_t *) VLC_USED;
++
++/**
++ * Checks for end of stream.
++ *
++ * Checks if the last attempt to reads data from the stream encountered the
++ * end of stream before the attempt could be fully satisfied.
++ * The value is initially false, and is reset to false by vlc_stream_Seek().
++ *
++ * \note The function can return false even though the current stream position
++ * is equal to the stream size. It will return true after the following attempt
++ * to read more than zero bytes.
++ *
++ * \note It might be possible to read after the end of the stream.
++ * It implies the size of the stream increased asynchronously in the mean time.
++ * Streams of most types cannot trigger such a case,
++ * but regular local files notably can.
++ *
++ * \note In principles, the stream size should match the stream offset when
++ * the end-of-stream is reached. But that rule is not enforced; it is entirely
++ * dependent on the underlying implementation of the stream.
++ */
++VLC_API bool vlc_stream_Eof(const stream_t *) VLC_USED;
++
++/**
++ * Sets the current stream position.
++ *
++ * This function changes the read offset within a stream, if the stream
++ * supports seeking. In case of error, the read offset is not changed.
++ *
++ * @note It is possible (but not useful) to seek past the end of a stream.
++ *
++ * @param offset byte offset from the beginning of the stream
++ * @return zero on success, a negative value on error
++ */
++VLC_API int vlc_stream_Seek(stream_t *, uint64_t offset) VLC_USED;
++
++VLC_API int vlc_stream_vaControl(stream_t *s, int query, va_list args);
++
++static inline int vlc_stream_Control(stream_t *s, int query, ...)
++{
++    va_list ap;
++    int ret;
++
++    va_start(ap, query);
++    ret = vlc_stream_vaControl(s, query, ap);
++    va_end(ap);
++    return ret;
++}
++
++VLC_API block_t *vlc_stream_Block(stream_t *s, size_t);
++VLC_API char *vlc_stream_ReadLine(stream_t *);
++VLC_API int vlc_stream_ReadDir(stream_t *, input_item_node_t *);
++
++/**
++ * Closes a byte stream.
++ * \param s byte stream to close
++ */
++VLC_API void vlc_stream_Delete(stream_t *s);
++
++VLC_API stream_t *vlc_stream_CommonNew(vlc_object_t *, void (*)(stream_t *));
++
++/**
++ * Get the size of the stream.
++ */
++VLC_USED static inline int vlc_stream_GetSize( stream_t *s, uint64_t *size )
++{
++    return vlc_stream_Control( s, STREAM_GET_SIZE, size );
++}
++
++static inline int64_t stream_Size( stream_t *s )
++{
++    uint64_t i_pos;
++
++    if( vlc_stream_GetSize( s, &i_pos ) )
++        return 0;
++    if( i_pos >> 62 )
++        return (int64_t)1 << 62;
++    return i_pos;
++}
++
++VLC_USED
++static inline bool stream_HasExtension( stream_t *s, const char *extension )
++{
++    const char *name = (s->psz_filepath != NULL) ? s->psz_filepath
++                                                 : s->psz_url;
++    const char *ext = strrchr( name, '.' );
++    return ext != NULL && !strcasecmp( ext, extension );
++}
++
++/**
++ * Get the Content-Type of a stream, or NULL if unknown.
++ * Result must be free()'d.
++ */
++static inline char *stream_ContentType( stream_t *s )
++{
++    char *res;
++    if( vlc_stream_Control( s, STREAM_GET_CONTENT_TYPE, &res ) )
++        return NULL;
++    return res;
++}
++
++/**
++ * Get the mime-type of a stream
++ *
++ * \warning the returned resource is to be freed by the caller
++ * \return the mime-type, or `NULL` if unknown
++ **/
++VLC_USED
++static inline char *stream_MimeType( stream_t *s )
++{
++    char* mime_type = stream_ContentType( s );
++
++    if( mime_type ) /* strip parameters */
++        mime_type[strcspn( mime_type, " ;" )] = '\0';
++
++    return mime_type;
++}
++
++/**
++ * Checks for a MIME type.
++ *
++ * Checks if the stream has a specific MIME type.
++ */
++VLC_USED
++static inline bool stream_IsMimeType(stream_t *s, const char *type)
++{
++    char *mime = stream_MimeType(s);
++    if (mime == NULL)
++        return false;
++
++    bool ok = !strcasecmp(mime, type);
++    free(mime);
++    return ok;
++}
++
++/**
++ * Create a stream from a memory buffer.
++ *
++ * \param obj parent VLC object
++ * \param base start address of the memory buffer to read from
++ * \param size size in bytes of the memory buffer
++ * \param preserve if false, free(base) will be called when the stream is
++ *                 destroyed; if true, the memory buffer is preserved
++ */
++VLC_API stream_t *vlc_stream_MemoryNew(vlc_object_t *obj, uint8_t *base,
++                                       size_t size, bool preserve) VLC_USED;
++#define vlc_stream_MemoryNew(a, b, c, d) \
++        vlc_stream_MemoryNew(VLC_OBJECT(a), b, c, d)
++
++/**
++ * Create a stream_t reading from a URL.
++ * You must delete it using vlc_stream_Delete.
++ */
++VLC_API stream_t * vlc_stream_NewURL(vlc_object_t *obj, const char *url)
++VLC_USED;
++#define vlc_stream_NewURL(a, b) vlc_stream_NewURL(VLC_OBJECT(a), b)
++
++/**
++ * \defgroup stream_fifo FIFO stream
++ * In-memory anonymous pipe
++  @{
++ */
++
++/**
++ * Creates a FIFO stream.
++ *
++ * Creates a non-seekable byte stream object whose byte stream is generated
++ * by another thread in the process. This is the LibVLC equivalent of an
++ * anonymous pipe/FIFO.
++ *
++ * On the reader side, the normal stream functions are used,
++ * e.g. vlc_stream_Read() and vlc_stream_Delete().
++ *
++ * The created stream object is automatically destroyed when both the reader
++ * and the writer sides have been closed, with vlc_stream_Delete() and
++ * vlc_stream_fifo_Close() respectively.
++ *
++ * \param parent parent VLC object for the stream
++ * \return a stream object or NULL on memory error.
++ */
++VLC_API stream_t *vlc_stream_fifo_New(vlc_object_t *parent);
++
++/**
++ * Writes a block to a FIFO stream.
++ *
++ * \param s FIFO stream created by vlc_stream_fifo_New()
++ * \param block data block to write to the stream
++ * \return 0 on success. -1 if the reader end has already been closed
++ * (errno is then set to EPIPE, and the block is deleted).
++ *
++ * \bug No congestion control is performed. If the reader end is not keeping
++ * up with the writer end, buffers will accumulate in memory.
++ */
++VLC_API int vlc_stream_fifo_Queue(stream_t *s, block_t *block);
++
++/**
++ * Writes data to a FIFO stream.
++ *
++ * This is a convenience helper for vlc_stream_fifo_Queue().
++ * \param s FIFO stream created by vlc_stream_fifo_New()
++ * \param buf start address of data to write
++ * \param len length of data to write in bytes
++ * \return len on success, or -1 on error (errno is set accordingly)
++ */
++VLC_API ssize_t vlc_stream_fifo_Write(stream_t *s, const void *buf,
++                                      size_t len);
++
++/**
++ * Terminates a FIFO stream.
++ *
++ * Marks the end of the FIFO stream and releases any underlying resources.
++ * \param s FIFO stream created by vlc_stream_fifo_New()
++ */
++VLC_API void vlc_stream_fifo_Close(stream_t *s);
++
++/**
++ * @}
++ */
++
++/**
++ * Try to add a stream filter to an open stream.
++ * @return New stream to use, or NULL if the filter could not be added.
++ **/
++VLC_API stream_t* vlc_stream_FilterNew( stream_t *p_source, const char *psz_stream_filter );
++
++/**
++ * Default ReadDir implementation for stream Filter. This implementation just
++ * forward the pf_readdir call to the p_source stream.
++ */
++VLC_API int vlc_stream_FilterDefaultReadDir(stream_t *s,
++                                            input_item_node_t *p_node);
++
++/**
++ * Sets vlc_stream_FilterDefaultReadDir as the pf_readdir callback for this
++ * stream filter.
++ */
++#define stream_FilterSetDefaultReadDir(stream) \
++do { \
++    (stream)->pf_readdir = vlc_stream_FilterDefaultReadDir; \
++} while (0)
++
++/**
++ * @}
++ */
++
++# ifdef __cplusplus
++}
++# endif
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_stream_extractor.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_stream_extractor.h
+new file mode 100644
+index 0000000..78c51c0
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_stream_extractor.h
+@@ -0,0 +1,170 @@
++/*****************************************************************************
++ * vlc_stream_extractor.h
++ *****************************************************************************
++ * Copyright (C) 2016 VLC authors and VideoLAN
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_STREAM_EXTRACTOR_H
++#define VLC_STREAM_EXTRACTOR_H
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++/**
++ * \defgroup stream_extractor Stream Extractor
++ * \ingroup input
++ *
++ * If a stream can be viewed as a directory, such as when opening a
++ * compressed archive, a \em stream-extractor is used to get access to
++ * the entities inside said stream.
++ *
++ * A \em stream-extractor can do one of two things;
++ *
++ *  - lists the logical entries within a stream:
++ *    - type = \ref stream_directory_t
++ *    - capability = "stream_directory"
++ *
++ *  - extract data associated with one specific entry within a stream:
++ *    - type = \ref stream_extractor_t
++ *    - capability = "stream_extractor"
++ *
++ * @{
++ *
++ **/
++
++typedef struct stream_extractor_t {
++    VLC_COMMON_MEMBERS
++
++    /**
++     * \name Callbacks for entity extraction
++     *
++     * The following members shall be populated as specified by the
++     * documentation associated with \ref stream_t for the equivalent name.
++     *
++     * @{
++     **/
++    ssize_t  (*pf_read)(struct stream_extractor_t*, void* buf, size_t len);
++    block_t* (*pf_block)(struct stream_extractor_t*, bool* eof);
++    int      (*pf_seek)(struct stream_extractor_t*, uint64_t);
++    int      (*pf_control)(struct stream_extractor_t*, int request, va_list args);
++    /** @} */
++
++    char const* identifier; /**< the name of the entity to be extracted */
++    stream_t* source; /**< the source stream to be consumed */
++    void* p_sys;      /**< private opaque handle to be used by the module */
++
++} stream_extractor_t;
++
++typedef struct stream_directory_t {
++    VLC_COMMON_MEMBERS
++
++    /**
++     * \name Callbacks for stream directories
++     *
++     * The following members shall be populated as specified by the
++     * documentation associated with \ref stream_t for the equivalent name.
++     *
++     * @{
++     **/
++    int (*pf_readdir)(struct stream_directory_t*, input_item_node_t* );
++    /** @} */
++
++    stream_t* source; /**< the source stream to be consumed */
++    void* p_sys; /**< private opaque handle to be used by the module */
++
++} stream_directory_t;
++
++/**
++ * Create a stream for the data referred to by a \ref mrl
++ *
++ * This function will create a \ref stream that reads from the specified \ref
++ * mrl, potentially making use of \ref stream_extractor%s to access named
++ * entities within the data read from the original source.
++ *
++ *  - See the \ref mrl specification for further information.
++ *  - The returned resource shall be deleted through \ref vlc_stream_Delete.
++ *
++ * \warning This function is only to be used when \ref mrl functionality is
++ *          explicitly needed. \ref vlc_stream_NewURL shall be used where
++ *          applicable.
++ *
++ * \param obj the owner of the requested stream
++ * \param mrl the mrl for which the stream_t should be created
++ * \return `NULL` on error, a pointer to \ref stream_t on success.
++ **/
++VLC_API stream_t * vlc_stream_NewMRL(vlc_object_t *obj, const char *mrl)
++VLC_USED;
++#define vlc_stream_NewMRL(a, b) vlc_stream_NewMRL(VLC_OBJECT(a), b)
++
++/**
++ * Create a relative MRL for the associated entity
++ *
++ * This function shall be used by stream_directory_t's in order to
++ * generate an MRL that refers to an entity within the stream. Normally
++ * this function will only be invoked within `pf_readdir` in order to
++ * get the virtual path of the listed items.
++ *
++ * \warning the returned value is to be freed by the caller
++ *
++ * \param extractor the stream_directory_t for which the entity belongs
++ * \param subentry the name of the entity in question
++ *
++ * \return a pointer to the resulting MRL on success, NULL on failure
++ **/
++VLC_API char* vlc_stream_extractor_CreateMRL( stream_directory_t*,
++                                              char const* subentry );
++
++/**
++ * \name Attach a stream-extractor to the passed stream
++ *
++ * These functions are used to attach a stream extractor to an already existing
++ * stream. As hinted by their names, \ref vlc_stream_extractor_Attach will
++ * attach an \em entity-extractor, whereas \ref vlc_stream_directory_Attach
++ * will attach a \em stream-directory.
++ *
++ * \param[out] stream a pointer-to-pointer to stream, `*stream` will
++ *             refer to the attached stream on success, and left
++ *             untouched on failure.
++ * \param identifier (if present) NULL or a c-style string referring to the
++ *                   desired entity
++ * \param module_name NULL or an explicit stream-extractor module name
++ *
++ * \return VLC_SUCCESS if a stream-extractor was successfully
++ *         attached, an error-code on failure.
++ *
++ * @{
++ **/
++
++VLC_API int vlc_stream_extractor_Attach( stream_t** source,
++                                         char const* identifier,
++                                         char const* module_name );
++
++VLC_API int vlc_stream_directory_Attach( stream_t** source,
++                                         char const* module_name );
++/**
++ * @}
++ */
++
++/**
++ * @}
++ */
++
++#ifdef __cplusplus
++} /* extern "C" */
++#endif
++#endif /* include-guard */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_strings.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_strings.h
+new file mode 100644
+index 0000000..c222e24
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_strings.h
+@@ -0,0 +1,159 @@
++/*****************************************************************************
++ * vlc_strings.h: String functions
++ *****************************************************************************
++ * Copyright (C) 2006 VLC authors and VideoLAN
++ * $Id: 9828fbd728ee791d409568405f280634132b91a6 $
++ *
++ * Authors: Antoine Cellerier <dionoea at videolan dot org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_STRINGS_H
++#define VLC_STRINGS_H 1
++
++/**
++ * \defgroup strings String helpers
++ * @{
++ * \file
++ * Helper functions for nul-terminated strings
++ */
++
++static inline int vlc_ascii_toupper( int c )
++{
++    if ( c >= 'a' && c <= 'z' )
++        return c + ( 'A' - 'a' );
++    else
++        return c;
++}
++
++static inline int vlc_ascii_tolower( int c )
++{
++    if ( c >= 'A' && c <= 'Z' )
++        return c + ( 'a' - 'A' );
++    else
++        return c;
++}
++
++/**
++ * Compare two ASCII strings ignoring case.
++ *
++ * The result is independent of the locale. If there are non-ASCII
++ * characters in the strings, their cases are NOT ignored in the
++ * comparison.
++ */
++static inline int vlc_ascii_strcasecmp( const char *psz1, const char *psz2 )
++{
++    const char *s1 = psz1;
++    const char *s2 = psz2;
++    int d = vlc_ascii_tolower( *s1 ) - vlc_ascii_tolower( *s2 );
++    while ( *s1 && d == 0)
++    {
++        s1++;
++        s2++;
++        d = vlc_ascii_tolower( *s1 ) - vlc_ascii_tolower( *s2 );
++    }
++
++    return d;
++}
++
++static inline int vlc_ascii_strncasecmp( const char *psz1, const char *psz2, size_t n )
++{
++    const char *s1 = psz1;
++    const char *s2 = psz2;
++    const char *s1end = psz1 + n;
++    int d = vlc_ascii_tolower( *s1 ) - vlc_ascii_tolower( *s2 );
++    while ( *s1 && s1 < s1end && d == 0)
++    {
++        s1++;
++        s2++;
++        d = vlc_ascii_tolower( *s1 ) - vlc_ascii_tolower( *s2 );
++    }
++
++    if (s1 == s1end)
++        return 0;
++    else
++        return d;
++}
++
++/**
++ * Decodes XML entities.
++ *
++ * Decodes a null-terminated UTF-8 string of XML character data into a regular
++ * nul-terminated UTF-8 string. In other words, replaces XML entities and
++ * numerical character references with the corresponding characters.
++ *
++ * This function operates in place (the output is always of smaller or equal
++ * length than the input) and always succeeds.
++ *
++ * \param str null-terminated string [IN/OUT]
++ */
++VLC_API void vlc_xml_decode(char *st);
++
++/**
++ * Encodes XML entites.
++ *
++ * Substitutes unsafe characters in a null-terminated UTF-8 strings with an
++ * XML entity or numerical character reference.
++ *
++ * \param str null terminated UTF-8 string
++ * \return On success, a heap-allocated null-terminated string is returned.
++ * If the input string was not a valid UTF-8 sequence, NULL is returned and
++ * errno is set to EILSEQ.
++ * If there was not enough memory, NULL is returned and errno is to ENOMEM.
++ */
++VLC_API char *vlc_xml_encode(const char *str) VLC_MALLOC;
++
++VLC_API char * vlc_b64_encode_binary( const uint8_t *, size_t );
++VLC_API char * vlc_b64_encode( const char * );
++
++VLC_API size_t vlc_b64_decode_binary_to_buffer( uint8_t *p_dst, size_t i_dst_max, const char *psz_src );
++VLC_API size_t vlc_b64_decode_binary( uint8_t **pp_dst, const char *psz_src );
++VLC_API char * vlc_b64_decode( const char *psz_src );
++
++/**
++ * Convenience wrapper for strftime().
++ *
++ * Formats the current time into a heap-allocated string.
++ *
++ * @param tformat time format (as with C strftime())
++ * @return an allocated string (must be free()'d), or NULL on memory error.
++ */
++VLC_API char *vlc_strftime( const char * );
++
++/**
++ * Formats input meta-data.
++ *
++ * Formats input and input item meta-informations into a heap-allocated string.
++ */
++VLC_API char *vlc_strfinput( input_thread_t *, const char * );
++
++static inline char *str_format( input_thread_t *input, const char *fmt )
++{
++    char *s1 = vlc_strftime( fmt );
++    char *s2 = vlc_strfinput( input, s1 );
++    free( s1 );
++    return s2;
++}
++
++VLC_API int vlc_filenamecmp(const char *, const char *);
++
++void filename_sanitize(char *);
++
++/**
++ * @}
++ */
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_subpicture.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_subpicture.h
+new file mode 100644
+index 0000000..67157c0
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_subpicture.h
+@@ -0,0 +1,237 @@
++/*****************************************************************************
++ * vlc_subpicture.h: subpicture definitions
++ *****************************************************************************
++ * Copyright (C) 1999 - 2009 VLC authors and VideoLAN
++ * $Id: b9de52c0493687f2f9920753562e2f1eebfd1b7b $
++ *
++ * Authors: Vincent Seguin <seguin@via.ecp.fr>
++ *          Samuel Hocevar <sam@via.ecp.fr>
++ *          Olivier Aubert <oaubert 47 videolan d07 org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_SUBPICTURE_H
++#define VLC_SUBPICTURE_H 1
++
++/**
++ */
++
++#include <vlc_picture.h>
++#include <vlc_text_style.h>
++
++/**
++ * \defgroup subpicture Video sub-pictures
++ * \ingroup video_output
++ * Subpictures are pictures that should be displayed on top of the video, like
++ * subtitles and OSD
++ * @{
++ * \file
++ * Subpictures functions
++ */
++
++/**
++ * Video subtitle region spu core private
++ */
++typedef struct subpicture_region_private_t subpicture_region_private_t;
++
++/**
++ * Video subtitle region
++ *
++ * A subtitle region is defined by a picture (graphic) and its rendering
++ * coordinates.
++ * Subtitles contain a list of regions.
++ */
++struct subpicture_region_t
++{
++    video_format_t  fmt;                          /**< format of the picture */
++    picture_t       *p_picture;          /**< picture comprising this region */
++
++    int             i_x;      /**< position of region, relative to alignment */
++    int             i_y;      /**< position of region, relative to alignment */
++    int             i_align;                  /**< alignment flags of region */
++    int             i_alpha;                               /**< transparency */
++
++    /* Parameters for text regions (p_picture to be rendered) */
++    text_segment_t  *p_text;         /**< subtitle text, made of a list of segments */
++    int             i_text_align;    /**< alignment flags of region content */
++    bool            b_noregionbg;    /**< render background under text only */
++    bool            b_gridmode;      /** if the decoder sends row/cols based output */
++    bool            b_balanced_text; /** try to balance wrapped text lines */
++    int             i_max_width;     /** horizontal rendering/cropping target/limit */
++    int             i_max_height;    /** vertical rendering/cropping target/limit */
++
++    subpicture_region_t *p_next;                /**< next region in the list */
++    subpicture_region_private_t *p_private;  /**< Private data for spu_t *only* */
++};
++
++/* Subpicture region position flags */
++#define SUBPICTURE_ALIGN_LEFT       0x1
++#define SUBPICTURE_ALIGN_RIGHT      0x2
++#define SUBPICTURE_ALIGN_TOP        0x4
++#define SUBPICTURE_ALIGN_BOTTOM     0x8
++#define SUBPICTURE_ALIGN_MASK ( SUBPICTURE_ALIGN_LEFT|SUBPICTURE_ALIGN_RIGHT| \
++                                SUBPICTURE_ALIGN_TOP |SUBPICTURE_ALIGN_BOTTOM )
++/**
++ * This function will create a new subpicture region.
++ *
++ * You must use subpicture_region_Delete to destroy it.
++ */
++VLC_API subpicture_region_t * subpicture_region_New( const video_format_t *p_fmt );
++
++/**
++ * This function will destroy a subpicture region allocated by
++ * subpicture_region_New.
++ *
++ * You may give it NULL.
++ */
++VLC_API void subpicture_region_Delete( subpicture_region_t *p_region );
++
++/**
++ * This function will destroy a list of subpicture regions allocated by
++ * subpicture_region_New.
++ *
++ * Provided for convenience.
++ */
++VLC_API void subpicture_region_ChainDelete( subpicture_region_t *p_head );
++
++/**
++ * This function will copy a subpicture region to a new allocated one
++ * and transfer all the properties
++ *
++ * Provided for convenience.
++ */
++VLC_API subpicture_region_t *subpicture_region_Copy( subpicture_region_t *p_region );
++
++/**
++ *
++ */
++typedef struct subpicture_updater_sys_t subpicture_updater_sys_t;
++typedef struct
++{
++    /** Optional pre update callback, usually useful on video format change.
++      * Will skip pf_update on VLC_SUCCESS, or will delete every region before
++      * the call to pf_update */
++    int  (*pf_validate)( subpicture_t *,
++                         bool has_src_changed, const video_format_t *p_fmt_src,
++                         bool has_dst_changed, const video_format_t *p_fmt_dst,
++                         mtime_t);
++    /** Mandatory callback called after pf_validate and doing
++      * the main job of creating the subpicture regions for the
++      * current video_format */
++    void (*pf_update)  ( subpicture_t *,
++                         const video_format_t *p_fmt_src,
++                         const video_format_t *p_fmt_dst,
++                         mtime_t );
++    /** Optional callback for subpicture private data cleanup */
++    void (*pf_destroy) ( subpicture_t * );
++    subpicture_updater_sys_t *p_sys;
++} subpicture_updater_t;
++
++typedef struct subpicture_private_t subpicture_private_t;
++
++/**
++ * Video subtitle
++ *
++ * Any subtitle destined to be displayed by a video output thread should
++ * be stored in this structure from it's creation to it's effective display.
++ * Subtitle type and flags should only be modified by the output thread. Note
++ * that an empty subtitle MUST have its flags set to 0.
++ */
++struct subpicture_t
++{
++    /** \name Channel ID */
++    /**@{*/
++    int             i_channel;                    /**< subpicture channel ID */
++    /**@}*/
++
++    /** \name Type and flags
++       Should NOT be modified except by the vout thread */
++    /**@{*/
++    int64_t         i_order;                 /** an increasing unique number */
++    subpicture_t *  p_next;               /**< next subtitle to be displayed */
++    /**@}*/
++
++    subpicture_region_t *p_region;  /**< region list composing this subtitle */
++
++    /** \name Date properties */
++    /**@{*/
++    mtime_t         i_start;                  /**< beginning of display date */
++    mtime_t         i_stop;                         /**< end of display date */
++    bool            b_ephemer;    /**< If this flag is set to true the subtitle
++                                will be displayed until the next one appear */
++    bool            b_fade;                               /**< enable fading */
++    /**@}*/
++
++    /** \name Display properties
++     * These properties are only indicative and may be
++     * changed by the video output thread, or simply ignored depending of the
++     * subtitle type. */
++    /**@{*/
++    bool         b_subtitle;            /**< the picture is a movie subtitle */
++    bool         b_absolute;                       /**< position is absolute */
++    int          i_original_picture_width;  /**< original width of the movie */
++    int          i_original_picture_height;/**< original height of the movie */
++    int          i_alpha;                                  /**< transparency */
++     /**@}*/
++
++    subpicture_updater_t updater;
++
++    subpicture_private_t *p_private;    /* Reserved to the core */
++};
++
++/**
++ * This function create a new empty subpicture.
++ *
++ * You must use subpicture_Delete to destroy it.
++ */
++VLC_API subpicture_t * subpicture_New( const subpicture_updater_t * );
++
++/**
++ * This function delete a subpicture created by subpicture_New.
++ * You may give it NULL.
++ */
++VLC_API void subpicture_Delete( subpicture_t *p_subpic );
++
++/**
++ * This function will create a subpicture having one region in the requested
++ * chroma showing the given picture.
++ *
++ * The picture_t given is not released nor used inside the
++ * returned subpicture_t.
++ */
++VLC_API subpicture_t * subpicture_NewFromPicture( vlc_object_t *, picture_t *, vlc_fourcc_t i_chroma );
++
++/**
++ * This function will update the content of a subpicture created with
++ * a non NULL subpicture_updater_t.
++ */
++VLC_API void subpicture_Update( subpicture_t *, const video_format_t *src, const video_format_t *, mtime_t );
++
++/**
++ * This function will blend a given subpicture onto a picture.
++ *
++ * The subpicture and all its region must:
++ *  - be absolute.
++ *  - not be ephemere.
++ *  - not have the fade flag.
++ *  - contains only picture (no text rendering).
++ * \return the number of region(s) successfully blent
++ */
++VLC_API unsigned picture_BlendSubpicture( picture_t *, filter_t *p_blend, subpicture_t * );
++
++/**@}*/
++
++#endif /* _VLC_VIDEO_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_text_style.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_text_style.h
+new file mode 100644
+index 0000000..13850d0
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_text_style.h
+@@ -0,0 +1,404 @@
++/*****************************************************************************
++ * vlc_text_style.h: text_style_t definition and helpers.
++ *****************************************************************************
++ * Copyright (C) 1999-2010 VLC authors and VideoLAN
++ * $Id: c24d76adcfedf63514255bb31483acb9325df1b1 $
++ *
++ * Authors: Derk-Jan Hartman <hartman _AT_ videolan _DOT_ org>
++ *          basOS G <noxelia 4t gmail , com>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_TEXT_STYLE_H
++#define VLC_TEXT_STYLE_H 1
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++/**
++ * Text style
++ *
++ * A text style is used to specify the formatting of text.
++ * A font renderer can use the supplied information to render the
++ * text specified.
++ */
++typedef struct
++{
++    /* Family font names */
++    char *     psz_fontname;      /**< The name of the font */
++    char *     psz_monofontname;  /**< The name of the mono font */
++
++    uint16_t   i_features;        /**< Feature flags (means non default) */
++    uint16_t   i_style_flags;     /**< Formatting style flags */
++
++    /* Font style */
++    float      f_font_relsize;    /**< The font size in video height % */
++    int        i_font_size;       /**< The font size in pixels */
++    int        i_font_color;      /**< The color of the text 0xRRGGBB
++                                       (native endianness) */
++    uint8_t    i_font_alpha;      /**< The transparency of the text.*/
++    int        i_spacing;         /**< The spaceing between glyphs in pixels */
++
++    /* Outline */
++    int        i_outline_color;   /**< The color of the outline 0xRRGGBB */
++    uint8_t    i_outline_alpha;   /**< The transparency of the outline */
++    int        i_outline_width;   /**< The width of the outline in pixels */
++
++    /* Shadow */
++    int        i_shadow_color;    /**< The color of the shadow 0xRRGGBB */
++    uint8_t    i_shadow_alpha;    /**< The transparency of the shadow. */
++    int        i_shadow_width;    /**< The width of the shadow in pixels */
++
++    /* Background (and karaoke) */
++    int        i_background_color;/**< The color of the background 0xRRGGBB */
++    uint8_t    i_background_alpha;/**< The transparency of the background */
++    int        i_karaoke_background_color;/**< Background color for karaoke 0xRRGGBB */
++    uint8_t    i_karaoke_background_alpha;/**< The transparency of the karaoke bg */
++
++    /* Line breaking */
++    enum
++    {
++        STYLE_WRAP_DEFAULT = 0,   /**< Breaks on whitespace or fallback on char */
++        STYLE_WRAP_CHAR,          /**< Breaks at character level only */
++        STYLE_WRAP_NONE,          /**< No line breaks (except explicit ones) */
++    } e_wrapinfo;
++} text_style_t;
++
++#define STYLE_ALPHA_OPAQUE      0xFF
++#define STYLE_ALPHA_TRANSPARENT 0x00
++
++/* Features flags for \ref i_features */
++#define STYLE_NO_DEFAULTS               0x0
++#define STYLE_FULLY_SET                 0xFFFF
++#define STYLE_HAS_FONT_COLOR            (1 << 0)
++#define STYLE_HAS_FONT_ALPHA            (1 << 1)
++#define STYLE_HAS_FLAGS                 (1 << 2)
++#define STYLE_HAS_OUTLINE_COLOR         (1 << 3)
++#define STYLE_HAS_OUTLINE_ALPHA         (1 << 4)
++#define STYLE_HAS_SHADOW_COLOR          (1 << 5)
++#define STYLE_HAS_SHADOW_ALPHA          (1 << 6)
++#define STYLE_HAS_BACKGROUND_COLOR      (1 << 7)
++#define STYLE_HAS_BACKGROUND_ALPHA      (1 << 8)
++#define STYLE_HAS_K_BACKGROUND_COLOR    (1 << 9)
++#define STYLE_HAS_K_BACKGROUND_ALPHA    (1 << 10)
++#define STYLE_HAS_WRAP_INFO             (1 << 11)
++
++/* Style flags for \ref text_style_t */
++#define STYLE_BOLD              (1 << 0)
++#define STYLE_ITALIC            (1 << 1)
++#define STYLE_OUTLINE           (1 << 2)
++#define STYLE_SHADOW            (1 << 3)
++#define STYLE_BACKGROUND        (1 << 4)
++#define STYLE_UNDERLINE         (1 << 5)
++#define STYLE_STRIKEOUT         (1 << 6)
++#define STYLE_HALFWIDTH         (1 << 7)
++#define STYLE_MONOSPACED        (1 << 8)
++#define STYLE_DOUBLEWIDTH       (1 << 9)
++#define STYLE_BLINK_FOREGROUND  (1 << 10)
++#define STYLE_BLINK_BACKGROUND  (1 << 11)
++
++#define STYLE_DEFAULT_FONT_SIZE 20
++#define STYLE_DEFAULT_REL_FONT_SIZE 6.25
++
++
++typedef struct text_segment_t text_segment_t;
++/**
++ * Text segment for subtitles
++ *
++ * This structure is used to store a formatted text, with mixed styles
++ * Every segment is comprised of one text and a unique style
++ *
++ * On style change, a new segment is created with the next part of text
++ * and the new style, and chained to the list
++ *
++ * Create with text_segment_New and clean the chain with
++ * text_segment_ChainDelete
++ */
++struct text_segment_t {
++    char *psz_text;                   /**< text string of the segment */
++    text_style_t *style;              /**< style applied to this segment */
++    text_segment_t *p_next;           /**< next segment */
++};
++
++/**
++ * Create a default text style
++ */
++VLC_API text_style_t * text_style_New( void );
++
++/**
++ * Create a text style
++ *
++ * Set feature flags as argument if you want to set style defaults
++ */
++VLC_API text_style_t * text_style_Create( int );
++
++/**
++ * Copy a text style into another
++ */
++VLC_API text_style_t * text_style_Copy( text_style_t *, const text_style_t * );
++
++/**
++ * Duplicate a text style
++ */
++VLC_API text_style_t * text_style_Duplicate( const text_style_t * );
++
++/**
++ * Merge two styles using non default values
++ *
++ * Set b_override to true if you also want to overwrite non-defaults
++ */
++VLC_API void text_style_Merge( text_style_t *, const text_style_t *, bool b_override );
++
++/**
++ * Delete a text style created by text_style_New or text_style_Duplicate
++ */
++VLC_API void text_style_Delete( text_style_t * );
++
++/**
++ * This function will create a new text segment.
++ *
++ * You should use text_segment_ChainDelete to destroy it, to clean all
++ * the linked segments, or text_segment_Delete to free a specic one
++ *
++ * This duplicates the string passed as argument
++ */
++VLC_API text_segment_t *text_segment_New( const char * );
++
++/**
++ * This function will create a new text segment and duplicates the style passed as argument
++ *
++ * You should use text_segment_ChainDelete to destroy it, to clean all
++ * the linked segments, or text_segment_Delete to free a specic one
++ *
++ * This doesn't initialize the text.
++ */
++VLC_API text_segment_t *text_segment_NewInheritStyle( const text_style_t* p_style );
++
++/**
++ * Delete a text segment and its content.
++ *
++ * This assumes the segment is not part of a chain
++ */
++VLC_API void text_segment_Delete( text_segment_t * );
++
++/**
++ * This function will destroy a list of text segments allocated
++ * by text_segment_New.
++ *
++ * You may pass it NULL.
++ */
++VLC_API void text_segment_ChainDelete( text_segment_t * );
++
++/**
++ * This function will copy a text_segment and its chain into a new one
++ *
++ * You may give it NULL, but it will return NULL.
++ */
++VLC_API text_segment_t * text_segment_Copy( text_segment_t * );
++
++static const struct {
++    const char *psz_name;
++    uint32_t   i_value;
++} p_html_colors[] = {
++    /* Official html colors */
++    { "Aqua",    0x00FFFF },
++    { "Black",   0x000000 },
++    { "Blue",    0x0000FF },
++    { "Fuchsia", 0xFF00FF },
++    { "Gray",    0x808080 },
++    { "Green",   0x008000 },
++    { "Lime",    0x00FF00 },
++    { "Maroon",  0x800000 },
++    { "Navy",    0x000080 },
++    { "Olive",   0x808000 },
++    { "Purple",  0x800080 },
++    { "Red",     0xFF0000 },
++    { "Silver",  0xC0C0C0 },
++    { "Teal",    0x008080 },
++    { "White",   0xFFFFFF },
++    { "Yellow",  0xFFFF00 },
++
++    /* Common ones */
++    { "AliceBlue", 0xF0F8FF },
++    { "AntiqueWhite", 0xFAEBD7 },
++    { "Aqua", 0x00FFFF },
++    { "Aquamarine", 0x7FFFD4 },
++    { "Azure", 0xF0FFFF },
++    { "Beige", 0xF5F5DC },
++    { "Bisque", 0xFFE4C4 },
++    { "Black", 0x000000 },
++    { "BlanchedAlmond", 0xFFEBCD },
++    { "Blue", 0x0000FF },
++    { "BlueViolet", 0x8A2BE2 },
++    { "Brown", 0xA52A2A },
++    { "BurlyWood", 0xDEB887 },
++    { "CadetBlue", 0x5F9EA0 },
++    { "Chartreuse", 0x7FFF00 },
++    { "Chocolate", 0xD2691E },
++    { "Coral", 0xFF7F50 },
++    { "CornflowerBlue", 0x6495ED },
++    { "Cornsilk", 0xFFF8DC },
++    { "Crimson", 0xDC143C },
++    { "Cyan", 0x00FFFF },
++    { "DarkBlue", 0x00008B },
++    { "DarkCyan", 0x008B8B },
++    { "DarkGoldenRod", 0xB8860B },
++    { "DarkGray", 0xA9A9A9 },
++    { "DarkGrey", 0xA9A9A9 },
++    { "DarkGreen", 0x006400 },
++    { "DarkKhaki", 0xBDB76B },
++    { "DarkMagenta", 0x8B008B },
++    { "DarkOliveGreen", 0x556B2F },
++    { "Darkorange", 0xFF8C00 },
++    { "DarkOrchid", 0x9932CC },
++    { "DarkRed", 0x8B0000 },
++    { "DarkSalmon", 0xE9967A },
++    { "DarkSeaGreen", 0x8FBC8F },
++    { "DarkSlateBlue", 0x483D8B },
++    { "DarkSlateGray", 0x2F4F4F },
++    { "DarkSlateGrey", 0x2F4F4F },
++    { "DarkTurquoise", 0x00CED1 },
++    { "DarkViolet", 0x9400D3 },
++    { "DeepPink", 0xFF1493 },
++    { "DeepSkyBlue", 0x00BFFF },
++    { "DimGray", 0x696969 },
++    { "DimGrey", 0x696969 },
++    { "DodgerBlue", 0x1E90FF },
++    { "FireBrick", 0xB22222 },
++    { "FloralWhite", 0xFFFAF0 },
++    { "ForestGreen", 0x228B22 },
++    { "Fuchsia", 0xFF00FF },
++    { "Gainsboro", 0xDCDCDC },
++    { "GhostWhite", 0xF8F8FF },
++    { "Gold", 0xFFD700 },
++    { "GoldenRod", 0xDAA520 },
++    { "Gray", 0x808080 },
++    { "Grey", 0x808080 },
++    { "Green", 0x008000 },
++    { "GreenYellow", 0xADFF2F },
++    { "HoneyDew", 0xF0FFF0 },
++    { "HotPink", 0xFF69B4 },
++    { "IndianRed", 0xCD5C5C },
++    { "Indigo", 0x4B0082 },
++    { "Ivory", 0xFFFFF0 },
++    { "Khaki", 0xF0E68C },
++    { "Lavender", 0xE6E6FA },
++    { "LavenderBlush", 0xFFF0F5 },
++    { "LawnGreen", 0x7CFC00 },
++    { "LemonChiffon", 0xFFFACD },
++    { "LightBlue", 0xADD8E6 },
++    { "LightCoral", 0xF08080 },
++    { "LightCyan", 0xE0FFFF },
++    { "LightGoldenRodYellow", 0xFAFAD2 },
++    { "LightGray", 0xD3D3D3 },
++    { "LightGrey", 0xD3D3D3 },
++    { "LightGreen", 0x90EE90 },
++    { "LightPink", 0xFFB6C1 },
++    { "LightSalmon", 0xFFA07A },
++    { "LightSeaGreen", 0x20B2AA },
++    { "LightSkyBlue", 0x87CEFA },
++    { "LightSlateGray", 0x778899 },
++    { "LightSlateGrey", 0x778899 },
++    { "LightSteelBlue", 0xB0C4DE },
++    { "LightYellow", 0xFFFFE0 },
++    { "Lime", 0x00FF00 },
++    { "LimeGreen", 0x32CD32 },
++    { "Linen", 0xFAF0E6 },
++    { "Magenta", 0xFF00FF },
++    { "Maroon", 0x800000 },
++    { "MediumAquaMarine", 0x66CDAA },
++    { "MediumBlue", 0x0000CD },
++    { "MediumOrchid", 0xBA55D3 },
++    { "MediumPurple", 0x9370D8 },
++    { "MediumSeaGreen", 0x3CB371 },
++    { "MediumSlateBlue", 0x7B68EE },
++    { "MediumSpringGreen", 0x00FA9A },
++    { "MediumTurquoise", 0x48D1CC },
++    { "MediumVioletRed", 0xC71585 },
++    { "MidnightBlue", 0x191970 },
++    { "MintCream", 0xF5FFFA },
++    { "MistyRose", 0xFFE4E1 },
++    { "Moccasin", 0xFFE4B5 },
++    { "NavajoWhite", 0xFFDEAD },
++    { "Navy", 0x000080 },
++    { "OldLace", 0xFDF5E6 },
++    { "Olive", 0x808000 },
++    { "OliveDrab", 0x6B8E23 },
++    { "Orange", 0xFFA500 },
++    { "OrangeRed", 0xFF4500 },
++    { "Orchid", 0xDA70D6 },
++    { "PaleGoldenRod", 0xEEE8AA },
++    { "PaleGreen", 0x98FB98 },
++    { "PaleTurquoise", 0xAFEEEE },
++    { "PaleVioletRed", 0xD87093 },
++    { "PapayaWhip", 0xFFEFD5 },
++    { "PeachPuff", 0xFFDAB9 },
++    { "Peru", 0xCD853F },
++    { "Pink", 0xFFC0CB },
++    { "Plum", 0xDDA0DD },
++    { "PowderBlue", 0xB0E0E6 },
++    { "Purple", 0x800080 },
++    { "RebeccaPurple", 0x663399 },
++    { "Red", 0xFF0000 },
++    { "RosyBrown", 0xBC8F8F },
++    { "RoyalBlue", 0x4169E1 },
++    { "SaddleBrown", 0x8B4513 },
++    { "Salmon", 0xFA8072 },
++    { "SandyBrown", 0xF4A460 },
++    { "SeaGreen", 0x2E8B57 },
++    { "SeaShell", 0xFFF5EE },
++    { "Sienna", 0xA0522D },
++    { "Silver", 0xC0C0C0 },
++    { "SkyBlue", 0x87CEEB },
++    { "SlateBlue", 0x6A5ACD },
++    { "SlateGray", 0x708090 },
++    { "SlateGrey", 0x708090 },
++    { "Snow", 0xFFFAFA },
++    { "SpringGreen", 0x00FF7F },
++    { "SteelBlue", 0x4682B4 },
++    { "Tan", 0xD2B48C },
++    { "Teal", 0x008080 },
++    { "Thistle", 0xD8BFD8 },
++    { "Tomato", 0xFF6347 },
++    { "Turquoise", 0x40E0D0 },
++    { "Violet", 0xEE82EE },
++    { "Wheat", 0xF5DEB3 },
++    { "White", 0xFFFFFF },
++    { "WhiteSmoke", 0xF5F5F5 },
++    { "Yellow", 0xFFFF00 },
++    { "YellowGreen", 0x9ACD32 },
++
++    { NULL, 0 }
++};
++
++/**
++ * Returns an integer representation of an HTML color.
++ *
++ * @param psz_value An HTML color, which can be either:
++ *  - A standard HTML color (red, cyan, ...) as defined in p_html_colors
++ *  - An hexadecimal color, of the form [#][AA]RRGGBB
++ * @param ok If non-null, true will be stored in this pointer to signal
++ *           a successful conversion
++ */
++VLC_API unsigned int vlc_html_color( const char *psz_value, bool* ok );
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif /* VLC_TEXT_STYLE_H */
++
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_threads.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_threads.h
+new file mode 100644
+index 0000000..960d458
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_threads.h
+@@ -0,0 +1,1083 @@
++/*****************************************************************************
++ * vlc_threads.h : threads implementation for the VideoLAN client
++ * This header provides portable declarations for mutexes & conditions
++ *****************************************************************************
++ * Copyright (C) 1999, 2002 VLC authors and VideoLAN
++ * Copyright © 2007-2016 Rémi Denis-Courmont
++ *
++ * Authors: Jean-Marc Dressler <polux@via.ecp.fr>
++ *          Samuel Hocevar <sam@via.ecp.fr>
++ *          Gildas Bazin <gbazin@netcourrier.com>
++ *          Christophe Massiot <massiot@via.ecp.fr>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_THREADS_H_
++#define VLC_THREADS_H_
++
++/**
++ * \ingroup os
++ * \defgroup thread Threads and synchronization primitives
++ * @{
++ * \file
++ * Thread primitive declarations
++ */
++
++/**
++ * Issues an explicit deferred cancellation point.
++ *
++ * This has no effects if thread cancellation is disabled.
++ * This can be called when there is a rather slow non-sleeping operation.
++ * This is also used to force a cancellation point in a function that would
++ * otherwise <em>not always</em> be one (block_FifoGet() is an example).
++ */
++VLC_API void vlc_testcancel(void);
++
++#if defined (_WIN32)
++# include <process.h>
++# ifndef ETIMEDOUT
++#  define ETIMEDOUT 10060 /* This is the value in winsock.h. */
++# endif
++
++typedef struct vlc_thread *vlc_thread_t;
++# define VLC_THREAD_CANCELED NULL
++# define LIBVLC_NEED_SLEEP
++typedef struct
++{
++    bool dynamic;
++    union
++    {
++        struct
++        {
++            bool locked;
++            unsigned long contention;
++        };
++        CRITICAL_SECTION mutex;
++    };
++} vlc_mutex_t;
++#define VLC_STATIC_MUTEX { false, { { false, 0 } } }
++#define LIBVLC_NEED_CONDVAR
++#define LIBVLC_NEED_SEMAPHORE
++#define LIBVLC_NEED_RWLOCK
++typedef struct vlc_threadvar *vlc_threadvar_t;
++typedef struct vlc_timer *vlc_timer_t;
++
++# define VLC_THREAD_PRIORITY_LOW      0
++# define VLC_THREAD_PRIORITY_INPUT    THREAD_PRIORITY_ABOVE_NORMAL
++# define VLC_THREAD_PRIORITY_AUDIO    THREAD_PRIORITY_HIGHEST
++# define VLC_THREAD_PRIORITY_VIDEO    0
++# define VLC_THREAD_PRIORITY_OUTPUT   THREAD_PRIORITY_ABOVE_NORMAL
++# define VLC_THREAD_PRIORITY_HIGHEST  THREAD_PRIORITY_TIME_CRITICAL
++
++static inline int vlc_poll(struct pollfd *fds, unsigned nfds, int timeout)
++{
++    int val;
++
++    vlc_testcancel();
++    val = poll(fds, nfds, timeout);
++    if (val < 0)
++        vlc_testcancel();
++    return val;
++}
++# define poll(u,n,t) vlc_poll(u, n, t)
++
++#elif defined (__OS2__)
++# include <errno.h>
++
++typedef struct vlc_thread *vlc_thread_t;
++#define VLC_THREAD_CANCELED NULL
++typedef struct
++{
++    bool dynamic;
++    union
++    {
++        struct
++        {
++            bool locked;
++            unsigned long contention;
++        };
++        HMTX hmtx;
++    };
++} vlc_mutex_t;
++#define VLC_STATIC_MUTEX { false, { { false, 0 } } }
++typedef struct
++{
++    HEV      hev;
++    unsigned waiters;
++    HEV      hevAck;
++    unsigned signaled;
++} vlc_cond_t;
++#define VLC_STATIC_COND { NULLHANDLE, 0, NULLHANDLE, 0 }
++#define LIBVLC_NEED_SEMAPHORE
++#define LIBVLC_NEED_RWLOCK
++typedef struct vlc_threadvar *vlc_threadvar_t;
++typedef struct vlc_timer *vlc_timer_t;
++
++# define VLC_THREAD_PRIORITY_LOW      0
++# define VLC_THREAD_PRIORITY_INPUT \
++                                    MAKESHORT(PRTYD_MAXIMUM / 2, PRTYC_REGULAR)
++# define VLC_THREAD_PRIORITY_AUDIO    MAKESHORT(PRTYD_MAXIMUM, PRTYC_REGULAR)
++# define VLC_THREAD_PRIORITY_VIDEO    0
++# define VLC_THREAD_PRIORITY_OUTPUT \
++                                    MAKESHORT(PRTYD_MAXIMUM / 2, PRTYC_REGULAR)
++# define VLC_THREAD_PRIORITY_HIGHEST  MAKESHORT(0, PRTYC_TIMECRITICAL)
++
++# define pthread_sigmask  sigprocmask
++
++static inline int vlc_poll (struct pollfd *fds, unsigned nfds, int timeout)
++{
++    static int (*vlc_poll_os2)(struct pollfd *, unsigned, int) = NULL;
++
++    if (!vlc_poll_os2)
++    {
++        HMODULE hmod;
++        CHAR szFailed[CCHMAXPATH];
++
++        if (DosLoadModule(szFailed, sizeof(szFailed), "vlccore", &hmod))
++            return -1;
++
++        if (DosQueryProcAddr(hmod, 0, "_vlc_poll_os2", (PFN *)&vlc_poll_os2))
++            return -1;
++    }
++
++    return (*vlc_poll_os2)(fds, nfds, timeout);
++}
++# define poll(u,n,t) vlc_poll(u, n, t)
++
++#elif defined (__ANDROID__)      /* pthreads subset without pthread_cancel() */
++# include <unistd.h>
++# include <pthread.h>
++# include <poll.h>
++# define LIBVLC_USE_PTHREAD_CLEANUP   1
++# define LIBVLC_NEED_SLEEP
++# define LIBVLC_NEED_CONDVAR
++# define LIBVLC_NEED_SEMAPHORE
++# define LIBVLC_NEED_RWLOCK
++
++typedef struct vlc_thread *vlc_thread_t;
++#define VLC_THREAD_CANCELED NULL
++typedef pthread_mutex_t vlc_mutex_t;
++#define VLC_STATIC_MUTEX PTHREAD_MUTEX_INITIALIZER
++
++typedef pthread_key_t   vlc_threadvar_t;
++typedef struct vlc_timer *vlc_timer_t;
++
++# define VLC_THREAD_PRIORITY_LOW      0
++# define VLC_THREAD_PRIORITY_INPUT    0
++# define VLC_THREAD_PRIORITY_AUDIO    0
++# define VLC_THREAD_PRIORITY_VIDEO    0
++# define VLC_THREAD_PRIORITY_OUTPUT   0
++# define VLC_THREAD_PRIORITY_HIGHEST  0
++
++static inline int vlc_poll (struct pollfd *fds, unsigned nfds, int timeout)
++{
++    int val;
++
++    do
++    {
++        int ugly_timeout = ((unsigned)timeout >= 50) ? 50 : timeout;
++        if (timeout >= 0)
++            timeout -= ugly_timeout;
++
++        vlc_testcancel ();
++        val = poll (fds, nfds, ugly_timeout);
++    }
++    while (val == 0 && timeout != 0);
++
++    return val;
++}
++
++# define poll(u,n,t) vlc_poll(u, n, t)
++
++#elif defined (__APPLE__)
++# define _APPLE_C_SOURCE    1 /* Proper pthread semantics on OSX */
++# include <unistd.h>
++# include <pthread.h>
++/* Unnamed POSIX semaphores not supported on Mac OS X */
++# include <mach/semaphore.h>
++# include <mach/task.h>
++# define LIBVLC_USE_PTHREAD           1
++# define LIBVLC_USE_PTHREAD_CLEANUP   1
++
++typedef pthread_t       vlc_thread_t;
++#define VLC_THREAD_CANCELED PTHREAD_CANCELED
++typedef pthread_mutex_t vlc_mutex_t;
++#define VLC_STATIC_MUTEX PTHREAD_MUTEX_INITIALIZER
++typedef pthread_cond_t vlc_cond_t;
++#define VLC_STATIC_COND PTHREAD_COND_INITIALIZER
++typedef semaphore_t     vlc_sem_t;
++typedef pthread_rwlock_t vlc_rwlock_t;
++#define VLC_STATIC_RWLOCK PTHREAD_RWLOCK_INITIALIZER
++typedef pthread_key_t   vlc_threadvar_t;
++typedef struct vlc_timer *vlc_timer_t;
++
++# define VLC_THREAD_PRIORITY_LOW      0
++# define VLC_THREAD_PRIORITY_INPUT   22
++# define VLC_THREAD_PRIORITY_AUDIO   22
++# define VLC_THREAD_PRIORITY_VIDEO    0
++# define VLC_THREAD_PRIORITY_OUTPUT  22
++# define VLC_THREAD_PRIORITY_HIGHEST 22
++
++#else /* POSIX threads */
++# include <unistd.h> /* _POSIX_SPIN_LOCKS */
++# include <pthread.h>
++# include <semaphore.h>
++
++/**
++ * Whether LibVLC threads are based on POSIX threads.
++ */
++# define LIBVLC_USE_PTHREAD           1
++
++/**
++ * Whether LibVLC thread cancellation is based on POSIX threads.
++ */
++# define LIBVLC_USE_PTHREAD_CLEANUP   1
++
++/**
++ * Thread handle.
++ */
++typedef struct
++{
++    pthread_t handle;
++} vlc_thread_t;
++
++/**
++ * Return value of a canceled thread.
++ */
++#define VLC_THREAD_CANCELED PTHREAD_CANCELED
++
++/**
++ * Mutex.
++ *
++ * Storage space for a mutual exclusion lock.
++ */
++typedef pthread_mutex_t vlc_mutex_t;
++
++/**
++ * Static initializer for (static) mutex.
++ */
++#define VLC_STATIC_MUTEX PTHREAD_MUTEX_INITIALIZER
++
++/**
++ * Condition variable.
++ *
++ * Storage space for a thread condition variable.
++ */
++typedef pthread_cond_t  vlc_cond_t;
++
++/**
++ * Static initializer for (static) condition variable.
++ *
++ * \note
++ * The condition variable will use the default clock, which is OS-dependent.
++ * Therefore, where timed waits are necessary the condition variable should
++ * always be initialized dynamically explicit instead of using this
++ * initializer.
++ */
++#define VLC_STATIC_COND  PTHREAD_COND_INITIALIZER
++
++/**
++ * Semaphore.
++ *
++ * Storage space for a thread-safe semaphore.
++ */
++typedef sem_t           vlc_sem_t;
++
++/**
++ * Read/write lock.
++ *
++ * Storage space for a slim reader/writer lock.
++ */
++typedef pthread_rwlock_t vlc_rwlock_t;
++
++/**
++ * Static initializer for (static) read/write lock.
++ */
++#define VLC_STATIC_RWLOCK PTHREAD_RWLOCK_INITIALIZER
++
++/**
++ * Thread-local key handle.
++ */
++typedef pthread_key_t   vlc_threadvar_t;
++
++/**
++ * Threaded timer handle.
++ */
++typedef struct vlc_timer *vlc_timer_t;
++
++# define VLC_THREAD_PRIORITY_LOW      0
++# define VLC_THREAD_PRIORITY_INPUT   10
++# define VLC_THREAD_PRIORITY_AUDIO    5
++# define VLC_THREAD_PRIORITY_VIDEO    0
++# define VLC_THREAD_PRIORITY_OUTPUT  15
++# define VLC_THREAD_PRIORITY_HIGHEST 20
++
++#endif
++
++#ifdef LIBVLC_NEED_CONDVAR
++typedef struct
++{
++    unsigned value;
++} vlc_cond_t;
++# define VLC_STATIC_COND { 0 }
++#endif
++
++#ifdef LIBVLC_NEED_SEMAPHORE
++typedef struct vlc_sem
++{
++    vlc_mutex_t lock;
++    vlc_cond_t  wait;
++    unsigned    value;
++} vlc_sem_t;
++#endif
++
++#ifdef LIBVLC_NEED_RWLOCK
++typedef struct vlc_rwlock
++{
++    vlc_mutex_t   mutex;
++    vlc_cond_t    wait;
++    long          state;
++} vlc_rwlock_t;
++# define VLC_STATIC_RWLOCK { VLC_STATIC_MUTEX, VLC_STATIC_COND, 0 }
++#endif
++
++/**
++ * Initializes a fast mutex.
++ *
++ * Recursive locking of a fast mutex is undefined behaviour. (In debug builds,
++ * recursive locking will cause an assertion failure.)
++ */
++VLC_API void vlc_mutex_init(vlc_mutex_t *);
++
++/**
++ * Initializes a recursive mutex.
++ * \warning This is strongly discouraged. Please use normal mutexes.
++ */
++VLC_API void vlc_mutex_init_recursive(vlc_mutex_t *);
++
++/**
++ * Deinitializes a mutex.
++ *
++ * The mutex must not be locked, otherwise behaviour is undefined.
++ */
++VLC_API void vlc_mutex_destroy(vlc_mutex_t *);
++
++/**
++ * Acquires a mutex.
++ *
++ * If needed, this waits for any other thread to release it.
++ *
++ * \warning Beware of deadlocks when locking multiple mutexes at the same time,
++ * or when using mutexes from callbacks.
++ *
++ * \note This function is not a cancellation point.
++ */
++VLC_API void vlc_mutex_lock(vlc_mutex_t *);
++
++/**
++ * Tries to acquire a mutex.
++ *
++ * This function acquires the mutex if and only if it is not currently held by
++ * another thread. This function never sleeps and can be used in delay-critical
++ * code paths.
++ *
++ * \note This function is not a cancellation point.
++ *
++ * \warning If this function fails, then the mutex is held... by another
++ * thread. The calling thread must deal with the error appropriately. That
++ * typically implies postponing the operations that would have required the
++ * mutex. If the thread cannot defer those operations, then it must use
++ * vlc_mutex_lock(). If in doubt, use vlc_mutex_lock() instead.
++ *
++ * @return 0 if the mutex could be acquired, an error code otherwise.
++ */
++VLC_API int vlc_mutex_trylock( vlc_mutex_t * ) VLC_USED;
++
++/**
++ * Releases a mutex.
++ *
++ * If the mutex is not held by the calling thread, the behaviour is undefined.
++ *
++ * \note This function is not a cancellation point.
++ */
++VLC_API void vlc_mutex_unlock(vlc_mutex_t *);
++
++/**
++ * Initializes a condition variable.
++ */
++VLC_API void vlc_cond_init(vlc_cond_t *);
++
++/**
++ * Initializes a condition variable (wall clock).
++ *
++ * This function initializes a condition variable for timed waiting using the
++ * UTC wall clock time. The time reference is the same as with time() and with
++ * timespec_get() and TIME_UTC.
++ * vlc_cond_timedwait_daytime() must be instead of
++ * vlc_cond_timedwait() for actual waiting.
++ */
++void vlc_cond_init_daytime(vlc_cond_t *);
++
++/**
++ * Deinitializes a condition variable.
++ *
++ * No threads shall be waiting or signaling the condition, otherwise the
++ * behavior is undefined.
++ */
++VLC_API void vlc_cond_destroy(vlc_cond_t *);
++
++/**
++ * Wakes up one thread waiting on a condition variable.
++ *
++ * If any thread is currently waiting on the condition variable, at least one
++ * of those threads will be woken up. Otherwise, this function has no effects.
++ *
++ * \note This function is not a cancellation point.
++ */
++VLC_API void vlc_cond_signal(vlc_cond_t *);
++
++/**
++ * Wakes up all threads waiting on a condition variable.
++ *
++ * \note This function is not a cancellation point.
++ */
++VLC_API void vlc_cond_broadcast(vlc_cond_t *);
++
++/**
++ * Waits on a condition variable.
++ *
++ * The calling thread will be suspended until another thread calls
++ * vlc_cond_signal() or vlc_cond_broadcast() on the same condition variable,
++ * the thread is cancelled with vlc_cancel(), or the system causes a
++ * <em>spurious</em> unsolicited wake-up.
++ *
++ * A mutex is needed to wait on a condition variable. It must <b>not</b> be
++ * a recursive mutex. Although it is possible to use the same mutex for
++ * multiple condition, it is not valid to use different mutexes for the same
++ * condition variable at the same time from different threads.
++ *
++ * The canonical way to use a condition variable to wait for event foobar is:
++ @code
++   vlc_mutex_lock(&lock);
++   mutex_cleanup_push(&lock); // release the mutex in case of cancellation
++
++   while (!foobar)
++       vlc_cond_wait(&wait, &lock);
++
++   // -- foobar is now true, do something about it here --
++
++   vlc_cleanup_pop();
++   vlc_mutex_unlock(&lock);
++  @endcode
++ *
++ * \note This function is a cancellation point. In case of thread cancellation,
++ * the mutex is always locked before cancellation proceeds.
++ *
++ * \param cond condition variable to wait on
++ * \param mutex mutex which is unlocked while waiting,
++ *              then locked again when waking up.
++ */
++VLC_API void vlc_cond_wait(vlc_cond_t *cond, vlc_mutex_t *mutex);
++
++/**
++ * Waits on a condition variable up to a certain date.
++ *
++ * This works like vlc_cond_wait() but with an additional time-out.
++ * The time-out is expressed as an absolute timestamp using the same arbitrary
++ * time reference as the mdate() and mwait() functions.
++ *
++ * \note This function is a cancellation point. In case of thread cancellation,
++ * the mutex is always locked before cancellation proceeds.
++ *
++ * \param cond condition variable to wait on
++ * \param mutex mutex which is unlocked while waiting,
++ *              then locked again when waking up
++ * \param deadline <b>absolute</b> timeout
++ *
++ * \warning If the variable was initialized with vlc_cond_init_daytime(), or
++ * was statically initialized with \ref VLC_STATIC_COND, the time reference
++ * used by this function is unspecified (depending on the implementation, it
++ * might be the Unix epoch or the mdate() clock).
++ *
++ * \return 0 if the condition was signaled, an error code in case of timeout.
++ */
++VLC_API int vlc_cond_timedwait(vlc_cond_t *cond, vlc_mutex_t *mutex,
++                               mtime_t deadline);
++
++int vlc_cond_timedwait_daytime(vlc_cond_t *, vlc_mutex_t *, time_t);
++
++/**
++ * Initializes a semaphore.
++ *
++ * @param count initial semaphore value (typically 0)
++ */
++VLC_API void vlc_sem_init(vlc_sem_t *, unsigned count);
++
++/**
++ * Deinitializes a semaphore.
++ */
++VLC_API void vlc_sem_destroy(vlc_sem_t *);
++
++/**
++ * Increments the value of a semaphore.
++ *
++ * \note This function is not a cancellation point.
++ *
++ * \return 0 on success, EOVERFLOW in case of integer overflow.
++ */
++VLC_API int vlc_sem_post(vlc_sem_t *);
++
++/**
++ * Waits on a semaphore.
++ *
++ * This function atomically waits for the semaphore to become non-zero then
++ * decrements it, and returns. If the semaphore is non-zero on entry, it is
++ * immediately decremented.
++ *
++ * \note This function may be a point of cancellation.
++ */
++VLC_API void vlc_sem_wait(vlc_sem_t *);
++
++/**
++ * Initializes a read/write lock.
++ */
++VLC_API void vlc_rwlock_init(vlc_rwlock_t *);
++
++/**
++ * Destroys an initialized unused read/write lock.
++ */
++VLC_API void vlc_rwlock_destroy(vlc_rwlock_t *);
++
++/**
++ * Acquires a read/write lock for reading.
++ *
++ * \note Recursion is allowed.
++ * \note This function may be a point of cancellation.
++ */
++VLC_API void vlc_rwlock_rdlock(vlc_rwlock_t *);
++
++/**
++ * Acquires a read/write lock for writing. Recursion is not allowed.
++ * \note This function may be a point of cancellation.
++ */
++VLC_API void vlc_rwlock_wrlock(vlc_rwlock_t *);
++
++/**
++ * Releases a read/write lock.
++ *
++ * The calling thread must hold the lock. Otherwise behaviour is undefined.
++ *
++ * \note This function is not a cancellation point.
++ */
++VLC_API void vlc_rwlock_unlock(vlc_rwlock_t *);
++
++/**
++ * Allocates a thread-specific variable.
++ *
++ * @param key where to store the thread-specific variable handle
++ * @param destr a destruction callback. It is called whenever a thread exits
++ * and the thread-specific variable has a non-NULL value.
++ *
++ * @return 0 on success, a system error code otherwise.
++ * This function can actually fail: on most systems, there is a fixed limit to
++ * the number of thread-specific variables in a given process.
++ */
++VLC_API int vlc_threadvar_create(vlc_threadvar_t *key, void (*destr) (void *));
++
++/**
++ * Deallocates a thread-specific variable.
++ */
++VLC_API void vlc_threadvar_delete(vlc_threadvar_t *);
++
++/**
++ * Sets a thread-specific variable.
++
++ * \param key thread-local variable key (created with vlc_threadvar_create())
++ * \param value new value for the variable for the calling thread
++ * \return 0 on success, a system error code otherwise.
++ */
++VLC_API int vlc_threadvar_set(vlc_threadvar_t key, void *value);
++
++/**
++ * Gets the value of a thread-local variable for the calling thread.
++ * This function cannot fail.
++ *
++ * \return the value associated with the given variable for the calling
++ * or NULL if no value was set.
++ */
++VLC_API void *vlc_threadvar_get(vlc_threadvar_t);
++
++/**
++ * Waits on an address.
++ *
++ * Puts the calling thread to sleep if a specific value is stored at a
++ * specified address. The thread will sleep until it is woken up by a call to
++ * vlc_addr_signal() or vlc_addr_broadcast() in another thread, or spuriously.
++ *
++ * If the value does not match, do nothing and return immediately.
++ *
++ * \param addr address to check for
++ * \param val value to match at the address
++ */
++void vlc_addr_wait(void *addr, unsigned val);
++
++/**
++ * Waits on an address with a time-out.
++ *
++ * This function operates as vlc_addr_wait() but provides an additional
++ * time-out. If the time-out elapses, the thread resumes and the function
++ * returns.
++ *
++ * \param addr address to check for
++ * \param val value to match at the address
++ * \param delay time-out duration
++ *
++ * \return true if the function was woken up before the time-out,
++ * false if the time-out elapsed.
++ */
++bool vlc_addr_timedwait(void *addr, unsigned val, mtime_t delay);
++
++/**
++ * Wakes up one thread on an address.
++ *
++ * Wakes up (at least) one of the thread sleeping on the specified address.
++ * The address must be equal to the first parameter given by at least one
++ * thread sleeping within the vlc_addr_wait() or vlc_addr_timedwait()
++ * functions. If no threads are found, this function does nothing.
++ *
++ * \param addr address identifying which threads may be woken up
++ */
++void vlc_addr_signal(void *addr);
++
++/**
++ * Wakes up all thread on an address.
++ *
++ * Wakes up all threads sleeping on the specified address (if any).
++ * Any thread sleeping within a call to vlc_addr_wait() or vlc_addr_timedwait()
++ * with the specified address as first call parameter will be woken up.
++ *
++ * \param addr address identifying which threads to wake up
++ */
++void vlc_addr_broadcast(void *addr);
++
++/**
++ * Creates and starts a new thread.
++ *
++ * The thread must be <i>joined</i> with vlc_join() to reclaim resources
++ * when it is not needed anymore.
++ *
++ * @param th storage space for the handle of the new thread (cannot be NULL)
++ *           [OUT]
++ * @param entry entry point for the thread
++ * @param data data parameter given to the entry point
++ * @param priority thread priority value
++ * @return 0 on success, a standard error code on error.
++ * @note In case of error, the value of *th is undefined.
++ */
++VLC_API int vlc_clone(vlc_thread_t *th, void *(*entry)(void *), void *data,
++                      int priority) VLC_USED;
++
++/**
++ * Marks a thread as cancelled.
++ *
++ * Next time the target thread reaches a cancellation point (while not having
++ * disabled cancellation), it will run its cancellation cleanup handler, the
++ * thread variable destructors, and terminate.
++ *
++ * vlc_join() must be used regardless of a thread being cancelled or not, to
++ * avoid leaking resources.
++ */
++VLC_API void vlc_cancel(vlc_thread_t);
++
++/**
++ * Waits for a thread to complete (if needed), then destroys it.
++ *
++ * \note This is a cancellation point. In case of cancellation, the thread is
++ * <b>not</b> joined.
++
++ * \warning A thread cannot join itself (normally VLC will abort if this is
++ * attempted). Also a detached thread <b>cannot</b> be joined.
++ *
++ * @param th thread handle
++ * @param result [OUT] pointer to write the thread return value or NULL
++ */
++VLC_API void vlc_join(vlc_thread_t th, void **result);
++
++/**
++ * Disables thread cancellation.
++ *
++ * This functions saves the current cancellation state (enabled or disabled),
++ * then disables cancellation for the calling thread. It must be called before
++ * entering a piece of code that is not cancellation-safe, unless it can be
++ * proven that the calling thread will not be cancelled.
++ *
++ * \note This function is not a cancellation point.
++ *
++ * \return Previous cancellation state (opaque value for vlc_restorecancel()).
++ */
++VLC_API int vlc_savecancel(void);
++
++/**
++ * Restores the cancellation state.
++ *
++ * This function restores the cancellation state of the calling thread to
++ * a state previously saved by vlc_savecancel().
++ *
++ * \note This function is not a cancellation point.
++ *
++ * \param state previous state as returned by vlc_savecancel().
++ */
++VLC_API void vlc_restorecancel(int state);
++
++/**
++ * Internal handler for thread cancellation.
++ *
++ * Do not call this function directly. Use wrapper macros instead:
++ * vlc_cleanup_push(), vlc_cleanup_pop().
++ */
++VLC_API void vlc_control_cancel(int cmd, ...);
++
++/**
++ * Thread handle.
++ *
++ * This function returns the thread handle of the calling thread.
++ *
++ * \note The exact type of the thread handle depends on the platform,
++ * including an integer type, a pointer type or a compound type of any size.
++ * If you need an integer identifier, use vlc_thread_id() instead.
++ *
++ * \note vlc_join(vlc_thread_self(), NULL) is undefined,
++ * as it obviously does not make any sense (it might result in a deadlock, but
++ * there are no warranties that it will).
++ *
++ * \return the thread handle
++ */
++VLC_API vlc_thread_t vlc_thread_self(void) VLC_USED;
++
++/**
++ * Thread identifier.
++ *
++ * This function returns the identifier of the calling thread. The identifier
++ * cannot change for the entire duration of the thread, and no other thread can
++ * have the same identifier at the same time in the same process. Typically,
++ * the identifier is also unique across all running threads of all existing
++ * processes, but that depends on the operating system.
++ *
++ * There are no particular semantics to the thread ID with LibVLC.
++ * It is provided mainly for tracing and debugging.
++ *
++ * \warning This function is not currently implemented on all supported
++ * platforms. Where not implemented, it returns (unsigned long)-1.
++ *
++ * \return the thread identifier (or -1 if unimplemented)
++ */
++VLC_API unsigned long vlc_thread_id(void) VLC_USED;
++
++/**
++ * Precision monotonic clock.
++ *
++ * In principles, the clock has a precision of 1 MHz. But the actual resolution
++ * may be much lower, especially when it comes to sleeping with mwait() or
++ * msleep(). Most general-purpose operating systems provide a resolution of
++ * only 100 to 1000 Hz.
++ *
++ * \warning The origin date (time value "zero") is not specified. It is
++ * typically the time the kernel started, but this is platform-dependent.
++ * If you need wall clock time, use gettimeofday() instead.
++ *
++ * \return a timestamp in microseconds.
++ */
++VLC_API mtime_t mdate(void);
++
++/**
++ * Waits until a deadline.
++ *
++ * \param deadline timestamp to wait for (\ref mdate())
++ *
++ * \note The deadline may be exceeded due to OS scheduling.
++ * \note This function is a cancellation point.
++ */
++VLC_API void mwait(mtime_t deadline);
++
++/**
++ * Waits for an interval of time.
++ *
++ * \param delay how long to wait (in microseconds)
++ *
++ * \note The delay may be exceeded due to OS scheduling.
++ * \note This function is a cancellation point.
++ */
++VLC_API void msleep(mtime_t delay);
++
++#define VLC_HARD_MIN_SLEEP   10000 /* 10 milliseconds = 1 tick at 100Hz */
++#define VLC_SOFT_MIN_SLEEP 9000000 /* 9 seconds */
++
++#if defined (__GNUC__) && !defined (__clang__)
++/* Linux has 100, 250, 300 or 1000Hz
++ *
++ * HZ=100 by default on FreeBSD, but some architectures use a 1000Hz timer
++ */
++
++static
++__attribute__((unused))
++__attribute__((noinline))
++__attribute__((error("sorry, cannot sleep for such short a time")))
++mtime_t impossible_delay( mtime_t delay )
++{
++    (void) delay;
++    return VLC_HARD_MIN_SLEEP;
++}
++
++static
++__attribute__((unused))
++__attribute__((noinline))
++__attribute__((warning("use proper event handling instead of short delay")))
++mtime_t harmful_delay( mtime_t delay )
++{
++    return delay;
++}
++
++# define check_delay( d ) \
++    ((__builtin_constant_p(d < VLC_HARD_MIN_SLEEP) \
++   && (d < VLC_HARD_MIN_SLEEP)) \
++       ? impossible_delay(d) \
++       : ((__builtin_constant_p(d < VLC_SOFT_MIN_SLEEP) \
++       && (d < VLC_SOFT_MIN_SLEEP)) \
++           ? harmful_delay(d) \
++           : d))
++
++static
++__attribute__((unused))
++__attribute__((noinline))
++__attribute__((error("deadlines can not be constant")))
++mtime_t impossible_deadline( mtime_t deadline )
++{
++    return deadline;
++}
++
++# define check_deadline( d ) \
++    (__builtin_constant_p(d) ? impossible_deadline(d) : d)
++#else
++# define check_delay(d) (d)
++# define check_deadline(d) (d)
++#endif
++
++#define msleep(d) msleep(check_delay(d))
++#define mwait(d) mwait(check_deadline(d))
++
++/**
++ * Initializes an asynchronous timer.
++ *
++ * \param id pointer to timer to be initialized
++ * \param func function that the timer will call
++ * \param data parameter for the timer function
++ * \return 0 on success, a system error code otherwise.
++ *
++ * \warning Asynchronous timers are processed from an unspecified thread.
++ * \note Multiple occurrences of a single interval timer are serialized:
++ * they cannot run concurrently.
++ */
++VLC_API int vlc_timer_create(vlc_timer_t *id, void (*func)(void *), void *data)
++VLC_USED;
++
++/**
++ * Destroys an initialized timer.
++ *
++ * If needed, the timer is first disarmed. Behaviour is undefined if the
++ * specified timer is not initialized.
++ *
++ * \warning This function <b>must</b> be called before the timer data can be
++ * freed and before the timer callback function can be unmapped/unloaded.
++ *
++ * \param timer timer to destroy
++ */
++VLC_API void vlc_timer_destroy(vlc_timer_t timer);
++
++/**
++ * Arms or disarms an initialized timer.
++ *
++ * This functions overrides any previous call to itself.
++ *
++ * \note A timer can fire later than requested due to system scheduling
++ * limitations. An interval timer can fail to trigger sometimes, either because
++ * the system is busy or suspended, or because a previous iteration of the
++ * timer is still running. See also vlc_timer_getoverrun().
++ *
++ * \param timer initialized timer
++ * \param absolute the timer value origin is the same as mdate() if true,
++ *                 the timer value is relative to now if false.
++ * \param value zero to disarm the timer, otherwise the initial time to wait
++ *              before firing the timer.
++ * \param interval zero to fire the timer just once, otherwise the timer
++ *                 repetition interval.
++ */
++VLC_API void vlc_timer_schedule(vlc_timer_t timer, bool absolute,
++                                mtime_t value, mtime_t interval);
++
++/**
++ * Fetches and resets the overrun counter for a timer.
++ *
++ * This functions returns the number of times that the interval timer should
++ * have fired, but the callback was not invoked due to scheduling problems.
++ * The call resets the counter to zero.
++ *
++ * \param timer initialized timer
++ * \return the timer overrun counter (typically zero)
++ */
++VLC_API unsigned vlc_timer_getoverrun(vlc_timer_t) VLC_USED;
++
++/**
++ * Count CPUs.
++ *
++ * \return number of available (logical) CPUs.
++ */
++VLC_API unsigned vlc_GetCPUCount(void);
++
++enum
++{
++    VLC_CLEANUP_PUSH,
++    VLC_CLEANUP_POP,
++    VLC_CANCEL_ADDR_SET,
++    VLC_CANCEL_ADDR_CLEAR,
++};
++
++#if defined (LIBVLC_USE_PTHREAD_CLEANUP)
++/**
++ * Registers a thread cancellation handler.
++ *
++ * This pushes a function to run if the thread is cancelled (or otherwise
++ * exits prematurely).
++ *
++ * If multiple procedures are registered,
++ * they are handled in last-in first-out order.
++ *
++ * \note Any call to vlc_cleanup_push() <b>must</b> paired with a call to
++ * vlc_cleanup_pop().
++ * \warning Branching into or out of the block between these two function calls
++ * is not allowed (read: it will likely crash the whole process).
++ *
++ * \param routine procedure to call if the thread ends
++ * \param arg argument for the procedure
++ */
++# define vlc_cleanup_push( routine, arg ) pthread_cleanup_push (routine, arg)
++
++/**
++ * Unregisters the last cancellation handler.
++ *
++ * This pops the cancellation handler that was last pushed with
++ * vlc_cleanup_push() in the calling thread.
++ */
++# define vlc_cleanup_pop( ) pthread_cleanup_pop (0)
++
++#else
++typedef struct vlc_cleanup_t vlc_cleanup_t;
++
++struct vlc_cleanup_t
++{
++    vlc_cleanup_t *next;
++    void         (*proc) (void *);
++    void          *data;
++};
++
++/* This macros opens a code block on purpose. This is needed for multiple
++ * calls within a single function. This also prevent Win32 developers from
++ * writing code that would break on POSIX (POSIX opens a block as well). */
++# define vlc_cleanup_push( routine, arg ) \
++    do { \
++        vlc_cleanup_t vlc_cleanup_data = { NULL, routine, arg, }; \
++        vlc_control_cancel (VLC_CLEANUP_PUSH, &vlc_cleanup_data)
++
++# define vlc_cleanup_pop( ) \
++        vlc_control_cancel (VLC_CLEANUP_POP); \
++    } while (0)
++
++#endif /* !LIBVLC_USE_PTHREAD_CLEANUP */
++
++static inline void vlc_cleanup_lock (void *lock)
++{
++    vlc_mutex_unlock ((vlc_mutex_t *)lock);
++}
++#define mutex_cleanup_push( lock ) vlc_cleanup_push (vlc_cleanup_lock, lock)
++
++static inline void vlc_cancel_addr_set(void *addr)
++{
++    vlc_control_cancel(VLC_CANCEL_ADDR_SET, addr);
++}
++
++static inline void vlc_cancel_addr_clear(void *addr)
++{
++    vlc_control_cancel(VLC_CANCEL_ADDR_CLEAR, addr);
++}
++
++#ifdef __cplusplus
++/**
++ * Helper C++ class to lock a mutex.
++ *
++ * The mutex is locked when the object is created, and unlocked when the object
++ * is destroyed.
++ */
++class vlc_mutex_locker
++{
++    private:
++        vlc_mutex_t *lock;
++    public:
++        vlc_mutex_locker (vlc_mutex_t *m) : lock (m)
++        {
++            vlc_mutex_lock (lock);
++        }
++
++        ~vlc_mutex_locker (void)
++        {
++            vlc_mutex_unlock (lock);
++        }
++};
++#endif
++
++enum
++{
++   VLC_AVCODEC_MUTEX = 0,
++   VLC_GCRYPT_MUTEX,
++   VLC_XLIB_MUTEX,
++   VLC_MOSAIC_MUTEX,
++   VLC_HIGHLIGHT_MUTEX,
++#ifdef _WIN32
++   VLC_MTA_MUTEX,
++#endif
++   /* Insert new entry HERE */
++   VLC_MAX_MUTEX
++};
++
++/**
++ * Internal handler for global mutexes.
++ *
++ * Do not use this function directly. Use helper macros instead:
++ * vlc_global_lock(), vlc_global_unlock().
++ */
++VLC_API void vlc_global_mutex(unsigned, bool);
++
++/**
++ * Acquires a global mutex.
++ */
++#define vlc_global_lock( n ) vlc_global_mutex(n, true)
++
++/**
++ * Releases a global mutex.
++ */
++#define vlc_global_unlock( n ) vlc_global_mutex(n, false)
++
++/** @} */
++
++#endif /* !_VLC_THREADS_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_timestamp_helper.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_timestamp_helper.h
+new file mode 100644
+index 0000000..7068d9f
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_timestamp_helper.h
+@@ -0,0 +1,101 @@
++/*****************************************************************************
++ * vlc_timestamp_helper.h : timestamp handling helpers
++ *****************************************************************************
++ * Copyright (C) 2014 VLC authors and VideoLAN
++ * $Id: 90840fbcf7a5197f235ab6160a2cc2708a87c54d $
++ *
++ * Authors: Felix Abecassis <felix.abecassis@gmail.com>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_TIMESTAMP_H
++#define VLC_TIMESTAMP_H 1
++
++/* Implementation of a circular buffer of timestamps with overwriting
++ * of older values. MediaCodec has only one type of timestamp, if a
++ * block has no PTS, we send the DTS instead. Some hardware decoders
++ * cannot cope with this situation and output the frames in the wrong
++ * order. As a workaround in this case, we use a FIFO of timestamps in
++ * order to remember which input packets had no PTS.  Since an
++ * hardware decoder can silently drop frames, this might cause a
++ * growing desynchronization with the actual timestamp. Thus the
++ * circular buffer has a limited size and will overwrite older values.
++ */
++typedef struct
++{
++    uint32_t          begin;
++    uint32_t          size;
++    uint32_t          capacity;
++    int64_t           *buffer;
++} timestamp_fifo_t;
++
++static inline timestamp_fifo_t *timestamp_FifoNew(uint32_t capacity)
++{
++    timestamp_fifo_t *fifo = calloc(1, sizeof(*fifo));
++    if (!fifo)
++        return NULL;
++    fifo->buffer = vlc_alloc(capacity, sizeof(*fifo->buffer));
++    if (!fifo->buffer) {
++        free(fifo);
++        return NULL;
++    }
++    fifo->capacity = capacity;
++    return fifo;
++}
++
++static inline void timestamp_FifoRelease(timestamp_fifo_t *fifo)
++{
++    free(fifo->buffer);
++    free(fifo);
++}
++
++static inline bool timestamp_FifoIsEmpty(timestamp_fifo_t *fifo)
++{
++    return fifo->size == 0;
++}
++
++static inline bool timestamp_FifoIsFull(timestamp_fifo_t *fifo)
++{
++    return fifo->size == fifo->capacity;
++}
++
++static inline void timestamp_FifoEmpty(timestamp_fifo_t *fifo)
++{
++    fifo->size = 0;
++}
++
++static inline void timestamp_FifoPut(timestamp_fifo_t *fifo, int64_t ts)
++{
++    uint32_t end = (fifo->begin + fifo->size) % fifo->capacity;
++    fifo->buffer[end] = ts;
++    if (!timestamp_FifoIsFull(fifo))
++        fifo->size += 1;
++    else
++        fifo->begin = (fifo->begin + 1) % fifo->capacity;
++}
++
++static inline int64_t timestamp_FifoGet(timestamp_fifo_t *fifo)
++{
++    if (timestamp_FifoIsEmpty(fifo))
++        return VLC_TS_INVALID;
++
++    int64_t result = fifo->buffer[fifo->begin];
++    fifo->begin = (fifo->begin + 1) % fifo->capacity;
++    fifo->size -= 1;
++    return result;
++}
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_tls.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_tls.h
+new file mode 100644
+index 0000000..84e44a5
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_tls.h
+@@ -0,0 +1,352 @@
++/*****************************************************************************
++ * vlc_tls.h:
++ *****************************************************************************
++ * Copyright (C) 2004-2016 Rémi Denis-Courmont
++ * Copyright (C) 2005-2006 VLC authors and VideoLAN
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_TLS_H
++# define VLC_TLS_H
++
++/**
++ * \ingroup net
++ * \defgroup transport Transport layer sockets
++ * Network stream abstraction
++ *
++ * Originally intended for the TLS protocol (Transport Layer Security),
++ * the Transport Layer Sockets now provides a generic abstraction
++ * for connection-oriented full-duplex I/O byte streams, such as TCP/IP sockets
++ * and TLS protocol sessions.
++ *
++ * @{
++ * \file
++ * Transport layer functions
++ */
++
++# include <vlc_network.h>
++
++/** Transport layer socket */
++typedef struct vlc_tls
++{
++    int (*get_fd)(struct vlc_tls *);
++    ssize_t (*readv)(struct vlc_tls *, struct iovec *, unsigned);
++    ssize_t (*writev)(struct vlc_tls *, const struct iovec *, unsigned);
++    int (*shutdown)(struct vlc_tls *, bool duplex);
++    void (*close)(struct vlc_tls *);
++
++    struct vlc_tls *p;
++} vlc_tls_t;
++
++/**
++ * \defgroup tls Transport Layer Security
++ * @{
++ */
++
++/**
++ * TLS credentials
++ *
++ * This structure contains the credentials for establishing TLS sessions.
++ * This includes root Certificate Authorities (on client side),
++ * trust and cryptographic parameters,
++ * public certificates and private keys.
++ */
++typedef struct vlc_tls_creds
++{
++    VLC_COMMON_MEMBERS
++
++    module_t *module;
++    void *sys;
++
++    vlc_tls_t *(*open)(struct vlc_tls_creds *, vlc_tls_t *sock,
++                       const char *host, const char *const *alpn);
++    int  (*handshake)(struct vlc_tls_creds *, vlc_tls_t *session,
++                      const char *hostname, const char *service,
++                      char ** /*restrict*/ alp);
++} vlc_tls_creds_t;
++
++/**
++ * Allocates TLS credentials for a client.
++ * Credentials can be cached and reused across multiple TLS sessions.
++ *
++ * @return TLS credentials object, or NULL on error.
++ **/
++VLC_API vlc_tls_creds_t *vlc_tls_ClientCreate(vlc_object_t *);
++
++/**
++ * Allocates server TLS credentials.
++ *
++ * @param cert path to an x509 certificate (required)
++ * @param key path to the PKCS private key for the certificate,
++ *            or NULL to use cert path
++ *
++ * @return TLS credentials object, or NULL on error.
++ */
++VLC_API vlc_tls_creds_t *vlc_tls_ServerCreate(vlc_object_t *, const char *cert,
++                                              const char *key);
++
++static inline int vlc_tls_SessionHandshake (vlc_tls_creds_t *crd,
++                                            vlc_tls_t *tls)
++{
++    return crd->handshake(crd, tls, NULL, NULL, NULL);
++}
++
++/**
++ * Releases TLS credentials.
++ *
++ * Releases data allocated with vlc_tls_ClientCreate() or
++ * vlc_tls_ServerCreate().
++ *
++ * @param srv object to be destroyed (or NULL)
++ */
++VLC_API void vlc_tls_Delete(vlc_tls_creds_t *);
++
++/**
++ * Initiates a client TLS session.
++ *
++ * Initiates a Transport Layer Security (TLS) session as the client side, using
++ * trusted root CAs previously loaded with vlc_tls_ClientCreate().
++ *
++ * This is a blocking network operation and may be a thread cancellation point.
++ *
++ * @param creds X.509 credentials, i.e. set of root certificates of trusted
++ *              certificate authorities
++ * @param sock socket through which to establish the secure channel
++ * @param hostname expected server name, used both as Server Name Indication
++ *                 and as expected Common Name of the peer certificate [IN]
++ * @param service unique identifier for the service to connect to
++ *                (only used locally for certificates database) [IN]
++ * @param alpn NULL-terminated list of Application Layer Protocols
++ *             to negotiate, or NULL to not negotiate protocols [IN]
++ * @param alp storage space for the negotiated Application Layer
++ *            Protocol or NULL if negotiation was not performed [OUT]
++ *
++ * @note The credentials must remain valid until the session is finished.
++ *
++ * @return TLS session, or NULL on error.
++ **/
++VLC_API vlc_tls_t *vlc_tls_ClientSessionCreate(vlc_tls_creds_t *creds,
++                                               vlc_tls_t *sock,
++                                               const char *host,
++                                               const char *service,
++                                               const char *const *alpn,
++                                               char **alp);
++
++/**
++ * Creates a TLS server session.
++ *
++ * Allocates a Transport Layer Security (TLS) session as the server side, using
++ * cryptographic keys pair and X.509 certificates chain already loaded with
++ * vlc_tls_ServerCreate().
++ *
++ * Unlike vlc_tls_ClientSessionCreate(), this function does not perform any
++ * actual network I/O. vlc_tls_SessionHandshake() must be used to perform the
++ * TLS handshake before sending and receiving data through the TLS session.
++ *
++ * This function is non-blocking and is not a cancellation point.
++ *
++ * @param creds server credentials, i.e. keys pair and X.509 certificates chain
++ * @param alpn NULL-terminated list of Application Layer Protocols
++ *             to negotiate, or NULL to not negotiate protocols
++ *
++ * @return TLS session, or NULL on error.
++ */
++VLC_API vlc_tls_t *vlc_tls_ServerSessionCreate(vlc_tls_creds_t *creds,
++                                               vlc_tls_t *sock,
++                                               const char *const *alpn);
++
++/** @} */
++
++/**
++ * Destroys a TLS session down.
++ *
++ * All resources associated with the TLS session are released.
++ *
++ * If the session was established successfully, then shutdown cleanly, the
++ * underlying socket can be reused. Otherwise, it must be closed. Either way,
++ * this function does not close the underlying socket: Use vlc_tls_Close()
++ * instead to close it at the same.
++ *
++ * This function is non-blocking and is not a cancellation point.
++ */
++VLC_API void vlc_tls_SessionDelete (vlc_tls_t *);
++
++static inline int vlc_tls_GetFD(vlc_tls_t *tls)
++{
++    return tls->get_fd(tls);
++}
++
++/**
++ * Receives data through a socket.
++ *
++ * This dequeues incoming data from a transport layer socket.
++ *
++ * @param buf received buffer start address [OUT]
++ * @param len buffer length (in bytes)
++ * @param waitall whether to wait for the exact buffer length (true),
++ *                or for any amount of data (false)
++ *
++ * @note At end of stream, the number of bytes returned may be shorter than
++ * requested regardless of the "waitall" flag.
++ *
++ * @return the number of bytes actually dequeued, or -1 on error.
++ */
++VLC_API ssize_t vlc_tls_Read(vlc_tls_t *, void *buf, size_t len, bool waitall);
++
++/**
++ * Receives a text line through a socket.
++ *
++ * This dequeues one line of text from a transport layer socket.
++ * @return a heap-allocated nul-terminated string, or NULL on error
++ */
++VLC_API char *vlc_tls_GetLine(vlc_tls_t *);
++
++/**
++ * Sends data through a socket.
++ */
++VLC_API ssize_t vlc_tls_Write(vlc_tls_t *, const void *buf, size_t len);
++
++/**
++ * Shuts a connection down.
++ *
++ * This sends the connection close notification.
++ *
++ * If the TLS protocol is used, this provides a secure indication to the other
++ * end that no further data will be sent. If using plain TCP/IP, this sets the
++ * FIN flag.
++ *
++ * Data can still be received until a close notification is received from the
++ * other end.
++ *
++ * @param duplex whether to stop receiving data as well
++ * @retval 0 the session was terminated securely and cleanly
++ *           (the underlying socket can be reused for other purposes)
++ * @return -1 the session was terminated locally, but either a notification
++ *            could not be sent or received (the underlying socket cannot be
++ *            reused and must be closed)
++ */
++static inline int vlc_tls_Shutdown(vlc_tls_t *tls, bool duplex)
++{
++    return tls->shutdown(tls, duplex);
++}
++
++/**
++ * Closes a connection and its underlying resources.
++ *
++ * This function closes the transport layer socket, and terminates any
++ * underlying connection. For instance, if the TLS protocol is used over a TCP
++ * stream, this function terminates both the TLS session, and then underlying
++ * TCP/IP connection.
++ *
++ * To close a connection but retain any underlying resources, use
++ * vlc_tls_SessionDelete() instead.
++ */
++static inline void vlc_tls_Close(vlc_tls_t *session)
++{
++    do
++    {
++        vlc_tls_t *p = session->p;
++
++        vlc_tls_SessionDelete(session);
++        session = p;
++    }
++    while (session != NULL);
++}
++
++/**
++ * Creates a transport-layer stream from a socket.
++ *
++ * Creates a transport-layer I/O stream from a socket file descriptor.
++ * Data will be sent and received directly through the socket. This can be used
++ * either to share common code between non-TLS and TLS cases, or for testing
++ * purposes.
++ *
++ * This function is not a cancellation point.
++ *
++ * @deprecated This function is transitional. Do not use it directly.
++ */
++VLC_API vlc_tls_t *vlc_tls_SocketOpen(int fd);
++
++/**
++ * Creates a connected pair of transport-layer sockets.
++ */
++VLC_API int vlc_tls_SocketPair(int family, int protocol, vlc_tls_t *[2]);
++
++struct addrinfo;
++
++/**
++ * Creates a transport-layer stream from a struct addrinfo.
++ *
++ * This function tries to allocate a socket using the specified addrinfo
++ * structure. Normally, the vlc_tls_SocketOpenTCP() function takes care of
++ * this. But in some cases, it cannot be used, notably:
++ * - if the remote destination is not resolved (directly) from getaddrinfo(),
++ * - if the socket type is not SOCK_STREAM,
++ * - if the transport protocol is not TCP (IPPROTO_TCP), or
++ * - if TCP Fast Open should be attempted.
++ *
++ * @param ai a filled addrinfo structure (the ai_next member is ignored)
++ * @param defer_connect whether to attempt a TCP Fast Open connection or not
++ */
++VLC_API vlc_tls_t *vlc_tls_SocketOpenAddrInfo(const struct addrinfo *ai,
++                                              bool defer_connect);
++
++/**
++ * Creates a transport-layer TCP stream from a name and port.
++ *
++ * This function resolves a hostname, and attempts to establish a TCP/IP
++ * connection to the specified host and port number.
++ *
++ * @note The function currently iterates through the addrinfo linked list.
++ * Future versions may implement different behaviour (e.g. RFC6555).
++ *
++ * @return a transport layer socket on success or NULL on error
++ */
++VLC_API vlc_tls_t *vlc_tls_SocketOpenTCP(vlc_object_t *obj,
++                                         const char *hostname, unsigned port);
++
++/**
++ * Initiates a TLS session over TCP.
++ *
++ * This function resolves a hostname, attempts to establish a TCP/IP
++ * connection to the specified host and port number, and finally attempts to
++ * establish a TLS session over the TCP/IP stream.
++ *
++ * See also vlc_tls_SocketOpenTCP() and vlc_tls_SessionCreate().
++ */
++VLC_API vlc_tls_t *vlc_tls_SocketOpenTLS(vlc_tls_creds_t *crd,
++                                         const char *hostname, unsigned port,
++                                         const char *service,
++                                         const char *const *alpn, char **alp);
++
++VLC_DEPRECATED
++static inline vlc_tls_t *
++vlc_tls_ClientSessionCreateFD(vlc_tls_creds_t *crd, int fd, const char *host,
++                              const char *srv, const char *const *lp, char **p)
++{
++    vlc_tls_t *sock = vlc_tls_SocketOpen(fd);
++    if (unlikely(sock == NULL))
++        return NULL;
++
++    vlc_tls_t *tls = vlc_tls_ClientSessionCreate(crd, sock, host, srv, lp, p);
++    if (unlikely(tls == NULL))
++        free(sock);
++    return tls;
++}
++
++/** @} */
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_url.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_url.h
+new file mode 100644
+index 0000000..ceae349
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_url.h
+@@ -0,0 +1,210 @@
++/*****************************************************************************
++ * vlc_url.h: URL related macros
++ *****************************************************************************
++ * Copyright (C) 2002-2006 VLC authors and VideoLAN
++ * $Id: e13b7a5abb57e777e5252c5287bed9f52c7e2de0 $
++ *
++ * Authors: Christophe Massiot <massiot@via.ecp.fr>
++ *          Rémi Denis-Courmont <rem # videolan.org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_URL_H
++# define VLC_URL_H
++
++/**
++ * \file
++ * This file defines functions for manipulating URL in vlc
++ *
++ * \ingroup strings
++ * @{
++ */
++
++/**
++ * Converts local path to URL.
++ *
++ * Builds a URL representation from a local UTF-8 null-terminated file path.
++ *
++ * @param path file path
++ * @param scheme URI scheme to use (default is auto: "file", "fd" or "smb")
++ * @return a heap-allocated URI string on success
++ * or NULL in case of error (errno will be set accordingly)
++ */
++VLC_API char *vlc_path2uri(const char *path, const char *scheme) VLC_MALLOC;
++
++/**
++ * Converts a URI to a local path.
++ *
++ * Builds a local path (UTF-8-encoded null-terminated string) from a URI if
++ * the URI scheme allows.
++ *
++ * @param url URI
++ * @return a heap-allocated string or success
++ * or NULL on error
++ */
++VLC_API char *vlc_uri2path(const char *url) VLC_MALLOC;
++
++/**
++ * Decodes an URI component in place.
++ *
++ * Decodes one null-terminated UTF-8 URI component to aa null-terminated UTF-8
++ * string in place.
++ *
++ * See also vlc_uri_decode_duplicate() for the not-in-place variant.
++ *
++ * \warning <b>This function does NOT decode entire URIs.</b>
++ * URI can only be decoded (and encoded) one component at a time
++ * (e.g. the host name, one directory, the file name).
++ * Complete URIs are always "encoded" (or they are syntaxically invalid).
++ * See IETF RFC3986, especially §2.4 for details.
++ *
++ * \note URI encoding is <b>different</b> from Javascript escaping. Especially,
++ * white spaces and Unicode non-ASCII code points are encoded differently.
++ *
++ * \param str null-terminated component
++ * \return str is returned on success. NULL if str was not properly encoded.
++ */
++VLC_API char *vlc_uri_decode(char *str);
++
++/**
++ * Decodes an URI component.
++ *
++ * See also vlc_uri_decode() for the in-place variant.
++ *
++ * \return a heap-allocated string on success or NULL on error.
++ */
++VLC_API char *vlc_uri_decode_duplicate(const char *str) VLC_MALLOC;
++
++/**
++ * Encodes a URI component.
++ *
++ * Substitutes URI-unsafe, URI delimiters and non-ASCII characters into their
++ * URI-encoded URI-safe representation. See also IETF RFC3986 §2.
++ *
++ * @param str nul-terminated UTF-8 representation of the component.
++ * @note Obviously, a URI containing nul bytes cannot be passed.
++ * @return heap-allocated string, or NULL if out of memory.
++ */
++VLC_API char *vlc_uri_encode(const char *str) VLC_MALLOC;
++
++/**
++ * Composes an URI.
++ *
++ * Converts a decomposed/parsed URI structure (\ref vlc_url_t) into a
++ * nul-terminated URI literal string.
++ *
++ * See also IETF RFC3986 section 5.3 for details.
++ *
++ * \bug URI fragments (i.e. HTML anchors) are not handled
++ *
++ * \return a heap-allocated nul-terminated string or NULL if out of memory
++ */
++VLC_API char *vlc_uri_compose(const vlc_url_t *) VLC_MALLOC;
++
++/**
++ * Resolves an URI reference.
++ *
++ * Resolves an URI reference relative to a base URI.
++ * If the reference is an absolute URI, then this function simply returns a
++ * copy of the URI reference.
++ *
++ * \param base base URI (as a nul-terminated string)
++ * \param ref URI reference (also as a nul-terminated string)
++ *
++ * \return a heap-allocated nul-terminated string representing the resolved
++ * absolute URI, or NULL if out of memory.
++ */
++VLC_API char *vlc_uri_resolve(const char *base, const char *ref) VLC_MALLOC;
++
++/**
++ * Fixes up a URI string.
++ *
++ * Attempts to convert a nul-terminated string into a syntactically valid URI.
++ * If the string is, or may be, a syntactically valid URI, an exact copy is
++ * returned. In any case, the result will only contain URI-safe and URI
++ * delimiter characters (generic delimiters or sub-delimiters) and all percent
++ * signs will be followed by two hexadecimal characters.
++ *
++ * @return a heap-allocated string, or NULL if on out of memory.
++ */
++VLC_API char *vlc_uri_fixup(const char *) VLC_MALLOC;
++
++struct vlc_url_t
++{
++    char *psz_protocol;
++    char *psz_username;
++    char *psz_password;
++    char *psz_host;
++    unsigned i_port;
++    char *psz_path;
++    char *psz_option;
++
++    char *psz_buffer; /* to be freed */
++    char *psz_pathbuffer; /* to be freed */
++};
++
++/**
++ * Parses an URI or IRI.
++ *
++ * Extracts the following parts from an URI string:
++ *  - scheme (i.e. protocol),
++ *  - user (deprecated),
++ *  - password (also deprecated),
++ *  - host name or IP address literal,
++ *  - port number,
++ *  - path (including the filename preceded by any and all directories)
++ *  - request parameters (excluding the leading question mark '?').
++ *
++ * The function accepts URIs, as well as UTF-8-encoded IRIs. For IRIs, the hier
++ * part (specifically, the host name) is assumed to be an IDN and is decoded to
++ * ASCII according, so it can be used for DNS resolution. If the host is an
++ * IPv6 address literal, brackets are stripped.
++ *
++ * Any missing part is set to nul. For historical reasons, the target structure
++ * is always initialized, even if parsing the URI string fails.
++ *
++ * On error, errno is set to one of the following value:
++ *  - ENOMEM in case of memory allocation failure,
++ *  - EINVAL in case of syntax error in the input string.
++ *
++ * \bug The URI fragment is discarded if present.
++ *
++ * \note This function allocates memory. vlc_UrlClean() must be used free
++ * associated the allocations, even if the function fails.
++ *
++ * \param url structure of URL parts [OUT]
++ * \param str nul-terminated URL string to split
++ * \retval 0 success
++ * \retval -1 failure
++ */
++VLC_API int vlc_UrlParse(vlc_url_t *url, const char *str);
++
++/**
++ * Parses an URI or IRI and fix up the path part.
++ *
++ * \see vlc_UrlParse
++ * \see vlc_uri_fixup
++ */
++VLC_API int vlc_UrlParseFixup(vlc_url_t *url, const char *str);
++
++/**
++ * Releases resources allocated by vlc_UrlParse().
++ */
++VLC_API void vlc_UrlClean(vlc_url_t *);
++
++/** @} */
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_variables.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_variables.h
+new file mode 100644
+index 0000000..a397580
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_variables.h
+@@ -0,0 +1,671 @@
++/*****************************************************************************
++ * vlc_variables.h: variables handling
++ *****************************************************************************
++ * Copyright (C) 2002-2004 VLC authors and VideoLAN
++ * $Id: 83752b171f82c86164142a6254f513fc9cb7a324 $
++ *
++ * Authors: Samuel Hocevar <sam@zoy.org>
++ *          Gildas Bazin <gbazin@netcourrier.com>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_VARIABLES_H
++#define VLC_VARIABLES_H 1
++
++/**
++ * \defgroup variables Variables
++ * \ingroup vlc_object
++ *
++ * VLC object variables and callbacks
++ *
++ * @{
++ * \file
++ * VLC object variables and callbacks interface
++ */
++
++#define VLC_VAR_TYPE      0x00ff
++#define VLC_VAR_CLASS     0x00f0
++#define VLC_VAR_FLAGS     0xff00
++
++/**
++ * \defgroup var_type Variable types
++ * These are the different types a vlc variable can have.
++ * @{
++ */
++#define VLC_VAR_VOID      0x0010
++#define VLC_VAR_BOOL      0x0020
++#define VLC_VAR_INTEGER   0x0030
++#define VLC_VAR_STRING    0x0040
++#define VLC_VAR_FLOAT     0x0050
++#define VLC_VAR_ADDRESS   0x0070
++#define VLC_VAR_COORDS    0x00A0
++/**@}*/
++
++/** \defgroup var_flags Additive flags
++ * These flags are added to the type field of the variable. Most as a result of
++ * a var_Change() call, but some may be added at creation time
++ * @{
++ */
++#define VLC_VAR_HASCHOICE 0x0100
++
++#define VLC_VAR_ISCOMMAND 0x2000
++
++/** Creation flag */
++/* If the variable is not found on the current module
++   search all parents and finally module config until found */
++#define VLC_VAR_DOINHERIT 0x8000
++/**@}*/
++
++/**
++ * \defgroup var_action Variable actions
++ * These are the different actions that can be used with var_Change().
++ * The parameters given are the meaning of the two last parameters of
++ * var_Change() when this action is being used.
++ * @{
++ */
++
++#define VLC_VAR_SETSTEP             0x0012
++
++/**
++ * Set the value of this variable without triggering any callbacks
++ * \param p_val The new value
++ * \param p_val2 Unused
++ */
++#define VLC_VAR_SETVALUE            0x0013
++
++#define VLC_VAR_SETTEXT             0x0014
++#define VLC_VAR_GETTEXT             0x0015
++
++#define VLC_VAR_GETMIN              0x0016
++#define VLC_VAR_GETMAX              0x0017
++#define VLC_VAR_GETSTEP             0x0018
++
++#define VLC_VAR_ADDCHOICE           0x0020
++#define VLC_VAR_DELCHOICE           0x0021
++#define VLC_VAR_CLEARCHOICES        0x0022
++#define VLC_VAR_GETCHOICES          0x0024
++
++#define VLC_VAR_CHOICESCOUNT        0x0026
++#define VLC_VAR_SETMINMAX           0x0027
++
++/**@}*/
++
++/** \defgroup var_GetAndSet Variable actions
++ * These are the different actions that can be used with var_GetAndSet()
++ * @{
++ */
++enum {
++    VLC_VAR_BOOL_TOGGLE, /**< Invert a boolean value (param ignored) */
++    VLC_VAR_INTEGER_ADD, /**< Add parameter to an integer value */
++    VLC_VAR_INTEGER_OR,  /**< Binary OR over an integer bits field */
++    VLC_VAR_INTEGER_NAND,/**< Binary NAND over an integer bits field */
++};
++/**@}*/
++
++/*****************************************************************************
++ * Prototypes
++ *****************************************************************************/
++VLC_API int var_Create( vlc_object_t *, const char *, int );
++#define var_Create(a,b,c) var_Create( VLC_OBJECT(a), b, c )
++
++VLC_API void var_Destroy( vlc_object_t *, const char * );
++#define var_Destroy(a,b) var_Destroy( VLC_OBJECT(a), b )
++
++VLC_API int var_Change( vlc_object_t *, const char *, int, vlc_value_t *, vlc_value_t * );
++#define var_Change(a,b,c,d,e) var_Change( VLC_OBJECT(a), b, c, d, e )
++
++VLC_API int var_Type( vlc_object_t *, const char * ) VLC_USED;
++#define var_Type(a,b) var_Type( VLC_OBJECT(a), b )
++
++VLC_API int var_Set( vlc_object_t *, const char *, vlc_value_t );
++#define var_Set(a,b,c) var_Set( VLC_OBJECT(a), b, c )
++
++VLC_API int var_Get( vlc_object_t *, const char *, vlc_value_t * );
++#define var_Get(a,b,c) var_Get( VLC_OBJECT(a), b, c )
++
++VLC_API int var_SetChecked( vlc_object_t *, const char *, int, vlc_value_t );
++#define var_SetChecked(o,n,t,v) var_SetChecked(VLC_OBJECT(o),n,t,v)
++VLC_API int var_GetChecked( vlc_object_t *, const char *, int, vlc_value_t * );
++#define var_GetChecked(o,n,t,v) var_GetChecked(VLC_OBJECT(o),n,t,v)
++VLC_API int var_GetAndSet( vlc_object_t *, const char *, int, vlc_value_t * );
++
++VLC_API int var_Inherit( vlc_object_t *, const char *, int, vlc_value_t * );
++
++VLC_API void var_FreeList( vlc_value_t *, vlc_value_t * );
++
++
++/*****************************************************************************
++ * Variable callbacks
++ *****************************************************************************
++ * int MyCallback( vlc_object_t *p_this,
++ *                 char const *psz_variable,
++ *                 vlc_value_t oldvalue,
++ *                 vlc_value_t newvalue,
++ *                 void *p_data);
++ *****************************************************************************/
++VLC_API void var_AddCallback( vlc_object_t *, const char *, vlc_callback_t, void * );
++VLC_API void var_DelCallback( vlc_object_t *, const char *, vlc_callback_t, void * );
++VLC_API void var_TriggerCallback( vlc_object_t *, const char * );
++
++VLC_API void var_AddListCallback( vlc_object_t *, const char *, vlc_list_callback_t, void * );
++VLC_API void var_DelListCallback( vlc_object_t *, const char *, vlc_list_callback_t, void * );
++
++#define var_AddCallback(a,b,c,d) var_AddCallback( VLC_OBJECT(a), b, c, d )
++#define var_DelCallback(a,b,c,d) var_DelCallback( VLC_OBJECT(a), b, c, d )
++#define var_TriggerCallback(a,b) var_TriggerCallback( VLC_OBJECT(a), b )
++
++#define var_AddListCallback(a,b,c,d) var_AddListCallback( VLC_OBJECT(a), b, c, d )
++#define var_DelListCallback(a,b,c,d) var_DelListCallback( VLC_OBJECT(a), b, c, d )
++
++/*****************************************************************************
++ * helpers functions
++ *****************************************************************************/
++
++/**
++ * Set the value of an integer variable
++ *
++ * \param p_obj The object that holds the variable
++ * \param psz_name The name of the variable
++ * \param i The new integer value of this variable
++ */
++static inline int var_SetInteger( vlc_object_t *p_obj, const char *psz_name,
++                                  int64_t i )
++{
++    vlc_value_t val;
++    val.i_int = i;
++    return var_SetChecked( p_obj, psz_name, VLC_VAR_INTEGER, val );
++}
++
++/**
++ * Set the value of an boolean variable
++ *
++ * \param p_obj The object that holds the variable
++ * \param psz_name The name of the variable
++ * \param b The new boolean value of this variable
++ */
++static inline int var_SetBool( vlc_object_t *p_obj, const char *psz_name, bool b )
++{
++    vlc_value_t val;
++    val.b_bool = b;
++    return var_SetChecked( p_obj, psz_name, VLC_VAR_BOOL, val );
++}
++
++static inline int var_SetCoords( vlc_object_t *obj, const char *name,
++                                 int32_t x, int32_t y )
++{
++    vlc_value_t val;
++    val.coords.x = x;
++    val.coords.y = y;
++    return var_SetChecked (obj, name, VLC_VAR_COORDS, val);
++}
++#define var_SetCoords(o,n,x,y) var_SetCoords(VLC_OBJECT(o),n,x,y)
++
++/**
++ * Set the value of a float variable
++ *
++ * \param p_obj The object that holds the variable
++ * \param psz_name The name of the variable
++ * \param f The new float value of this variable
++ */
++static inline int var_SetFloat( vlc_object_t *p_obj, const char *psz_name, float f )
++{
++    vlc_value_t val;
++    val.f_float = f;
++    return var_SetChecked( p_obj, psz_name, VLC_VAR_FLOAT, val );
++}
++
++/**
++ * Set the value of a string variable
++ *
++ * \param p_obj The object that holds the variable
++ * \param psz_name The name of the variable
++ * \param psz_string The new string value of this variable
++ */
++static inline int var_SetString( vlc_object_t *p_obj, const char *psz_name, const char *psz_string )
++{
++    vlc_value_t val;
++    val.psz_string = (char *)psz_string;
++    return var_SetChecked( p_obj, psz_name, VLC_VAR_STRING, val );
++}
++
++/**
++ * Set the value of a pointer variable
++ *
++ * \param p_obj The object that holds the variable
++ * \param psz_name The name of the variable
++ * \param ptr The new pointer value of this variable
++ */
++static inline
++int var_SetAddress( vlc_object_t *p_obj, const char *psz_name, void *ptr )
++{
++    vlc_value_t val;
++    val.p_address = ptr;
++    return var_SetChecked( p_obj, psz_name, VLC_VAR_ADDRESS, val );
++}
++
++#define var_SetInteger(a,b,c)   var_SetInteger( VLC_OBJECT(a),b,c)
++#define var_SetBool(a,b,c)      var_SetBool( VLC_OBJECT(a),b,c)
++#define var_SetFloat(a,b,c)     var_SetFloat( VLC_OBJECT(a),b,c)
++#define var_SetString(a,b,c)    var_SetString( VLC_OBJECT(a),b,c)
++#define var_SetAddress(o, n, p) var_SetAddress(VLC_OBJECT(o), n, p)
++
++
++/**
++ * Get an integer value
++*
++ * \param p_obj The object that holds the variable
++ * \param psz_name The name of the variable
++ */
++VLC_USED
++static inline int64_t var_GetInteger( vlc_object_t *p_obj, const char *psz_name )
++{
++    vlc_value_t val;
++    if( !var_GetChecked( p_obj, psz_name, VLC_VAR_INTEGER, &val ) )
++        return val.i_int;
++    else
++        return 0;
++}
++
++/**
++ * Get a boolean value
++ *
++ * \param p_obj The object that holds the variable
++ * \param psz_name The name of the variable
++ */
++VLC_USED
++static inline bool var_GetBool( vlc_object_t *p_obj, const char *psz_name )
++{
++    vlc_value_t val; val.b_bool = false;
++
++    if( !var_GetChecked( p_obj, psz_name, VLC_VAR_BOOL, &val ) )
++        return val.b_bool;
++    else
++        return false;
++}
++
++static inline void var_GetCoords( vlc_object_t *obj, const char *name,
++                                  int32_t *px, int32_t *py )
++{
++    vlc_value_t val;
++
++    if (likely(!var_GetChecked (obj, name, VLC_VAR_COORDS, &val)))
++    {
++        *px = val.coords.x;
++        *py = val.coords.y;
++    }
++    else
++        *px = *py = 0;
++}
++#define var_GetCoords(o,n,x,y) var_GetCoords(VLC_OBJECT(o),n,x,y)
++
++/**
++ * Get a float value
++ *
++ * \param p_obj The object that holds the variable
++ * \param psz_name The name of the variable
++ */
++VLC_USED
++static inline float var_GetFloat( vlc_object_t *p_obj, const char *psz_name )
++{
++    vlc_value_t val; val.f_float = 0.0;
++    if( !var_GetChecked( p_obj, psz_name, VLC_VAR_FLOAT, &val ) )
++        return val.f_float;
++    else
++        return 0.0;
++}
++
++/**
++ * Get a string value
++ *
++ * \param p_obj The object that holds the variable
++ * \param psz_name The name of the variable
++ */
++VLC_USED VLC_MALLOC
++static inline char *var_GetString( vlc_object_t *p_obj, const char *psz_name )
++{
++    vlc_value_t val; val.psz_string = NULL;
++    if( var_GetChecked( p_obj, psz_name, VLC_VAR_STRING, &val ) )
++        return NULL;
++    else
++        return val.psz_string;
++}
++
++VLC_USED VLC_MALLOC
++static inline char *var_GetNonEmptyString( vlc_object_t *p_obj, const char *psz_name )
++{
++    vlc_value_t val;
++    if( var_GetChecked( p_obj, psz_name, VLC_VAR_STRING, &val ) )
++        return NULL;
++    if( val.psz_string && *val.psz_string )
++        return val.psz_string;
++    free( val.psz_string );
++    return NULL;
++}
++
++VLC_USED
++static inline void *var_GetAddress( vlc_object_t *p_obj, const char *psz_name )
++{
++    vlc_value_t val;
++    if( var_GetChecked( p_obj, psz_name, VLC_VAR_ADDRESS, &val ) )
++        return NULL;
++    else
++        return val.p_address;
++}
++
++/**
++ * Increment an integer variable
++ * \param p_obj the object that holds the variable
++ * \param psz_name the name of the variable
++ */
++static inline int64_t var_IncInteger( vlc_object_t *p_obj, const char *psz_name )
++{
++    vlc_value_t val;
++    val.i_int = 1;
++    if( var_GetAndSet( p_obj, psz_name, VLC_VAR_INTEGER_ADD, &val ) )
++        return 0;
++    return val.i_int;
++}
++#define var_IncInteger(a,b) var_IncInteger( VLC_OBJECT(a), b )
++
++/**
++ * Decrement an integer variable
++ * \param p_obj the object that holds the variable
++ * \param psz_name the name of the variable
++ */
++static inline int64_t var_DecInteger( vlc_object_t *p_obj, const char *psz_name )
++{
++    vlc_value_t val;
++    val.i_int = -1;
++    if( var_GetAndSet( p_obj, psz_name, VLC_VAR_INTEGER_ADD, &val ) )
++        return 0;
++    return val.i_int;
++}
++#define var_DecInteger(a,b) var_DecInteger( VLC_OBJECT(a), b )
++
++static inline uint64_t var_OrInteger( vlc_object_t *obj, const char *name,
++                                      unsigned v )
++{
++    vlc_value_t val;
++    val.i_int = v;
++    if( var_GetAndSet( obj, name, VLC_VAR_INTEGER_OR, &val ) )
++        return 0;
++    return val.i_int;
++}
++#define var_OrInteger(a,b,c) var_OrInteger(VLC_OBJECT(a),b,c)
++
++static inline uint64_t var_NAndInteger( vlc_object_t *obj, const char *name,
++                                        unsigned v )
++{
++    vlc_value_t val;
++    val.i_int = v;
++    if( var_GetAndSet( obj, name, VLC_VAR_INTEGER_NAND, &val ) )
++        return 0;
++    return val.i_int;
++}
++#define var_NAndInteger(a,b,c) var_NAndInteger(VLC_OBJECT(a),b,c)
++
++/**
++ * Create a integer variable with inherit and get its value.
++ *
++ * \param p_obj The object that holds the variable
++ * \param psz_name The name of the variable
++ */
++VLC_USED
++static inline int64_t var_CreateGetInteger( vlc_object_t *p_obj, const char *psz_name )
++{
++    var_Create( p_obj, psz_name, VLC_VAR_INTEGER | VLC_VAR_DOINHERIT );
++    return var_GetInteger( p_obj, psz_name );
++}
++
++/**
++ * Create a boolean variable with inherit and get its value.
++ *
++ * \param p_obj The object that holds the variable
++ * \param psz_name The name of the variable
++ */
++VLC_USED
++static inline bool var_CreateGetBool( vlc_object_t *p_obj, const char *psz_name )
++{
++    var_Create( p_obj, psz_name, VLC_VAR_BOOL | VLC_VAR_DOINHERIT );
++    return var_GetBool( p_obj, psz_name );
++}
++
++/**
++ * Create a float variable with inherit and get its value.
++ *
++ * \param p_obj The object that holds the variable
++ * \param psz_name The name of the variable
++ */
++VLC_USED
++static inline float var_CreateGetFloat( vlc_object_t *p_obj, const char *psz_name )
++{
++    var_Create( p_obj, psz_name, VLC_VAR_FLOAT | VLC_VAR_DOINHERIT );
++    return var_GetFloat( p_obj, psz_name );
++}
++
++/**
++ * Create a string variable with inherit and get its value.
++ *
++ * \param p_obj The object that holds the variable
++ * \param psz_name The name of the variable
++ */
++VLC_USED VLC_MALLOC
++static inline char *var_CreateGetString( vlc_object_t *p_obj,
++                                           const char *psz_name )
++{
++    var_Create( p_obj, psz_name, VLC_VAR_STRING | VLC_VAR_DOINHERIT );
++    return var_GetString( p_obj, psz_name );
++}
++
++VLC_USED VLC_MALLOC
++static inline char *var_CreateGetNonEmptyString( vlc_object_t *p_obj,
++                                                   const char *psz_name )
++{
++    var_Create( p_obj, psz_name, VLC_VAR_STRING | VLC_VAR_DOINHERIT );
++    return var_GetNonEmptyString( p_obj, psz_name );
++}
++
++/**
++ * Create an address variable with inherit and get its value.
++ *
++ * \param p_obj The object that holds the variable
++ * \param psz_name The name of the variable
++ */
++VLC_USED
++static inline void *var_CreateGetAddress( vlc_object_t *p_obj,
++                                           const char *psz_name )
++{
++    var_Create( p_obj, psz_name, VLC_VAR_ADDRESS | VLC_VAR_DOINHERIT );
++    return var_GetAddress( p_obj, psz_name );
++}
++
++#define var_CreateGetInteger(a,b)   var_CreateGetInteger( VLC_OBJECT(a),b)
++#define var_CreateGetBool(a,b)   var_CreateGetBool( VLC_OBJECT(a),b)
++#define var_CreateGetFloat(a,b)   var_CreateGetFloat( VLC_OBJECT(a),b)
++#define var_CreateGetString(a,b)   var_CreateGetString( VLC_OBJECT(a),b)
++#define var_CreateGetNonEmptyString(a,b)   var_CreateGetNonEmptyString( VLC_OBJECT(a),b)
++#define var_CreateGetAddress(a,b)  var_CreateGetAddress( VLC_OBJECT(a),b)
++
++/**
++ * Create a integer command variable with inherit and get its value.
++ *
++ * \param p_obj The object that holds the variable
++ * \param psz_name The name of the variable
++ */
++VLC_USED
++static inline int64_t var_CreateGetIntegerCommand( vlc_object_t *p_obj, const char *psz_name )
++{
++    var_Create( p_obj, psz_name, VLC_VAR_INTEGER | VLC_VAR_DOINHERIT
++                                   | VLC_VAR_ISCOMMAND );
++    return var_GetInteger( p_obj, psz_name );
++}
++
++/**
++ * Create a boolean command variable with inherit and get its value.
++ *
++ * \param p_obj The object that holds the variable
++ * \param psz_name The name of the variable
++ */
++VLC_USED
++static inline bool var_CreateGetBoolCommand( vlc_object_t *p_obj, const char *psz_name )
++{
++    var_Create( p_obj, psz_name, VLC_VAR_BOOL | VLC_VAR_DOINHERIT
++                                   | VLC_VAR_ISCOMMAND );
++    return var_GetBool( p_obj, psz_name );
++}
++
++/**
++ * Create a float command variable with inherit and get its value.
++ *
++ * \param p_obj The object that holds the variable
++ * \param psz_name The name of the variable
++ */
++VLC_USED
++static inline float var_CreateGetFloatCommand( vlc_object_t *p_obj, const char *psz_name )
++{
++    var_Create( p_obj, psz_name, VLC_VAR_FLOAT | VLC_VAR_DOINHERIT
++                                   | VLC_VAR_ISCOMMAND );
++    return var_GetFloat( p_obj, psz_name );
++}
++
++/**
++ * Create a string command variable with inherit and get its value.
++ *
++ * \param p_obj The object that holds the variable
++ * \param psz_name The name of the variable
++ */
++VLC_USED VLC_MALLOC
++static inline char *var_CreateGetStringCommand( vlc_object_t *p_obj,
++                                           const char *psz_name )
++{
++    var_Create( p_obj, psz_name, VLC_VAR_STRING | VLC_VAR_DOINHERIT
++                                   | VLC_VAR_ISCOMMAND );
++    return var_GetString( p_obj, psz_name );
++}
++
++VLC_USED VLC_MALLOC
++static inline char *var_CreateGetNonEmptyStringCommand( vlc_object_t *p_obj,
++                                                   const char *psz_name )
++{
++    var_Create( p_obj, psz_name, VLC_VAR_STRING | VLC_VAR_DOINHERIT
++                                   | VLC_VAR_ISCOMMAND );
++    return var_GetNonEmptyString( p_obj, psz_name );
++}
++
++#define var_CreateGetIntegerCommand(a,b)   var_CreateGetIntegerCommand( VLC_OBJECT(a),b)
++#define var_CreateGetBoolCommand(a,b)   var_CreateGetBoolCommand( VLC_OBJECT(a),b)
++#define var_CreateGetFloatCommand(a,b)   var_CreateGetFloatCommand( VLC_OBJECT(a),b)
++#define var_CreateGetStringCommand(a,b)   var_CreateGetStringCommand( VLC_OBJECT(a),b)
++#define var_CreateGetNonEmptyStringCommand(a,b)   var_CreateGetNonEmptyStringCommand( VLC_OBJECT(a),b)
++
++VLC_USED
++static inline int var_CountChoices( vlc_object_t *p_obj, const char *psz_name )
++{
++    vlc_value_t count;
++    if( var_Change( p_obj, psz_name, VLC_VAR_CHOICESCOUNT, &count, NULL ) )
++        return 0;
++    return count.i_int;
++}
++#define var_CountChoices(a,b) var_CountChoices( VLC_OBJECT(a),b)
++
++
++static inline bool var_ToggleBool( vlc_object_t *p_obj, const char *psz_name )
++{
++    vlc_value_t val;
++    if( var_GetAndSet( p_obj, psz_name, VLC_VAR_BOOL_TOGGLE, &val ) )
++        return false;
++    return val.b_bool;
++}
++#define var_ToggleBool(a,b) var_ToggleBool( VLC_OBJECT(a),b )
++
++
++VLC_USED
++static inline bool var_InheritBool( vlc_object_t *obj, const char *name )
++{
++    vlc_value_t val;
++
++    if( var_Inherit( obj, name, VLC_VAR_BOOL, &val ) )
++        val.b_bool = false;
++    return val.b_bool;
++}
++#define var_InheritBool(o, n) var_InheritBool(VLC_OBJECT(o), n)
++
++VLC_USED
++static inline int64_t var_InheritInteger( vlc_object_t *obj, const char *name )
++{
++    vlc_value_t val;
++
++    if( var_Inherit( obj, name, VLC_VAR_INTEGER, &val ) )
++        val.i_int = 0;
++    return val.i_int;
++}
++#define var_InheritInteger(o, n) var_InheritInteger(VLC_OBJECT(o), n)
++
++VLC_USED
++static inline float var_InheritFloat( vlc_object_t *obj, const char *name )
++{
++    vlc_value_t val;
++
++    if( var_Inherit( obj, name, VLC_VAR_FLOAT, &val ) )
++        val.f_float = 0.;
++    return val.f_float;
++}
++#define var_InheritFloat(o, n) var_InheritFloat(VLC_OBJECT(o), n)
++
++VLC_USED VLC_MALLOC
++static inline char *var_InheritString( vlc_object_t *obj, const char *name )
++{
++    vlc_value_t val;
++
++    if( var_Inherit( obj, name, VLC_VAR_STRING, &val ) )
++        val.psz_string = NULL;
++    else if( val.psz_string && !*val.psz_string )
++    {
++        free( val.psz_string );
++        val.psz_string = NULL;
++    }
++    return val.psz_string;
++}
++#define var_InheritString(o, n) var_InheritString(VLC_OBJECT(o), n)
++
++VLC_USED
++static inline void *var_InheritAddress( vlc_object_t *obj, const char *name )
++{
++    vlc_value_t val;
++
++    if( var_Inherit( obj, name, VLC_VAR_ADDRESS, &val ) )
++        val.p_address = NULL;
++    return val.p_address;
++}
++#define var_InheritAddress(o, n) var_InheritAddress(VLC_OBJECT(o), n)
++
++VLC_API int var_InheritURational( vlc_object_t *, unsigned *num, unsigned *den, const char *var );
++#define var_InheritURational(a,b,c,d) var_InheritURational(VLC_OBJECT(a), b, c, d)
++
++#define var_GetInteger(a,b)   var_GetInteger( VLC_OBJECT(a),b)
++#define var_GetBool(a,b)   var_GetBool( VLC_OBJECT(a),b)
++#define var_GetFloat(a,b)   var_GetFloat( VLC_OBJECT(a),b)
++#define var_GetString(a,b)   var_GetString( VLC_OBJECT(a),b)
++#define var_GetNonEmptyString(a,b)   var_GetNonEmptyString( VLC_OBJECT(a),b)
++#define var_GetAddress(a,b)  var_GetAddress( VLC_OBJECT(a),b)
++
++VLC_API int var_LocationParse(vlc_object_t *, const char *mrl, const char *prefix);
++#define var_LocationParse(o, m, p) var_LocationParse(VLC_OBJECT(o), m, p)
++
++/**
++ * @}
++ */
++#endif /*  _VLC_VARIABLES_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_video_splitter.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_video_splitter.h
+new file mode 100644
+index 0000000..c7ac885
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_video_splitter.h
+@@ -0,0 +1,158 @@
++/*****************************************************************************
++ * vlc_video_splitter.h: "video splitter" related structures and functions
++ *****************************************************************************
++ * Copyright (C) 2009 Laurent Aimar
++ * $Id: a5afba5230b0fb5b42c5cff3daab70a1e527f9eb $
++ *
++ * Authors: Laurent Aimar <fenrir _AT_ videolan _DOT_ org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_VIDEO_SPLITTER_H
++#define VLC_VIDEO_SPLITTER_H 1
++
++#include <vlc_es.h>
++#include <vlc_picture.h>
++#include <vlc_mouse.h>
++
++/**
++ * \file
++ * This file defines the structure and types used by video splitter filters.
++ */
++
++typedef struct video_splitter_t video_splitter_t;
++typedef struct video_splitter_sys_t video_splitter_sys_t;
++typedef struct video_splitter_owner_t video_splitter_owner_t;
++
++/** Structure describing a video splitter output properties
++ */
++typedef struct
++{
++    /* Video format of the output */
++    video_format_t fmt;
++
++    /* Window hints */
++    struct
++    {
++        /* Relative position.
++         * (0,0) is equal to the default position.
++         */
++        int i_x;
++        int i_y;
++
++        /* Alignment inside the window
++         */
++        int i_align;
++    } window;
++
++    /* Video output module
++     * Use NULL for default
++     */
++    char *psz_module;
++
++} video_splitter_output_t;
++
++/** Structure describing a video splitter
++ */
++struct video_splitter_t
++{
++    VLC_COMMON_MEMBERS
++
++    /* Module properties */
++    module_t        *p_module;
++
++    /* configuration */
++    config_chain_t  *p_cfg;
++
++    /* Input format
++     * It is filled by the creator and cannot be modified.
++     */
++    video_format_t  fmt;
++
++    /* Output formats
++     *
++     * It can only be set in the open() function and must remain
++     * constant.
++     * The module is responsible for the allocation and deallocation.
++     */
++    int                     i_output;
++    video_splitter_output_t *p_output;
++
++    int             (*pf_filter)( video_splitter_t *, picture_t *pp_dst[],
++                                  picture_t *p_src );
++    int             (*pf_mouse) ( video_splitter_t *, vlc_mouse_t *,
++                                  int i_index,
++                                  const vlc_mouse_t *p_old, const vlc_mouse_t *p_new );
++
++    video_splitter_sys_t *p_sys;
++
++    /* Buffer allocation */
++    int  (*pf_picture_new) ( video_splitter_t *, picture_t *pp_picture[] );
++    void (*pf_picture_del) ( video_splitter_t *, picture_t *pp_picture[] );
++    video_splitter_owner_t *p_owner;
++};
++
++/**
++ * It will create an array of pictures suitable as output.
++ *
++ * You must either returned them through pf_filter or by calling
++ * video_splitter_DeletePicture.
++ *
++ * If VLC_SUCCESS is not returned, pp_picture values are undefined.
++ */
++static inline int video_splitter_NewPicture( video_splitter_t *p_splitter,
++                                             picture_t *pp_picture[] )
++{
++    int i_ret = p_splitter->pf_picture_new( p_splitter, pp_picture );
++    if( i_ret )
++        msg_Warn( p_splitter, "can't get output pictures" );
++    return i_ret;
++}
++
++/**
++ * It will release an array of pictures created by video_splitter_NewPicture.
++ * Provided for convenience.
++ */
++static inline void video_splitter_DeletePicture( video_splitter_t *p_splitter,
++                                                 picture_t *pp_picture[] )
++{
++    p_splitter->pf_picture_del( p_splitter, pp_picture );
++}
++
++/* */
++video_splitter_t * video_splitter_New( vlc_object_t *, const char *psz_name, const video_format_t * );
++void video_splitter_Delete( video_splitter_t * );
++
++static inline int video_splitter_Filter( video_splitter_t *p_splitter,
++                                         picture_t *pp_dst[], picture_t *p_src )
++{
++    return p_splitter->pf_filter( p_splitter, pp_dst, p_src );
++}
++static inline int video_splitter_Mouse( video_splitter_t *p_splitter,
++                                        vlc_mouse_t *p_mouse,
++                                        int i_index,
++                                        const vlc_mouse_t *p_old, const vlc_mouse_t *p_new )
++{
++    if( !p_splitter->pf_mouse )
++    {
++        *p_mouse = *p_new;
++        return VLC_SUCCESS;
++    }
++    return p_splitter->pf_mouse( p_splitter, p_mouse, i_index, p_old, p_new );
++}
++
++#endif /* VLC_VIDEO_SPLITTER_H */
++
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_viewpoint.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_viewpoint.h
+new file mode 100644
+index 0000000..cf01913
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_viewpoint.h
+@@ -0,0 +1,68 @@
++/*****************************************************************************
++ * vlc_viewpoint.h: viewpoint struct and helpers
++ *****************************************************************************
++ * Copyright (C) 2017 VLC authors and VideoLAN
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_VIEWPOINT_H_
++#define VLC_VIEWPOINT_H_ 1
++
++#include <vlc_common.h>
++
++#include <math.h>
++
++/**
++ * \defgroup output Output
++ * \ingroup output
++ *
++ * @{
++ * \file
++ * Video and audio viewpoint struct and helpers
++ */
++
++#define FIELD_OF_VIEW_DEGREES_DEFAULT  80.f
++#define FIELD_OF_VIEW_DEGREES_MAX 150.f
++#define FIELD_OF_VIEW_DEGREES_MIN 20.f
++
++/**
++ * Viewpoints
++ */
++struct vlc_viewpoint_t {
++    float yaw;   /* yaw in degrees */
++    float pitch; /* pitch in degrees */
++    float roll;  /* roll in degrees */
++    float fov;   /* field of view in degrees */
++};
++
++static inline void vlc_viewpoint_init( vlc_viewpoint_t *p_vp )
++{
++    p_vp->yaw = p_vp->pitch = p_vp->roll = 0.0f;
++    p_vp->fov = FIELD_OF_VIEW_DEGREES_DEFAULT;
++}
++
++static inline void vlc_viewpoint_clip( vlc_viewpoint_t *p_vp )
++{
++    p_vp->yaw = fmodf( p_vp->yaw, 360.f );
++    p_vp->pitch = fmodf( p_vp->pitch, 360.f );
++    p_vp->roll = fmodf( p_vp->roll, 360.f );
++    p_vp->fov = VLC_CLIP( p_vp->fov, FIELD_OF_VIEW_DEGREES_MIN,
++                          FIELD_OF_VIEW_DEGREES_MAX );
++}
++
++/**@}*/
++
++#endif /* VLC_VIEWPOINT_H_ */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_vlm.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_vlm.h
+new file mode 100644
+index 0000000..7e3c61d
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_vlm.h
+@@ -0,0 +1,368 @@
++/*****************************************************************************
++ * vlc_vlm.h: VLM core structures
++ *****************************************************************************
++ * Copyright (C) 2000, 2001 VLC authors and VideoLAN
++ * $Id: 88d4437cc1028468c0cadeaea32fa645769e2ee6 $
++ *
++ * Authors: Simon Latapie <garf@videolan.org>
++ *          Laurent Aimar <fenrir@videolan.org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_VLM_H
++#define VLC_VLM_H 1
++
++#include <vlc_input.h>
++
++/**
++ * \defgroup server VLM
++ * VLC stream manager
++ *
++ * VLM is the server core in vlc that allows streaming of multiple media streams
++ * at the same time. It provides broadcast, schedule and video on demand features
++ * for streaming using several streaming and network protocols.
++ * @{
++ * \file
++ * VLC stream manager interface
++ */
++
++/** VLM media */
++typedef struct
++{
++    int64_t     id;     /*< numeric id for vlm_media_t item */
++    bool  b_enabled;    /*< vlm_media_t is enabled */
++
++    char *psz_name;     /*< descriptive name of vlm_media_t item */
++
++    int  i_input;       /*< number of input options */
++    char **ppsz_input;  /*< array of input options */
++
++    int  i_option;      /*< number of output options */
++    char **ppsz_option; /*< array of output options */
++
++    char *psz_output;   /*< */
++
++    bool b_vod;         /*< vlm_media_t is of type VOD */
++    struct
++    {
++        bool b_loop;    /*< this vlc_media_t broadcast item should loop */
++    } broadcast;        /*< Broadcast specific information */
++    struct
++    {
++        char *psz_mux;  /*< name of muxer to use */
++    } vod;              /*< VOD specific information */
++
++} vlm_media_t;
++
++/** VLM media instance */
++typedef struct
++{
++    char *psz_name;         /*< vlm media instance descriptive name */
++
++    int64_t     i_time;     /*< vlm media instance vlm media current time */
++    int64_t     i_length;   /*< vlm media instance vlm media item length */
++    double      d_position; /*< vlm media instance position in stream */
++    bool        b_paused;   /*< vlm media instance is paused */
++    int         i_rate;     // normal is INPUT_RATE_DEFAULT
++} vlm_media_instance_t;
++
++#if 0
++typedef struct
++{
++
++} vlm_schedule_t
++#endif
++
++/** VLM events
++ * You can catch vlm event by adding a callback on the variable "intf-event"
++ * of the VLM object.
++ * This variable is an address that will hold a vlm_event_t* value.
++ */
++enum vlm_event_type_e
++{
++    /* */
++    VLM_EVENT_MEDIA_ADDED   = 0x100,
++    VLM_EVENT_MEDIA_REMOVED,
++    VLM_EVENT_MEDIA_CHANGED,
++
++    /* */
++    VLM_EVENT_MEDIA_INSTANCE_STARTED    = 0x200,
++    VLM_EVENT_MEDIA_INSTANCE_STOPPED,
++    VLM_EVENT_MEDIA_INSTANCE_STATE,
++};
++
++typedef struct
++{
++    int            i_type;            /* a vlm_event_type_e value */
++    int64_t        id;                /* Media ID */
++    const char    *psz_name;          /* Media name */
++    const char    *psz_instance_name; /* Instance name or NULL */
++    input_state_e  input_state;       /* Input instance event type */
++} vlm_event_t;
++
++/** VLM control query */
++enum vlm_query_e
++{
++    /* --- Media control */
++    /* Get all medias */
++    VLM_GET_MEDIAS,                     /* arg1=vlm_media_t ***, int *pi_media      */
++    /* Delete all medias */
++    VLM_CLEAR_MEDIAS,                   /* no arg */
++
++    /* Add a new media */
++    VLM_ADD_MEDIA,                      /* arg1=vlm_media_t* arg2=int64_t *p_id         res=can fail */
++    /* Delete an existing media */
++    VLM_DEL_MEDIA,                      /* arg1=int64_t id */
++    /* Change properties of an existing media (all fields but id and b_vod) */
++    VLM_CHANGE_MEDIA,                   /* arg1=vlm_media_t*                            res=can fail */
++    /* Get 1 media by it's ID */
++    VLM_GET_MEDIA,                      /* arg1=int64_t id arg2=vlm_media_t **  */
++    /* Get media ID from its name */
++    VLM_GET_MEDIA_ID,                   /* arg1=const char *psz_name arg2=int64_t*  */
++
++    /* Media instance control XXX VOD control are for internal use only */
++    /* Get all media instances */
++    VLM_GET_MEDIA_INSTANCES,            /* arg1=int64_t id arg2=vlm_media_instance_t *** arg3=int *pi_instance */
++    /* Delete all media instances */
++    VLM_CLEAR_MEDIA_INSTANCES,          /* arg1=int64_t id */
++    /* Control broadcast instance */
++    VLM_START_MEDIA_BROADCAST_INSTANCE, /* arg1=int64_t id, arg2=const char *psz_instance_name, int i_input_index  res=can fail */
++    /* Control VOD instance */
++    VLM_START_MEDIA_VOD_INSTANCE,       /* arg1=int64_t id, arg2=const char *psz_instance_name, int i_input_index char *psz_vod_output res=can fail */
++    /* Stop an instance */
++    VLM_STOP_MEDIA_INSTANCE,            /* arg1=int64_t id, arg2=const char *psz_instance_name      res=can fail */
++    /* Pause an instance */
++    VLM_PAUSE_MEDIA_INSTANCE,           /* arg1=int64_t id, arg2=const char *psz_instance_name      res=can fail */
++    /* Get instance position time (in microsecond) */
++    VLM_GET_MEDIA_INSTANCE_TIME,        /* arg1=int64_t id, arg2=const char *psz_instance_name arg3=int64_t *   */
++    /* Set instance position time (in microsecond) */
++    VLM_SET_MEDIA_INSTANCE_TIME,        /* arg1=int64_t id, arg2=const char *psz_instance_name arg3=int64_t     */
++    /* Get instance position ([0.0 .. 1.0]) */
++    VLM_GET_MEDIA_INSTANCE_POSITION,    /* arg1=int64_t id, arg2=const char *psz_instance_name arg3=double *   */
++    /* Set instance position ([0.0 .. 1.0]) */
++    VLM_SET_MEDIA_INSTANCE_POSITION,    /* arg1=int64_t id, arg2=const char *psz_instance_name arg3=double     */
++
++    /* Schedule control */
++    VLM_CLEAR_SCHEDULES,                /* no arg */
++    /* TODO: missing schedule control */
++
++    /* */
++};
++
++
++/* VLM specific - structures and functions */
++
++/* ok, here is the structure of a vlm_message:
++   The parent node is ( name_of_the_command , NULL ), or
++   ( name_of_the_command , message_error ) on error.
++   If a node has children, it should not have a value (=NULL).*/
++struct vlm_message_t
++{
++    char *psz_name;         /*< message name */
++    char *psz_value;        /*< message value */
++
++    int           i_child;  /*< number of child messages */
++    vlm_message_t **child;  /*< array of vlm_message_t */
++};
++
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++VLC_API vlm_t * vlm_New( vlc_object_t * );
++#define vlm_New( a ) vlm_New( VLC_OBJECT(a) )
++VLC_API void vlm_Delete( vlm_t * );
++VLC_API int vlm_ExecuteCommand( vlm_t *, const char *, vlm_message_t ** );
++VLC_API int vlm_Control( vlm_t *p_vlm, int i_query, ... );
++
++VLC_API vlm_message_t * vlm_MessageSimpleNew( const char * );
++VLC_API vlm_message_t * vlm_MessageNew( const char *, const char *, ... ) VLC_FORMAT( 2, 3 );
++VLC_API vlm_message_t * vlm_MessageAdd( vlm_message_t *, vlm_message_t * );
++VLC_API void vlm_MessageDelete( vlm_message_t * );
++
++/* media helpers */
++
++/**
++ * Initialize a vlm_media_t instance
++ * \param p_media vlm_media_t instance to initialize
++ */
++static inline void vlm_media_Init( vlm_media_t *p_media )
++{
++    memset( p_media, 0, sizeof(vlm_media_t) );
++    p_media->id = 0;    // invalid id
++    p_media->psz_name = NULL;
++    TAB_INIT( p_media->i_input, p_media->ppsz_input );
++    TAB_INIT( p_media->i_option, p_media->ppsz_option );
++    p_media->psz_output = NULL;
++    p_media->b_vod = false;
++
++    p_media->vod.psz_mux = NULL;
++    p_media->broadcast.b_loop = false;
++}
++
++/**
++ * Copy a vlm_media_t instance into another vlm_media_t instance
++ * \param p_dst vlm_media_t instance to copy to
++ * \param p_src vlm_media_t instance to copy from
++ */
++static inline void
++#ifndef __cplusplus
++vlm_media_Copy( vlm_media_t *restrict p_dst, const vlm_media_t *restrict p_src )
++#else
++vlm_media_Copy( vlm_media_t *p_dst, const vlm_media_t *p_src )
++#endif
++{
++    int i;
++
++    memset( p_dst, 0, sizeof(vlm_media_t) );
++    p_dst->id = p_src->id;
++    p_dst->b_enabled = p_src->b_enabled;
++    if( p_src->psz_name )
++        p_dst->psz_name = strdup( p_src->psz_name );
++
++    for( i = 0; i < p_src->i_input; i++ )
++        TAB_APPEND_CAST( (char**), p_dst->i_input, p_dst->ppsz_input, strdup(p_src->ppsz_input[i]) );
++    for( i = 0; i < p_src->i_option; i++ )
++        TAB_APPEND_CAST( (char**), p_dst->i_option, p_dst->ppsz_option, strdup(p_src->ppsz_option[i]) );
++
++    if( p_src->psz_output )
++        p_dst->psz_output = strdup( p_src->psz_output );
++
++    p_dst->b_vod = p_src->b_vod;
++    if( p_src->b_vod )
++    {
++        if( p_src->vod.psz_mux )
++            p_dst->vod.psz_mux = strdup( p_src->vod.psz_mux );
++    }
++    else
++    {
++        p_dst->broadcast.b_loop = p_src->broadcast.b_loop;
++    }
++}
++
++/**
++ * Cleanup and release memory associated with this vlm_media_t instance.
++ * You still need to release p_media itself with vlm_media_Delete().
++ * \param p_media vlm_media_t to cleanup
++ */
++static inline void vlm_media_Clean( vlm_media_t *p_media )
++{
++    int i;
++    free( p_media->psz_name );
++
++    for( i = 0; i < p_media->i_input; i++ )
++        free( p_media->ppsz_input[i]);
++    TAB_CLEAN(p_media->i_input, p_media->ppsz_input );
++
++    for( i = 0; i < p_media->i_option; i++ )
++        free( p_media->ppsz_option[i]);
++    TAB_CLEAN(p_media->i_option, p_media->ppsz_option );
++
++    free( p_media->psz_output );
++    if( p_media->b_vod )
++        free( p_media->vod.psz_mux );
++}
++
++/**
++ * Allocate a new vlm_media_t instance
++ * \return vlm_media_t instance
++ */
++static inline vlm_media_t *vlm_media_New(void)
++{
++    vlm_media_t *p_media = (vlm_media_t *)malloc( sizeof(vlm_media_t) );
++    if( p_media )
++        vlm_media_Init( p_media );
++    return p_media;
++}
++
++/**
++ * Delete a vlm_media_t instance
++ * \param p_media vlm_media_t instance to delete
++ */
++static inline void vlm_media_Delete( vlm_media_t *p_media )
++{
++    vlm_media_Clean( p_media );
++    free( p_media );
++}
++
++/**
++ * Copy a vlm_media_t instance
++ * \param p_src vlm_media_t instance to copy
++ * \return vlm_media_t duplicate of p_src
++ */
++static inline vlm_media_t *vlm_media_Duplicate( vlm_media_t *p_src )
++{
++    vlm_media_t *p_dst = vlm_media_New();
++    if( p_dst )
++        vlm_media_Copy( p_dst, p_src );
++    return p_dst;
++}
++
++/* media instance helpers */
++/**
++ * Initialize vlm_media_instance_t
++ * \param p_instance vlm_media_instance_t to initialize
++ */
++static inline void vlm_media_instance_Init( vlm_media_instance_t *p_instance )
++{
++    memset( p_instance, 0, sizeof(vlm_media_instance_t) );
++    p_instance->psz_name = NULL;
++    p_instance->i_time = 0;
++    p_instance->i_length = 0;
++    p_instance->d_position = 0.0;
++    p_instance->b_paused = false;
++    p_instance->i_rate = INPUT_RATE_DEFAULT;
++}
++
++/**
++ * Cleanup vlm_media_instance_t
++ * \param p_instance vlm_media_instance_t to cleanup
++ */
++static inline void vlm_media_instance_Clean( vlm_media_instance_t *p_instance )
++{
++    free( p_instance->psz_name );
++}
++
++/**
++ * Allocate a new vlm_media_instance_t
++ * \return a new vlm_media_instance_t
++ */
++static inline vlm_media_instance_t *vlm_media_instance_New(void)
++{
++    vlm_media_instance_t *p_instance = (vlm_media_instance_t *) malloc( sizeof(vlm_media_instance_t) );
++    if( p_instance )
++        vlm_media_instance_Init( p_instance );
++    return p_instance;
++}
++
++/**
++ * Delete a vlm_media_instance_t
++ * \param p_instance vlm_media_instance_t to delete
++ */
++static inline void vlm_media_instance_Delete( vlm_media_instance_t *p_instance )
++{
++    vlm_media_instance_Clean( p_instance );
++    free( p_instance );
++}
++
++#ifdef __cplusplus
++}
++#endif
++
++/**@}*/
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_vout.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_vout.h
+new file mode 100644
+index 0000000..d7306d8
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_vout.h
+@@ -0,0 +1,167 @@
++/*****************************************************************************
++ * vlc_vout.h: common video definitions
++ *****************************************************************************
++ * Copyright (C) 1999 - 2008 VLC authors and VideoLAN
++ * $Id: 627f6cec2e3b96eea04f9566ef799ed5b3a93b2a $
++ *
++ * Authors: Vincent Seguin <seguin@via.ecp.fr>
++ *          Samuel Hocevar <sam@via.ecp.fr>
++ *          Olivier Aubert <oaubert 47 videolan d07 org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_VOUT_H_
++#define VLC_VOUT_H_ 1
++
++#include <vlc_es.h>
++#include <vlc_picture.h>
++#include <vlc_subpicture.h>
++
++/**
++ * \defgroup output Output
++ * \defgroup video_output Video output
++ * \ingroup output
++ * Video rendering, output and window management
++ *
++ * This module describes the programming interface for video output threads.
++ * It includes functions allowing to open a new thread, send pictures to a
++ * thread, and destroy a previously opened video output thread.
++ * @{
++ * \file
++ * Video output thread interface
++ */
++
++/**
++ * Vout configuration
++ */
++typedef struct {
++    vout_thread_t        *vout;
++    vlc_object_t         *input;
++    bool                 change_fmt;
++    const video_format_t *fmt;
++    unsigned             dpb_size;
++} vout_configuration_t;
++
++/**
++ * Video output thread private structure
++ */
++typedef struct vout_thread_sys_t vout_thread_sys_t;
++
++/**
++ * Video output thread descriptor
++ *
++ * Any independent video output device, such as an X11 window or a GGI device,
++ * is represented by a video output thread, and described using the following
++ * structure.
++ */
++struct vout_thread_t {
++    VLC_COMMON_MEMBERS
++
++    /* Private vout_thread data */
++    vout_thread_sys_t *p;
++};
++
++/* Alignment flags */
++#define VOUT_ALIGN_LEFT         0x0001
++#define VOUT_ALIGN_RIGHT        0x0002
++#define VOUT_ALIGN_HMASK        0x0003
++#define VOUT_ALIGN_TOP          0x0004
++#define VOUT_ALIGN_BOTTOM       0x0008
++#define VOUT_ALIGN_VMASK        0x000C
++
++/*****************************************************************************
++ * Prototypes
++ *****************************************************************************/
++
++/**
++ * Returns a suitable vout or release the given one.
++ *
++ * If cfg->fmt is non NULL and valid, a vout will be returned, reusing cfg->vout
++ * is possible, otherwise it returns NULL.
++ * If cfg->vout is not used, it will be closed and released.
++ *
++ * You can release the returned value either by vout_Request or vout_Close()
++ * followed by a vlc_object_release() or shorter vout_CloseAndRelease()
++ *
++ * \param object a vlc object
++ * \param cfg the video configuration requested.
++ * \return a vout
++ */
++VLC_API vout_thread_t * vout_Request( vlc_object_t *object, const vout_configuration_t *cfg );
++#define vout_Request(a,b) vout_Request(VLC_OBJECT(a),b)
++
++/**
++ * This function will close a vout created by vout_Request.
++ * The associated vout module is closed.
++ * Note: It is not released yet, you'll have to call vlc_object_release()
++ * or use the convenient vout_CloseAndRelease().
++ *
++ * \param p_vout the vout to close
++ */
++VLC_API void vout_Close( vout_thread_t *p_vout );
++
++/**
++ * This function will close a vout created by vout_Create
++ * and then release it.
++ *
++ * \param p_vout the vout to close and release
++ */
++static inline void vout_CloseAndRelease( vout_thread_t *p_vout )
++{
++    vout_Close( p_vout );
++    vlc_object_release( p_vout );
++}
++
++/**
++ * This function will handle a snapshot request.
++ *
++ * pp_image, pp_picture and p_fmt can be NULL otherwise they will be
++ * set with returned value in case of success.
++ *
++ * pp_image will hold an encoded picture in psz_format format.
++ *
++ * p_fmt can be NULL otherwise it will be set with the format used for the
++ * picture before encoding.
++ *
++ * i_timeout specifies the time the function will wait for a snapshot to be
++ * available.
++ *
++ */
++VLC_API int vout_GetSnapshot( vout_thread_t *p_vout,
++                              block_t **pp_image, picture_t **pp_picture,
++                              video_format_t *p_fmt,
++                              const char *psz_format, mtime_t i_timeout );
++
++VLC_API void vout_ChangeAspectRatio( vout_thread_t *p_vout,
++                                     unsigned int i_num, unsigned int i_den );
++
++/* */
++VLC_API picture_t * vout_GetPicture( vout_thread_t * );
++VLC_API void vout_PutPicture( vout_thread_t *, picture_t * );
++
++/* Subpictures channels ID */
++#define VOUT_SPU_CHANNEL_INVALID      (-1) /* Always fails in comparison */
++#define VOUT_SPU_CHANNEL_OSD            1 /* OSD channel is automatically cleared */
++#define VOUT_SPU_CHANNEL_AVAIL_FIRST    8 /* Registerable channels from this offset */
++
++/* */
++VLC_API void vout_PutSubpicture( vout_thread_t *, subpicture_t * );
++VLC_API int vout_RegisterSubpictureChannel( vout_thread_t * );
++VLC_API void vout_FlushSubpictureChannel( vout_thread_t *, int );
++
++/**@}*/
++
++#endif /* _VLC_VIDEO_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_vout_display.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_vout_display.h
+new file mode 100644
+index 0000000..36f1227
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_vout_display.h
+@@ -0,0 +1,481 @@
++/*****************************************************************************
++ * vlc_vout_display.h: vout_display_t definitions
++ *****************************************************************************
++ * Copyright (C) 2009 Laurent Aimar
++ * $Id: 80761c8762d6b2acd48091507637fdcefb3317bd $
++ *
++ * Authors: Laurent Aimar <fenrir _AT_ videolan _DOT_ org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_VOUT_DISPLAY_H
++#define VLC_VOUT_DISPLAY_H 1
++
++#include <vlc_es.h>
++#include <vlc_picture.h>
++#include <vlc_picture_pool.h>
++#include <vlc_subpicture.h>
++#include <vlc_actions.h>
++#include <vlc_mouse.h>
++#include <vlc_vout.h>
++#include <vlc_vout_window.h>
++#include <vlc_viewpoint.h>
++
++/**
++ * \defgroup video_display Video output display
++ * Video output display: output buffers and rendering
++ *
++ * \ingroup video_output
++ * @{
++ * \file
++ * Video output display modules interface
++ */
++
++/* XXX
++ * Do NOT use video_format_t::i_aspect but i_sar_num/den everywhere. i_aspect
++ * will be removed as soon as possible.
++ *
++ */
++typedef struct vout_display_t vout_display_t;
++typedef struct vout_display_sys_t vout_display_sys_t;
++typedef struct vout_display_owner_t vout_display_owner_t;
++
++/**
++ * Possible alignments for vout_display.
++ */
++typedef enum
++{
++    VOUT_DISPLAY_ALIGN_CENTER,
++    /* */
++    VOUT_DISPLAY_ALIGN_LEFT,
++    VOUT_DISPLAY_ALIGN_RIGHT,
++    /* */
++    VOUT_DISPLAY_ALIGN_TOP,
++    VOUT_DISPLAY_ALIGN_BOTTOM,
++} vout_display_align_t;
++
++/**
++ * Window management state.
++ */
++enum {
++    VOUT_WINDOW_STATE_NORMAL=0,
++    VOUT_WINDOW_STATE_ABOVE=1,
++    VOUT_WINDOW_STATE_BELOW=2,
++    VOUT_WINDOW_STACK_MASK=3,
++};
++
++/**
++ * Initial/Current configuration for a vout_display_t
++ */
++typedef struct {
++#if defined(_WIN32) || defined(__OS2__)
++    bool is_fullscreen VLC_DEPRECATED;  /* Is the display fullscreen */
++#endif
++
++    /* Display properties */
++    struct {
++        /* Window title (may be NULL) */
++        const char *title;
++
++        /* Display size */
++        unsigned  width;
++        unsigned  height;
++
++        /* Display SAR */
++        vlc_rational_t sar;
++    } display;
++
++    /* Alignment of the picture inside the display */
++    struct {
++        int horizontal;
++        int vertical;
++    } align;
++
++    /* Do we fill up the display with the video */
++    bool is_display_filled;
++
++    /* Zoom to use
++     * It will be applied to the whole display if b_display_filled is set, otherwise
++     * only on the video source */
++    struct {
++        int num;
++        int den;
++    } zoom;
++
++    vlc_viewpoint_t viewpoint;
++} vout_display_cfg_t;
++
++/**
++ * Information from a vout_display_t to configure
++ * the core behaviour.
++ *
++ * By default they are all false or NULL.
++ *
++ */
++typedef struct {
++    bool is_slow;                           /* The picture memory has slow read/write */
++    bool has_double_click;                  /* Is double-click generated */
++    bool needs_hide_mouse;                  /* Needs VOUT_DISPLAY_HIDE_MOUSE,
++                                             * needs to call vout_display_SendEventMouseMoved()
++                                             * or vout_display_SendEventMouseState() */
++    bool has_pictures_invalid;              /* Will VOUT_DISPLAY_EVENT_PICTURES_INVALID be used */
++    const vlc_fourcc_t *subpicture_chromas; /* List of supported chromas for subpicture rendering. */
++} vout_display_info_t;
++
++/**
++ * Control query for vout_display_t
++ */
++enum {
++    /* Hide the mouse. It will be sent when
++     * vout_display_t::info.needs_hide_mouse is true */
++    VOUT_DISPLAY_HIDE_MOUSE VLC_DEPRECATED_ENUM,
++
++    /* Ask to reset the internal buffers after a VOUT_DISPLAY_EVENT_PICTURES_INVALID
++     * request.
++     */
++    VOUT_DISPLAY_RESET_PICTURES,
++
++#if defined(_WIN32) || defined(__OS2__)
++    /* Ask the module to acknowledge/refuse the fullscreen state change after
++     * being requested (externally or by VOUT_DISPLAY_EVENT_FULLSCREEN */
++    VOUT_DISPLAY_CHANGE_FULLSCREEN VLC_DEPRECATED_ENUM,     /* bool fs */
++    /* Ask the module to acknowledge/refuse the window management state change
++     * after being requested externally or by VOUT_DISPLAY_WINDOW_STATE */
++    VOUT_DISPLAY_CHANGE_WINDOW_STATE VLC_DEPRECATED_ENUM,   /* unsigned state */
++#endif
++    /* Ask the module to acknowledge/refuse the display size change requested
++     * (externally or by VOUT_DISPLAY_EVENT_DISPLAY_SIZE) */
++    VOUT_DISPLAY_CHANGE_DISPLAY_SIZE,   /* const vout_display_cfg_t *p_cfg */
++
++    /* Ask the module to acknowledge/refuse fill display state change after
++     * being requested externally */
++    VOUT_DISPLAY_CHANGE_DISPLAY_FILLED, /* const vout_display_cfg_t *p_cfg */
++
++    /* Ask the module to acknowledge/refuse zoom change after being requested
++     * externally */
++    VOUT_DISPLAY_CHANGE_ZOOM, /* const vout_display_cfg_t *p_cfg */
++
++    /* Ask the module to acknowledge/refuse source aspect ratio after being
++     * requested externally */
++    VOUT_DISPLAY_CHANGE_SOURCE_ASPECT,
++
++    /* Ask the module to acknowledge/refuse source crop change after being
++     * requested externally.
++     * The cropping requested is stored by video_format_t::i_x/y_offset and
++     * video_format_t::i_visible_width/height */
++    VOUT_DISPLAY_CHANGE_SOURCE_CROP,
++
++    /* Ask the module to acknowledge/refuse VR/360° viewing direction after
++     * being requested externally */
++    VOUT_DISPLAY_CHANGE_VIEWPOINT,   /* const vout_display_cfg_t *p_cfg */
++};
++
++/**
++ * Event from vout_display_t
++ *
++ * Events modifiying the state may be sent multiple times.
++ * Only the transition will be retained and acted upon.
++ */
++enum {
++    /* TODO:
++     * ZOOM ? DISPLAY_FILLED ? ON_TOP ?
++     */
++    /* */
++    VOUT_DISPLAY_EVENT_PICTURES_INVALID,    /* The buffer are now invalid and need to be changed */
++
++#if defined(_WIN32) || defined(__OS2__)
++    VOUT_DISPLAY_EVENT_FULLSCREEN,
++    VOUT_DISPLAY_EVENT_WINDOW_STATE,
++#endif
++
++    VOUT_DISPLAY_EVENT_DISPLAY_SIZE,        /* The display size need to change : int i_width, int i_height */
++
++    /* */
++    VOUT_DISPLAY_EVENT_CLOSE,
++    VOUT_DISPLAY_EVENT_KEY,
++
++    /* Full mouse state.
++     * You can use it OR use the other mouse events. The core will do
++     * the conversion.
++     */
++    VOUT_DISPLAY_EVENT_MOUSE_STATE,
++
++    /* Mouse event */
++    VOUT_DISPLAY_EVENT_MOUSE_MOVED,
++    VOUT_DISPLAY_EVENT_MOUSE_PRESSED,
++    VOUT_DISPLAY_EVENT_MOUSE_RELEASED,
++    VOUT_DISPLAY_EVENT_MOUSE_DOUBLE_CLICK,
++
++    /* VR navigation */
++    VOUT_DISPLAY_EVENT_VIEWPOINT_MOVED,
++};
++
++/**
++ * Vout owner structures
++ */
++struct vout_display_owner_t {
++    /* Private place holder for the vout_display_t creator
++     */
++    void *sys;
++
++    /* Event coming from the module
++     *
++     * This function is set prior to the module instantiation and must not
++     * be overwritten nor used directly (use the vout_display_SendEvent*
++     * wrapper.
++     *
++     * You can send it at any time i.e. from any vout_display_t functions or
++     * from another thread.
++     * Be careful, it does not ensure correct serialization if it is used
++     * from multiple threads.
++     */
++    void            (*event)(vout_display_t *, int, va_list);
++
++    /* Window management
++     *
++     * These functions are set prior to the module instantiation and must not
++     * be overwritten nor used directly (use the vout_display_*Window
++     * wrapper */
++    vout_window_t *(*window_new)(vout_display_t *, unsigned type);
++    void           (*window_del)(vout_display_t *, vout_window_t *);
++};
++
++struct vout_display_t {
++    VLC_COMMON_MEMBERS
++
++    /* Module */
++    module_t *module;
++
++    /* Initial and current configuration.
++     * You cannot modify it directly, you must use the appropriate events.
++     *
++     * It reflects the current values, i.e. after the event has been accepted
++     * and applied/configured if needed.
++     */
++    const vout_display_cfg_t *cfg;
++
++    /* video source format.
++     *
++     * Cropping is not requested while in the open function.
++     * You cannot change it.
++     */
++    video_format_t source;
++
++    /* picture_t format.
++     *
++     * You can only change it inside the module open function to
++     * match what you want, and when a VOUT_DISPLAY_RESET_PICTURES control
++     * request is made and succeeds.
++     *
++     * By default, it is equal to ::source except for the aspect ratio
++     * which is undefined(0) and is ignored.
++     */
++    video_format_t fmt;
++
++    /* Information
++     *
++     * You can only set them in the open function.
++     */
++    vout_display_info_t info;
++
++    /* Return a pointer over the current picture_pool_t* (mandatory).
++     *
++     * For performance reasons, it is best to provide at least count
++     * pictures but it is not mandatory.
++     * You can return NULL when you cannot/do not want to allocate
++     * pictures.
++     * The vout display module keeps the ownership of the pool and can
++     * destroy it only when closing or on invalid pictures control.
++     */
++    picture_pool_t *(*pool)(vout_display_t *, unsigned count);
++
++    /* Prepare a picture and an optional subpicture for display (optional).
++     *
++     * It is called before the next pf_display call to provide as much
++     * time as possible to prepare the given picture and the subpicture
++     * for display.
++     * You are guaranted that pf_display will always be called and using
++     * the exact same picture_t and subpicture_t.
++     * You cannot change the pixel content of the picture_t or of the
++     * subpicture_t.
++     */
++    void       (*prepare)(vout_display_t *, picture_t *, subpicture_t *);
++
++    /* Display a picture and an optional subpicture (mandatory).
++     *
++     * The picture and the optional subpicture must be displayed as soon as
++     * possible.
++     * You cannot change the pixel content of the picture_t or of the
++     * subpicture_t.
++     *
++     * This function gives away the ownership of the picture and of the
++     * subpicture, so you must release them as soon as possible.
++     */
++    void       (*display)(vout_display_t *, picture_t *, subpicture_t *);
++
++    /* Control on the module (mandatory) */
++    int        (*control)(vout_display_t *, int, va_list);
++
++    /* Manage pending event (optional) */
++    void       (*manage)(vout_display_t *) VLC_DEPRECATED;
++
++    /* Private place holder for the vout_display_t module (optional)
++     *
++     * A module is free to use it as it wishes.
++     */
++    vout_display_sys_t *sys;
++
++    /* Reserved for the vout_display_t owner.
++     *
++     * It must not be overwritten nor used directly by a module.
++     */
++    vout_display_owner_t owner;
++};
++
++static inline void vout_display_SendEvent(vout_display_t *vd, int query, ...)
++{
++    va_list args;
++    va_start(args, query);
++    vd->owner.event(vd, query, args);
++    va_end(args);
++}
++
++static inline void vout_display_SendEventDisplaySize(vout_display_t *vd, int width, int height)
++{
++    vout_display_SendEvent(vd, VOUT_DISPLAY_EVENT_DISPLAY_SIZE, width, height);
++}
++static inline void vout_display_SendEventPicturesInvalid(vout_display_t *vd)
++{
++    vout_display_SendEvent(vd, VOUT_DISPLAY_EVENT_PICTURES_INVALID);
++}
++static inline void vout_display_SendEventClose(vout_display_t *vd)
++{
++    vout_display_SendEvent(vd, VOUT_DISPLAY_EVENT_CLOSE);
++}
++static inline void vout_display_SendEventKey(vout_display_t *vd, int key)
++{
++    vout_display_SendEvent(vd, VOUT_DISPLAY_EVENT_KEY, key);
++}
++#if defined(_WIN32) || defined(__OS2__)
++static inline void vout_display_SendEventFullscreen(vout_display_t *vd, bool is_fullscreen,
++                                                    bool is_window_fullscreen)
++{
++    vout_display_SendEvent(vd, VOUT_DISPLAY_EVENT_FULLSCREEN, is_fullscreen, is_window_fullscreen);
++}
++static inline void vout_display_SendWindowState(vout_display_t *vd, unsigned state)
++{
++    vout_display_SendEvent(vd, VOUT_DISPLAY_EVENT_WINDOW_STATE, state);
++}
++#endif
++/* The mouse position (State and Moved event) must be expressed against vout_display_t::source unit */
++static inline void vout_display_SendEventMouseState(vout_display_t *vd, int x, int y, int button_mask)
++{
++    vout_display_SendEvent(vd, VOUT_DISPLAY_EVENT_MOUSE_STATE, x, y, button_mask);
++}
++static inline void vout_display_SendEventMouseMoved(vout_display_t *vd, int x, int y)
++{
++    vout_display_SendEvent(vd, VOUT_DISPLAY_EVENT_MOUSE_MOVED, x, y);
++}
++static inline void vout_display_SendEventMousePressed(vout_display_t *vd, int button)
++{
++    vout_display_SendEvent(vd, VOUT_DISPLAY_EVENT_MOUSE_PRESSED, button);
++}
++static inline void vout_display_SendEventMouseReleased(vout_display_t *vd, int button)
++{
++    vout_display_SendEvent(vd, VOUT_DISPLAY_EVENT_MOUSE_RELEASED, button);
++}
++static inline void vout_display_SendEventMouseDoubleClick(vout_display_t *vd)
++{
++    vout_display_SendEvent(vd, VOUT_DISPLAY_EVENT_MOUSE_DOUBLE_CLICK);
++}
++static inline void vout_display_SendEventViewpointMoved(vout_display_t *vd,
++                                                        const vlc_viewpoint_t *vp)
++{
++    vout_display_SendEvent(vd, VOUT_DISPLAY_EVENT_VIEWPOINT_MOVED, vp);
++}
++
++/**
++ * Asks for a new window of a given type.
++ */
++static inline vout_window_t *vout_display_NewWindow(vout_display_t *vd, unsigned type)
++{
++    return vd->owner.window_new(vd, type);
++}
++/**
++ * Deletes a window created by vout_display_NewWindow if window is non NULL
++ * or any unused windows otherwise.
++ */
++static inline void vout_display_DeleteWindow(vout_display_t *vd,
++                                             vout_window_t *window)
++{
++    vd->owner.window_del(vd, window);
++}
++
++static inline bool vout_display_IsWindowed(vout_display_t *vd)
++{
++    vout_window_t *window = vout_display_NewWindow(vd, VOUT_WINDOW_TYPE_INVALID);
++    if (window != NULL)
++        vout_display_DeleteWindow(vd, window);
++    return window != NULL;
++}
++
++/**
++ * Computes the default display size given the source and
++ * the display configuration.
++ *
++ * This asssumes that the picture is already cropped.
++ */
++VLC_API void vout_display_GetDefaultDisplaySize(unsigned *width, unsigned *height, const video_format_t *source, const vout_display_cfg_t *);
++
++
++/**
++ * Structure used to store the result of a vout_display_PlacePicture.
++ */
++typedef struct {
++    int x;
++    int y;
++    unsigned width;
++    unsigned height;
++} vout_display_place_t;
++
++/**
++ * Computes how to place a picture inside the display to respect
++ * the given parameters.
++ * This assumes that cropping is done by an external mean.
++ *
++ * \param p_place Place inside the window (window pixel unit)
++ * \param p_source Video source format
++ * \param p_cfg Display configuration
++ * \param b_clip If true, prevent the video to go outside the display (break zoom).
++ */
++VLC_API void vout_display_PlacePicture(vout_display_place_t *place, const video_format_t *source, const vout_display_cfg_t *cfg, bool do_clipping);
++
++
++/**
++ * Helper function that applies the necessary transforms to the mouse position
++ * and then calls vout_display_SendEventMouseMoved.
++ *
++ * \param vd vout_display_t.
++ * \param orient_display The orientation of the picture as seen on screen (probably ORIENT_NORMAL).
++ * \param m_x Mouse x position (relative to place, origin is top left).
++ * \param m_y Mouse y position (relative to place, origin is top left).
++ * \param place Place of the picture.
++ */
++VLC_API void vout_display_SendMouseMovedDisplayCoordinates(vout_display_t *vd, video_orientation_t orient_display, int m_x, int m_y,
++                                                           vout_display_place_t *place);
++
++/** @} */
++#endif /* VLC_VOUT_DISPLAY_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_vout_osd.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_vout_osd.h
+new file mode 100644
+index 0000000..0cb6853
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_vout_osd.h
+@@ -0,0 +1,102 @@
++/*****************************************************************************
++ * vlc_vout_osd.h: vout OSD
++ *****************************************************************************
++ * Copyright (C) 1999-2010 VLC authors and VideoLAN
++ * Copyright (C) 2004-2005 M2X
++ * $Id: a07cd9073156d9ce0d5363543bcc3fd98a6de8f8 $
++ *
++ * Authors: Jean-Paul Saman <jpsaman #_at_# m2x dot nl>
++ *          Gildas Bazin <gbazin@videolan.org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_VOUT_OSD_H
++#define VLC_VOUT_OSD_H 1
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++/**
++ * \defgroup osd On-screen display
++ * \ingroup spu
++ * @{
++ * \file
++ * Overlay text and widgets
++ */
++
++/**
++ * OSD menu position and picture type defines
++ */
++enum
++{
++    /* Icons */
++    OSD_PLAY_ICON = 1,
++    OSD_PAUSE_ICON,
++    OSD_SPEAKER_ICON,
++    OSD_MUTE_ICON,
++    /* Sliders */
++    OSD_HOR_SLIDER,
++    OSD_VERT_SLIDER,
++};
++
++VLC_API int vout_OSDEpg( vout_thread_t *, input_item_t * );
++
++/**
++ * \brief Write an informative message if the OSD option is enabled.
++ * \param vout The vout on which the message will be displayed
++ * \param channel Subpicture channel
++ * \param position Position of the text
++ * \param duration Duration of the text being displayed
++ * \param text Text to be displayed
++ */
++VLC_API void vout_OSDText( vout_thread_t *vout, int channel, int position, mtime_t duration, const char *text );
++
++/**
++ * \brief Write an informative message at the default location,
++ *        for the default duration and only if the OSD option is enabled.
++ * \param vout The vout on which the message will be displayed
++ * \param channel Subpicture channel
++ * \param format printf style formatting
++ *
++ * Provided for convenience.
++ */
++VLC_API void vout_OSDMessage( vout_thread_t *, int, const char *, ... ) VLC_FORMAT( 3, 4 );
++
++/**
++ * Display a slider on the video output.
++ * \param p_this    The object that called the function.
++ * \param i_channel Subpicture channel
++ * \param i_postion Current position in the slider
++ * \param i_type    Types are: OSD_HOR_SLIDER and OSD_VERT_SLIDER.
++ */
++VLC_API void vout_OSDSlider( vout_thread_t *, int, int , short );
++
++/**
++ * Display an Icon on the video output.
++ * \param p_this    The object that called the function.
++ * \param i_channel Subpicture channel
++ * \param i_type    Types are: OSD_PLAY_ICON, OSD_PAUSE_ICON, OSD_SPEAKER_ICON, OSD_MUTE_ICON
++ */
++VLC_API void vout_OSDIcon( vout_thread_t *, int, short );
++
++/** @} */
++#ifdef __cplusplus
++}
++#endif
++
++#endif /* VLC_VOUT_OSD_H */
++
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_vout_window.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_vout_window.h
+new file mode 100644
+index 0000000..edc94fe
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_vout_window.h
+@@ -0,0 +1,373 @@
++/*****************************************************************************
++ * vlc_vout_window.h: vout_window_t definitions
++ *****************************************************************************
++ * Copyright (C) 2008 Rémi Denis-Courmont
++ * Copyright (C) 2009 Laurent Aimar
++ * $Id: 3a613d4e4701783a43cefd299e171f95164e30e9 $
++ *
++ * Authors: Laurent Aimar <fenrir _AT_ videolan _DOT_ org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_VOUT_WINDOW_H
++#define VLC_VOUT_WINDOW_H 1
++
++#include <stdarg.h>
++#include <vlc_common.h>
++
++/**
++ * \defgroup video_window Video window
++ * \ingroup video_output
++ * Video output window management
++ * @{
++ * \file
++ * Video output window modules interface
++ */
++
++typedef struct vout_window_t vout_window_t;
++typedef struct vout_window_sys_t vout_window_sys_t;
++
++struct wl_display;
++struct wl_surface;
++
++/**
++ * Window handle type
++ */
++enum vout_window_type {
++    VOUT_WINDOW_TYPE_INVALID=0 /**< Invalid or unspecified window type */,
++    VOUT_WINDOW_TYPE_XID /**< X11 window */,
++    VOUT_WINDOW_TYPE_HWND /**< Win32 or OS/2 window */,
++    VOUT_WINDOW_TYPE_NSOBJECT /**< MacOS X view */,
++    VOUT_WINDOW_TYPE_ANDROID_NATIVE /**< Android native window */,
++    VOUT_WINDOW_TYPE_WAYLAND /**< Wayland surface */,
++};
++
++/**
++ * Control query for vout_window_t
++ */
++enum vout_window_control {
++    VOUT_WINDOW_SET_STATE, /* unsigned state */
++    VOUT_WINDOW_SET_SIZE,   /* unsigned i_width, unsigned i_height */
++    VOUT_WINDOW_SET_FULLSCREEN, /* int b_fullscreen */
++    VOUT_WINDOW_HIDE_MOUSE, /* int b_hide */
++};
++
++/**
++ * Window mouse event type for vout_window_mouse_event_t
++ */
++enum vout_window_mouse_event_type {
++    VOUT_WINDOW_MOUSE_STATE,
++    VOUT_WINDOW_MOUSE_MOVED,
++    VOUT_WINDOW_MOUSE_PRESSED,
++    VOUT_WINDOW_MOUSE_RELEASED,
++    VOUT_WINDOW_MOUSE_DOUBLE_CLICK,
++};
++
++/**
++ * Window mouse event
++ */
++typedef struct vout_window_mouse_event_t
++{
++    enum vout_window_mouse_event_type type;
++    int x;
++    int y;
++    int button_mask;
++} vout_window_mouse_event_t;
++
++typedef struct vout_window_cfg_t {
++    /* Window handle type */
++    unsigned type;
++
++    /* If true, a standalone window is requested */
++    bool is_standalone;
++    bool is_fullscreen;
++
++#ifdef __APPLE__
++    /* Window position hint */
++    int x;
++    int y;
++#endif
++
++    /* Windows size hint */
++    unsigned width;
++    unsigned height;
++
++} vout_window_cfg_t;
++
++typedef struct vout_window_owner {
++    void *sys;
++    void (*resized)(vout_window_t *, unsigned width, unsigned height);
++    void (*closed)(vout_window_t *);
++    void (*mouse_event)(vout_window_t *, const vout_window_mouse_event_t *mouse);
++} vout_window_owner_t;
++
++/**
++ * Graphical window
++ *
++ * This structure is an abstract interface to the windowing system.
++ * The window is normally used to draw video (and subpictures) into, but it
++ * can also be used for other purpose (e.g. OpenGL visualization).
++ *
++ * The window is responsible for providing a window handle, whose exact
++ * meaning depends on the windowing system. It also must report some events
++ * such as user input (keyboard, mouse) and window resize.
++ *
++ * Finally, it must support some control requests such as for fullscreen mode.
++ */
++struct vout_window_t {
++    VLC_COMMON_MEMBERS
++
++     /**
++      * Window handle type
++      *
++      * This identified the windowing system and protocol that the window
++      * needs to use. This also selects which member of the \ref handle union
++      * and the \ref display union are to be set.
++      *
++      * The possible values are defined in \ref vout_window_type.
++      *
++      * VOUT_WINDOW_TYPE_INVALID is a special placeholder type. It means that
++      * any windowing system is acceptable. In that case, the plugin must set
++      * its actual type during activation.
++      */
++    unsigned type;
++
++    /**
++     * Window handle (mandatory)
++     *
++     * This must be filled by the plugin upon activation.
++     *
++     * Depending on the \ref type above, a different member of this union is
++     * used.
++     */
++    union {
++        void     *hwnd;          /**< Win32 window handle */
++        uint32_t xid;            /**< X11 windows ID */
++        void     *nsobject;      /**< Mac OSX view object */
++        void     *anativewindow; /**< Android native window */
++        struct wl_surface *wl;   /**< Wayland surface (client pointer) */
++    } handle;
++
++    /** Display server (mandatory)
++     *
++     * This must be filled by the plugin upon activation.
++     *
++     * The window handle is relative to the display server. The exact meaning
++     * of the display server depends on the window handle type. Not all window
++     * handle type provide a display server field.
++     */
++    union {
++        char     *x11; /**< X11 display string (NULL = use default) */
++        struct wl_display *wl; /**< Wayland display (client pointer) */
++    } display;
++
++    /**
++     * Control callback (mandatory)
++     *
++     * This callback handles some control request regarding the window.
++     * See \ref vout_window_control.
++     *
++     * This field should not be used directly when manipulating a window.
++     * vout_window_Control() should be used instead.
++     */
++    int (*control)(vout_window_t *, int query, va_list);
++
++    struct {
++        bool has_double_click; /**< Whether double click events are sent,
++                                    or need to be emulated */
++    } info;
++
++    /* Private place holder for the vout_window_t module (optional)
++     *
++     * A module is free to use it as it wishes.
++     */
++    vout_window_sys_t *sys;
++
++    vout_window_owner_t owner;
++};
++
++/**
++ * Creates a new window.
++ *
++ * @param module plugin name (usually "$window")
++ * @note If you are inside a "vout display", you must use
++ / vout_display_NewWindow() and vout_display_DeleteWindow() instead.
++ * This enables recycling windows.
++ */
++VLC_API vout_window_t * vout_window_New(vlc_object_t *, const char *module, const vout_window_cfg_t *, const vout_window_owner_t *);
++
++/**
++ * Deletes a window created by vout_window_New().
++ *
++ * @note See vout_window_New() about window recycling.
++ */
++VLC_API void vout_window_Delete(vout_window_t *);
++
++void vout_window_SetInhibition(vout_window_t *window, bool enabled);
++
++static inline int vout_window_vaControl(vout_window_t *window, int query,
++                                        va_list ap)
++{
++    return window->control(window, query, ap);
++}
++
++/**
++ * Reconfigures a window.
++ *
++ * @note The vout_window_* wrappers should be used instead of this function.
++ *
++ * @warning The caller must own the window, as vout_window_t is not thread safe.
++ */
++static inline int vout_window_Control(vout_window_t *window, int query, ...)
++{
++    va_list ap;
++    int ret;
++
++    va_start(ap, query);
++    ret = vout_window_vaControl(window, query, ap);
++    va_end(ap);
++    return ret;
++}
++
++/**
++ * Configures the window manager state for this window.
++ */
++static inline int vout_window_SetState(vout_window_t *window, unsigned state)
++{
++    return vout_window_Control(window, VOUT_WINDOW_SET_STATE, state);
++}
++
++/**
++ * Configures the window display (i.e. inner/useful) size.
++ */
++static inline int vout_window_SetSize(vout_window_t *window,
++                                      unsigned width, unsigned height)
++{
++    return vout_window_Control(window, VOUT_WINDOW_SET_SIZE, width, height);
++}
++
++/**
++ * Sets fullscreen mode.
++ */
++static inline int vout_window_SetFullScreen(vout_window_t *window, bool full)
++{
++    return vout_window_Control(window, VOUT_WINDOW_SET_FULLSCREEN, full);
++}
++
++/**
++ * Hide the mouse cursor
++ */
++static inline int vout_window_HideMouse(vout_window_t *window, bool hide)
++{
++    return vout_window_Control(window, VOUT_WINDOW_HIDE_MOUSE, hide);
++}
++
++/**
++ * Report current window size
++ *
++ * This notifies the user of the window what the pixel dimensions of the
++ * window are (or should be, depending on the windowing system).
++ *
++ * \note This function is thread-safe. In case of concurrent call, it is
++ * undefined which one is taken into account (but at least one is).
++ */
++static inline void vout_window_ReportSize(vout_window_t *window,
++                                          unsigned width, unsigned height)
++{
++    if (window->owner.resized != NULL)
++        window->owner.resized(window, width, height);
++}
++
++static inline void vout_window_ReportClose(vout_window_t *window)
++{
++    if (window->owner.closed != NULL)
++        window->owner.closed(window);
++}
++
++static inline void vout_window_SendMouseEvent(vout_window_t *window,
++                                              const vout_window_mouse_event_t *mouse)
++{
++    if (window->owner.mouse_event != NULL)
++        window->owner.mouse_event(window, mouse);
++}
++
++/**
++ * Send a full mouse state
++ *
++ * The mouse position must be expressed against window unit. You can use this
++ * function of others vout_window_ReportMouse*() functions.
++ */
++static inline void vout_window_ReportMouseState(vout_window_t *window,
++                                                int x, int y, int button_mask)
++{
++    const vout_window_mouse_event_t mouse = {
++        VOUT_WINDOW_MOUSE_STATE, x, y, button_mask
++    };
++    vout_window_SendMouseEvent(window, &mouse);
++}
++
++/**
++ * Send a mouse movement
++ *
++ * The mouse position must be expressed against window unit.
++ */
++static inline void vout_window_ReportMouseMoved(vout_window_t *window,
++                                                int x, int y)
++{
++    const vout_window_mouse_event_t mouse = {
++        VOUT_WINDOW_MOUSE_MOVED, x, y, 0
++    };
++    vout_window_SendMouseEvent(window, &mouse);
++}
++
++/**
++ * Send a mouse pressed event
++ */
++static inline void vout_window_ReportMousePressed(vout_window_t *window,
++                                                  int button)
++{
++    const vout_window_mouse_event_t mouse = {
++        VOUT_WINDOW_MOUSE_PRESSED, 0, 0, button,
++    };
++    vout_window_SendMouseEvent(window, &mouse);
++}
++
++/**
++ * Send a mouse released event
++ */
++static inline void vout_window_ReportMouseReleased(vout_window_t *window,
++                                                  int button)
++{
++    const vout_window_mouse_event_t mouse = {
++        VOUT_WINDOW_MOUSE_RELEASED, 0, 0, button,
++    };
++    vout_window_SendMouseEvent(window, &mouse);
++}
++
++/**
++ * Send a mouse double click event
++ */
++static inline void vout_window_ReportMouseDoubleClick(vout_window_t *window,
++                                                      int button)
++{
++    const vout_window_mouse_event_t mouse = {
++        VOUT_WINDOW_MOUSE_DOUBLE_CLICK, 0, 0, button,
++    };
++    vout_window_SendMouseEvent(window, &mouse);
++}
++
++/** @} */
++#endif /* VLC_VOUT_WINDOW_H */
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_xlib.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_xlib.h
+new file mode 100644
+index 0000000..b6818c1
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_xlib.h
+@@ -0,0 +1,57 @@
++/*****************************************************************************
++ * vlc_xlib.h: initialization of Xlib
++ *****************************************************************************
++ * Copyright (C) 2010 Rémi Denis-Courmont
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_XLIB_H
++# define VLC_XLIB_H 1
++
++# include <stdio.h>
++# include <stdlib.h>
++# include <X11/Xlib.h>
++# include <X11/Xlibint.h>
++
++static inline bool vlc_xlib_init (vlc_object_t *obj)
++{
++    if (!var_InheritBool (obj, "xlib"))
++        return false;
++
++    bool ok = false;
++
++    /* XInitThreads() can be called multiple times,
++     * but it is not reentrant, so we need this global lock. */
++    vlc_global_lock (VLC_XLIB_MUTEX);
++
++    if (_Xglobal_lock == NULL && unlikely(_XErrorFunction != NULL))
++        /* (_Xglobal_lock == NULL) => Xlib threads not initialized */
++        /* (_XErrorFunction != NULL) => Xlib already in use */
++        fprintf (stderr, "%s:%u:%s: Xlib not initialized for threads.\n"
++                 "This process is probably using LibVLC incorrectly.\n"
++                 "Pass \"--no-xlib\" to libvlc_new() to fix this.\n",
++                 __FILE__, __LINE__, __func__);
++    else if (XInitThreads ())
++        ok = true;
++
++    vlc_global_unlock (VLC_XLIB_MUTEX);
++
++    if (!ok)
++        msg_Err (obj, "Xlib not initialized for threads");
++    return ok;
++}
++
++#endif
+diff --git a/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_xml.h b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_xml.h
+new file mode 100644
+index 0000000..661e76d
+--- /dev/null
++++ b/VLC.app/Contents/MacOS/include/vlc/plugins/vlc_xml.h
+@@ -0,0 +1,121 @@
++/*****************************************************************************
++ * vlc_xml.h: XML abstraction layer
++ *****************************************************************************
++ * Copyright (C) 2004-2010 VLC authors and VideoLAN
++ *
++ * Author: Gildas Bazin <gbazin@videolan.org>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation; either version 2.1 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
++ *****************************************************************************/
++
++#ifndef VLC_XML_H
++#define VLC_XML_H
++
++/**
++* \file
++* This file defines functions and structures to handle xml tags in vlc
++*
++*/
++
++# ifdef __cplusplus
++extern "C" {
++# endif
++
++struct xml_t
++{
++    VLC_COMMON_MEMBERS
++
++    /* Module properties */
++    module_t  *p_module;
++    xml_sys_t *p_sys;
++
++    void (*pf_catalog_load) ( xml_t *, const char * );
++    void (*pf_catalog_add) ( xml_t *, const char *, const char *,
++                            const char * );
++};
++
++VLC_API xml_t * xml_Create( vlc_object_t * ) VLC_USED;
++#define xml_Create( a ) xml_Create( VLC_OBJECT(a) )
++VLC_API void xml_Delete( xml_t * );
++
++static inline void xml_CatalogLoad( xml_t *xml, const char *catalog )
++{
++    xml->pf_catalog_load( xml, catalog );
++}
++
++static inline void xml_CatalogAdd( xml_t *xml, const char *type,
++                                   const char *orig, const char *value )
++{
++    xml->pf_catalog_add( xml, type, orig, value );
++}
++
++
++struct xml_reader_t
++{
++    VLC_COMMON_MEMBERS
++
++    xml_reader_sys_t *p_sys;
++    stream_t *p_stream;
++    module_t *p_module;
++
++    int (*pf_next_node) ( xml_reader_t *, const char ** );
++    const char *(*pf_next_attr) ( xml_reader_t *, const char ** );
++
++    int (*pf_use_dtd) ( xml_reader_t * );
++    int (*pf_is_empty) ( xml_reader_t * );
++};
++
++VLC_API xml_reader_t * xml_ReaderCreate(vlc_object_t *, stream_t *) VLC_USED;
++#define xml_ReaderCreate( a, s ) xml_ReaderCreate(VLC_OBJECT(a), s)
++VLC_API void xml_ReaderDelete(xml_reader_t *);
++VLC_API xml_reader_t * xml_ReaderReset(xml_reader_t *, stream_t *) VLC_USED;
++
++static inline int xml_ReaderNextNode( xml_reader_t *reader, const char **pval )
++{
++    return reader->pf_next_node( reader, pval );
++}
++
++static inline const char *xml_ReaderNextAttr( xml_reader_t *reader,
++                                              const char **pval )
++{
++  return reader->pf_next_attr( reader, pval );
++}
++
++static inline int xml_ReaderUseDTD( xml_reader_t *reader )
++{
++  return reader->pf_use_dtd( reader );
++}
++
++static inline int xml_ReaderIsEmptyElement( xml_reader_t *reader )
++{
++    if(reader->pf_is_empty == NULL)
++        return -2;
++
++    return reader->pf_is_empty( reader );
++}
++
++enum {
++    XML_READER_ERROR=-1,
++    XML_READER_NONE=0,
++    XML_READER_STARTELEM,
++    XML_READER_ENDELEM,
++    XML_READER_TEXT,
++};
++
++# ifdef __cplusplus
++}
++# endif
++
++#endif

--- a/binary/_mac/vlc/vlc.py
+++ b/binary/_mac/vlc/vlc.py
@@ -1,0 +1,52 @@
+import shutil
+
+import info
+from Package.BinaryPackageBase import *
+
+
+class subinfo(info.infoclass):
+    vlc_ver = None
+
+    def setTargets(self):
+        for ver in ["2.2.6", "2.2.7", "2.2.8", "3.0.0", "3.0.1", "3.0.2", "3.0.3", "3.0.4", "3.0.5", "3.0.6"]:
+            self.targets[ver] = f"http://download.videolan.org/pub/videolan/vlc/{ver}/macosx/vlc-{ver}.dmg"
+            self.targetInstSrc[ver] = f"vlc-{ver}"
+            self.targetDigestUrls[ver] = f"http://download.videolan.org/pub/videolan/vlc/{ver}/macosx/vlc-{ver}.dmg.sha256"
+            self.patchToApply[ver] = [("vlc-plugin-headers.diff", 1)]
+        self.webpage = "https://www.videolan.org/"
+        self.description = "an open-source multimedia framework"
+
+        self.defaultTarget = "3.0.6"
+
+    def setDependencies(self):
+        self.buildDependencies["virtual/bin-base"] = None
+
+
+class Package(BinaryPackageBase):
+    def __init__(self):
+        BinaryPackageBase.__init__(self)
+
+    def unpack(self):
+        workdir = self.workDir()
+
+        for filename in self.localFileNames():
+            utils.system("hdiutil attach -mountpoint %s %s"%(os.path.join(CraftCore.standardDirs.downloadDir(), "archives", self.package.path, "temp"),
+                os.path.join(CraftCore.standardDirs.downloadDir(), "archives", self.package.path, filename)))
+            utils.copyDir(os.path.join(CraftCore.standardDirs.downloadDir(), "archives", self.package.path, "temp", "VLC.app"),
+                os.path.join(self.workDir(), "VLC.app"), linkOnly=False)
+            
+            for patch, depth in self.subinfo.patchesToApply():
+                utils.applyPatch(self.workDir(), os.path.join(self.packageDir(), patch), depth)
+
+            utils.system('hdiutil detach %s'%os.path.join(CraftCore.standardDirs.downloadDir(), "archives", self.package.path, "temp"))
+
+        return True
+
+    def install(self):
+
+        utils.mergeTree(os.path.join(self.workDir(), "VLC.app", "Contents", "MacOS", "include"),
+                    os.path.join(self.installDir(), "include"))
+        utils.mergeTree(os.path.join(self.workDir(), "VLC.app", "Contents", "MacOS", "lib"), os.path.join(self.installDir(), "lib"))
+        print(self.installDir())
+
+        return True

--- a/binary/_mac/vlc/vlc.py
+++ b/binary/_mac/vlc/vlc.py
@@ -27,8 +27,6 @@ class Package(BinaryPackageBase):
         BinaryPackageBase.__init__(self)
 
     def unpack(self):
-        workdir = self.workDir()
-
         for filename in self.localFileNames():
             utils.system("hdiutil attach -mountpoint %s %s"%(os.path.join(CraftCore.standardDirs.downloadDir(), "archives", self.package.path, "temp"),
                 os.path.join(CraftCore.standardDirs.downloadDir(), "archives", self.package.path, filename)))


### PR DESCRIPTION
The VLC DMG installer can be found on https://download.videolan.org/pub/videolan/vlc/.

But in `Contents/MacOS/include/vlc/`, there is no `plugins` folder.
`phonon-vlc` needs `vlc/plugins/vlc_common.h` to build on macOS.

So a patch file is added into any version of VLC Binary on macOS.