### PR TITLE
Fix phonon-vlc build on macos

### DIFF
--- a/qt-libs/phonon-vlc/phonon-vlc.py
+++ b/qt-libs/phonon-vlc/phonon-vlc.py
@@ -17,8 +17,7 @@ class subinfo(info.infoclass):
             self.targetDigestUrls[ver] = f"https://download.kde.org/stable/phonon/phonon-backend-vlc/{ver}/phonon-backend-vlc-{ver}.tar.xz.sha256"
             self.targetInstSrc[ver] = f"phonon-vlc-{ver}"
 
-            if OsUtils.isMac():
-                self.patchToApply[ver] = [("qtdbus-lib-macos.diff", 1)] # Add patch for link error of QtDBus on macOS
+            self.patchToApply[ver] = [("qtdbus-lib-macos.diff", 1)] # Add patch for link error of QtDBus on macOS
 
         self.svnTargets["master"] = "git://anongit.kde.org/phonon-vlc"
 

--- a/qt-libs/phonon-vlc/phonon-vlc.py
+++ b/qt-libs/phonon-vlc/phonon-vlc.py
@@ -16,6 +16,10 @@ class subinfo(info.infoclass):
             self.targets[ver] = f"https://download.kde.org/stable/phonon/phonon-backend-vlc/{ver}/phonon-backend-vlc-{ver}.tar.xz"
             self.targetDigestUrls[ver] = f"https://download.kde.org/stable/phonon/phonon-backend-vlc/{ver}/phonon-backend-vlc-{ver}.tar.xz.sha256"
             self.targetInstSrc[ver] = f"phonon-vlc-{ver}"
+
+            if OsUtils.isMac():
+                self.patchToApply[ver] = [("qtdbus-lib-macos.diff", 1)] # Add patch for link error of QtDBus on macOS
+
         self.svnTargets["master"] = "git://anongit.kde.org/phonon-vlc"
 
         self.description = "the vlc based phonon multimedia backend"

--- a/qt-libs/phonon-vlc/qtdbus-lib-macos.diff
+++ b/qt-libs/phonon-vlc/qtdbus-lib-macos.diff
@@ -1,0 +1,13 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 47427b2..1cdb250 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -81,7 +81,7 @@ if(APPLE)
+ endif(APPLE)
+ 
+ automoc4_add_library(phonon_vlc MODULE ${phonon_vlc_SRCS})
+-qt5_use_modules(phonon_vlc Core Widgets)
++qt5_use_modules(phonon_vlc Core Widgets DBus)
+ 
+ set_target_properties(phonon_vlc PROPERTIES
+     PREFIX ""


### PR DESCRIPTION
With `vlc` binary o macOS, `phonon-vlc` can be built successfully.

The only problem is an error of linking, which indicates `QtDBus` cannot be found. The reason is that `QtDBus` is a separate library on macOS.

So the diff patch is created for macOS.

<img width="842" alt="Build phonon-vlc on macOS" src="https://user-images.githubusercontent.com/8311300/57679903-b216fb80-762c-11e9-99e0-514789e39ba9.png">
